### PR TITLE
Pull request for Issue811: AM1DCalibrationABEditor crash bug

### DIFF
--- a/source/analysis/AM1DCalibrationABEditor.cpp
+++ b/source/analysis/AM1DCalibrationABEditor.cpp
@@ -44,7 +44,7 @@ AM1DCalibrationABEditor::AM1DCalibrationABEditor(AM1DCalibrationAB *analysisBloc
 	energyCalibrationOffsetBox_->setValue(analysisBlock_->energyCalibrationOffset());
 	energyCalibrationReferenceBox_ = new QDoubleSpinBox;
 	energyCalibrationReferenceBox_->setSingleStep(0.1);
-	energyCalibrationReferenceBox_->setRange(-1000,1000);
+	energyCalibrationReferenceBox_->setRange(-1000,20000);
 	energyCalibrationReferenceBox_->setValue(analysisBlock_->energyCalibrationReference());
 	energyCalibrationScalingBox_ = new QDoubleSpinBox;
 	energyCalibrationScalingBox_->setSingleStep(0.01);


### PR DESCRIPTION
Fixed up a missing null initialization for chooseScanDialog_ (which later had a null check) and changed the range of energyCalibrationReferenceBox_ from 1000 to 20,000

This may need testing on a another beamline. Not sure where abouts I would go to on SGM to find this (nor even if its used on here)
