### PR TITLE
Pull Request for Issue713 attempt2: REIXS Improve XES image processing

### DIFF
--- a/source/analysis/REIXS/REIXSXESImageInterpolationAB.h
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationAB.h
@@ -241,7 +241,20 @@ protected slots:
 
 
 protected:
+	// Helper Functions
+	///////////////////////
 
+	/// helper function to compute and fill cachedValues_.
+	void computeCachedValues() const;
+	/// Helper fucntion to compute interpolated shift map
+	void computeShiftMap(int iSize, int jSize, double *shiftValues) const;
+	/// Helper to compute energy axis scale, and fill cachedAxisValues_.
+	void computeCachedAxisValues() const;
+
+	/// Helper function to look at our overall situation and determine what the output state should be.
+	void reviewState();
+
+	// Member variables
 	/// Caches the shifted and summed values.  Access only if cacheInvalid_ is false.
 	mutable QVector<double> cachedValues_;
 	/// True if the cachedValues_ needs to be re-calculated.
@@ -289,8 +302,6 @@ protected:
 	int shiftPosition1_;
 	/// The position of the second set of shift values used to offset each row of the image when summing
 	int shiftPosition2_;
-	/// a 64x1024 shiftmap used for interpolation bethe two sets of shiftValues
-//	mutable QList<QList <double> > shiftMap_;
 	/// The level of onterpolation, hard-coded for now
 	int interpolationLevel_;
 
@@ -306,19 +317,6 @@ protected:
 
 	/// Smoothing object used for the shift curve after correlation
 	REIXSFunctionFitter* curveSmoother_;
-
-	// Helper Functions
-	///////////////////////
-
-	/// helper function to compute and fill cachedValues_.
-	void computeCachedValues() const;
-	/// Helper fucntion to compute interpolated shift map
-	void computeShiftMap(int iSize, int jSize, double *shiftValues) const;
-	/// Helper to compute energy axis scale, and fill cachedAxisValues_.
-	void computeCachedAxisValues() const;
-
-	/// Helper function to look at our overall situation and determine what the output state should be.
-	void reviewState();
 
 };
 


### PR DESCRIPTION
This optimizes the REIXSImageInterpolationAB.  It also acts as a clean up to make the code readable and easier to understand.  In terms of performance metrics, the old code used to run at 67-73 ms and the new code runs at 17-32 ms.  Averages being 71ms for the old and 28ms for the new.
