### PR TITLE
Pull Request for Issue794 - Added dead time check button to IDEAS XRF View

### DIFF
--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
@@ -59,6 +59,8 @@ void IDEASXRFDetailedDetectorViewWithSave::buildScanSaveViews()
 	scanInfoGridLayout->setVerticalSpacing(4);
 	scanInfoGridLayout->setContentsMargins(12, -1, -1, -1);
 
+	deadTimeCheckButton = new QPushButton("Check Dead Time");
+
 	peakingTimeBox = new QComboBox();
 	peakingTimeBox->setObjectName(QString::fromUtf8("peakingTimeBox"));
 	peakingTimeBox->addItem("Setting Unknown");
@@ -116,6 +118,8 @@ void IDEASXRFDetailedDetectorViewWithSave::buildScanSaveViews()
 
 	scanInfoGridLayout->addWidget(scanNumber, 1, 1, 1, 1);
 
+	rightLayout_->addWidget(deadTimeCheckButton);
+
 	rightLayout_->addWidget(peakingTimeBox);
 
 	rightLayout_->addStretch();
@@ -134,6 +138,7 @@ void IDEASXRFDetailedDetectorViewWithSave::buildScanSaveViews()
 	connect(scanName, SIGNAL(textChanged(QString)), this, SLOT(onScanNameChanged(QString)));
 	connect(scanNumber, SIGNAL(valueChanged(int)), this, SLOT(onScanNumberChanged(int)));
 	connect(peakingTimeBox, SIGNAL(currentIndexChanged(QString)), this, SLOT(onPeakingTimeBoxChanged(QString)));
+	connect(deadTimeCheckButton, SIGNAL(clicked()), this, SLOT(onDeadTimeCheckButtonClicked()));
 	connect(acquireButton_, SIGNAL(clicked(bool)),saveScanButton_, SLOT(setEnabled(bool)));
 	connect(IDEASBeamline::ideas()->ketek(), SIGNAL(acquisitionSucceeded()),this, SLOT(onAcquisitionSucceeded()));
 	connect(cancelButton_, SIGNAL(clicked()),this, SLOT(onAcquisitionSucceeded()));
@@ -230,4 +235,18 @@ void IDEASXRFDetailedDetectorViewWithSave::onKETEKPeakingTimeChanged()
 
     peakingTimeBox->blockSignals(false);
 
+}
+
+void IDEASXRFDetailedDetectorViewWithSave::onDeadTimeCheckButtonClicked()
+{
+ if(IDEASBeamline::ideas()->ketek()->isAcquiring()) return;
+
+ float requestedTime = IDEASBeamline::ideas()->ketek()->acquisitionTime();
+
+ AMListAction3 *deadTimeCheckActions = new AMListAction3(new AMListActionInfo3("Quick Deadtime Check", "Quick Deadtime Check"));
+ deadTimeCheckActions->addSubAction(IDEASBeamline::ideas()->ketek()->createSetAcquisitionTimeAction(0.1));
+ deadTimeCheckActions->addSubAction(IDEASBeamline::ideas()->ketek()->createAcquisitionAction(AMDetectorDefinitions::SingleRead));
+ deadTimeCheckActions->addSubAction(IDEASBeamline::ideas()->ketek()->createSetAcquisitionTimeAction(requestedTime));
+
+ deadTimeCheckActions->start();
 }

--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.h
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.h
@@ -27,7 +27,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "acquaman/IDEAS/IDEASXRFScanConfiguration.h"
 #include "actions3/actions/AMScanAction.h"
 
-
+#include <QPushButton>
 #include <QSignalMapper>
 #include <QPlainTextEdit>
 #include <QLineEdit>
@@ -56,6 +56,7 @@ protected slots:
 	void onPeakingTimeBoxChanged(const QString &arg1);
 	void onAcquisitionSucceeded();
 	void onKETEKPeakingTimeChanged();
+	void onDeadTimeCheckButtonClicked();
 
 protected:
 	/// Method that builds the Scan Save Button and associated things.
@@ -63,6 +64,10 @@ protected:
 
 	/// The button for saving the scan.
 	QPushButton *saveScanButton_;
+
+	/// button to trigger a 0.1s XRF acquitisition to check to too-high count rates.
+	QPushButton *deadTimeCheckButton;
+
 
 	/// A  scan configuration notes editor
 	QPlainTextEdit *notesEdit;


### PR DESCRIPTION
to IDEASXRFDetailedDetectorViewWithSave that triggers a 0.1s acquisition
and then replaces the previous acquisition time value.
