### PR TITLE
Debugged this with help from Darren:

### DIFF
--- a/source/ui/CLS/CLSSIS3820ScalerView.cpp
+++ b/source/ui/CLS/CLSSIS3820ScalerView.cpp
@@ -259,13 +259,19 @@ void CLSSIS3820ScalerView::onOutputViewModeChanged(CLSSIS3820ScalerChannelView::
 void CLSSIS3820ScalerView::setAmplifierViewPrecision(int newPrecision)
 {
 	foreach (CLSSIS3820ScalerChannelView *view, channelViews_)
-		view->setAmplifierViewPrecision(newPrecision);
+	{
+		if(view->hasAmplifierView())
+			view->setAmplifierViewPrecision(newPrecision);
+	}
 }
 
 void CLSSIS3820ScalerView::setAmplifierViewFormat(char newFormat)
 {
 	foreach (CLSSIS3820ScalerChannelView *view, channelViews_)
-		view->setAmplifierViewFormat(newFormat);
+	{
+		if(view->hasAmplifierView())
+			view->setAmplifierViewFormat(newFormat);
+	}
 }
 
 // CLSSIS3820ScalerChannelView
@@ -329,6 +335,11 @@ CLSSIS3820ScalerChannelView::CLSSIS3820ScalerChannelView(CLSSIS3820ScalerChannel
 }
 
 CLSSIS3820ScalerChannelView::~CLSSIS3820ScalerChannelView(){}
+
+bool CLSSIS3820ScalerChannelView::hasAmplifierView() const
+{
+	return amplifierView_ != 0;
+}
 
 void CLSSIS3820ScalerChannelView::onReadingChanged()
 {
@@ -436,10 +447,12 @@ void CLSSIS3820ScalerChannelView::onNewCurrentAmplifierAttached()
 
 void CLSSIS3820ScalerChannelView::setAmplifierViewPrecision(int newPrecision)
 {
-	amplifierView_->setPrecision(newPrecision);
+	if(amplifierView_)
+		amplifierView_->setPrecision(newPrecision);
 }
 
 void CLSSIS3820ScalerChannelView::setAmplifierViewFormat(char newFormat)
 {
-	amplifierView_->setFormat(newFormat);
+	if(amplifierView_)
+		amplifierView_->setFormat(newFormat);
 }

--- a/source/ui/CLS/CLSSIS3820ScalerView.h
+++ b/source/ui/CLS/CLSSIS3820ScalerView.h
@@ -53,6 +53,8 @@ public:
 	CLSSIS3820ScalerChannelView(CLSSIS3820ScalerChannel *channel, QWidget *parent = 0);
 	virtual ~CLSSIS3820ScalerChannelView();
 
+	/// Whether or not the view has a connected AmplifierView
+	bool hasAmplifierView() const;
 signals:
 	/// Notifier that the channel changed viewing mode.  Passes the new mode.
 	void outputViewModeChanged(CLSSIS3820ScalerChannelView::OutputViewMode);


### PR DESCRIPTION
Added:
- CLSSIS3820ScalerView::hasAmplifierView() ~ Function which returns
  whether this view has a valid, non null amplifierView_

Altered:
- CLSSIS3820ScalerChannelView::setAmplifierViewFormat() and
  setAmplifierViewPrecision() ~ not check if amplifierView_ is not null
  before attempting to set its precision/format
- CLSSIS3820ScalerView::setAmplifierViewFormat() and
  setAmplifierViewPrecision ~ in a belt and braces approach this also
  checks whether the channel view has a valid amplifierView_ by calling
  hasAmplifierView() before attempting to set its format/precision.
