### PR TITLE
Pull request for Issue782 - fixed REIXS null sample add crash bug

### DIFF
--- a/source/ui/dataman/AMSamplePlatePre2013View.cpp
+++ b/source/ui/dataman/AMSamplePlatePre2013View.cpp
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License
 along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <QMessageBox>
 
 #include "AMSamplePlatePre2013View.h"
 #include "dataman/database/AMDbObjectSupport.h"
@@ -555,26 +556,35 @@ AMSamplePlatePre2013View::AMSamplePlatePre2013View(AMSamplePlatePre2013 *existin
 
 void AMSamplePlatePre2013View::onAddSampleButtonClicked() {
 
+	if(samplePlate_ &&  sampleSelector_->currentSampleId() != -1){
 
-	if(manipulator_){
-		qDebug() << "Apparently we have a manipulator";
-		samplePlate_->append(
-					AMSamplePositionPre2013(
-						sampleSelector_->currentSampleId(),
-						manipulator_->position(),
-						manipulator_->facilityId()));
+		if(manipulator_){
+			qDebug() << "Apparently we have a manipulator";
+			samplePlate_->append(
+						AMSamplePositionPre2013(
+							sampleSelector_->currentSampleId(),
+							manipulator_->position(),
+							manipulator_->facilityId()));
+		}
+		else{
+			qDebug() << "Apparently we DO NOT have a manipulator";
+			samplePlate_->append(
+						AMSamplePositionPre2013(
+							sampleSelector_->currentSampleId(),
+							AMControlInfoList(),
+							0));
+		}
+
+		// save the sample plate, because it's been modified.
+		samplePlate_->storeToDb(AMDatabase::database("user"));
 	}
 	else{
-		qDebug() << "Apparently we DO NOT have a manipulator";
-		samplePlate_->append(
-					AMSamplePositionPre2013(
-						sampleSelector_->currentSampleId(),
-						AMControlInfoList(),
-						0));
+		QMessageBox msgBox;
+		msgBox.setText("Please select a plate and sample before adding a sample to the plate.");
+		msgBox.exec();
+
 	}
 
-	// save the sample plate, because it's been modified.
-	samplePlate_->storeToDb(AMDatabase::database("user"));
 
 }
 


### PR DESCRIPTION
Modified AMSamplePlatePre2013View::onAddSampleButtonClicked() to test for a valid sample and plate before calling samplePlate_->append() and to provide feedback to a user that tries to add a sample to a plate without a sample or a plate selected.
