### PR TITLE
Pull Request for Issue98: Issues changing the run associated with a scan

### DIFF
--- a/source/dataman/AMScan.cpp
+++ b/source/dataman/AMScan.cpp
@@ -174,13 +174,19 @@ const AMSample* AMScan::sample() const{
 }
 
 // associate this object with a particular run. Set to (-1) to dissociate with any run.  (Note: for now, it's the caller's responsibility to make sure the runId is valid.)
-void AMScan::setRunId(int newRunId) {
+void AMScan::setRunId(int newRunId)
+{
+	if(newRunId <= 0){
 
-	if(newRunId <= 0)
 		runId_ = -1;
-	else
+		setModified(true);
+	}
+
+	else if (runId_ != newRunId){
+
 		runId_ = newRunId;
-	setModified(true);
+		setModified(true);
+	}
 }
 
 


### PR DESCRIPTION
I was unable to reproduce the slowness that was mentioned.  If it becomes an issue in the future, then it'll be tackled then.  Made a pretty trivial change to only modify the runId when it actually changes.
