### PR TITLE
Pull request for Issue751

### DIFF
--- a/source/dataman/VESPERS/VESPERSDbUpgrade1Pt6.cpp
+++ b/source/dataman/VESPERS/VESPERSDbUpgrade1Pt6.cpp
@@ -120,7 +120,7 @@ bool VESPERSDbUpgrade1Pt6::upgradeImplementation()
 												   << roiInfosId1Column.at(i)
 												   << "VESPERSScanConfigurationDbObject_table"
 												   << roiInfosId2Column.at(i)
-												   << "AMRegionsOfInterest_table"
+												   << "AMRegionOfInterest_table"
 												   );
 		}
 


### PR DESCRIPTION
This simple patch fixes a typo that made a large portion of VESPERSDbUpgrade1Pt6 useless.  It created references to AMRegionsOfInterest_table - which doesn't exist.
