### PR TITLE
Pull request for Issue833:  IDEAS XAS scans crash when detector 'none'

### DIFF
--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -274,7 +274,8 @@ void IDEASAppController::configureSingleSpectrumView(AMGenericScanEditor *editor
 		if (scan->dataSourceAt(i)->rank()-scanRank == 1)
 			spectraNames << scan->dataSourceAt(i)->name();
 
-	editor->setSingleSpectrumViewDataSourceName(spectraNames.first());
+	if(!spectraNames.isEmpty())
+			editor->setSingleSpectrumViewDataSourceName(spectraNames.first());
 
 	editor->setPlotRange(AMPeriodicTable::table()->elementBySymbol("Al")->Kalpha().energy(), 20480);
 }

--- a/source/ui/dataman/AMGenericScanEditor.cpp
+++ b/source/ui/dataman/AMGenericScanEditor.cpp
@@ -338,7 +338,6 @@ void AMGenericScanEditor::addScan(AMScan* newScan) {
 	connect(newScan, SIGNAL(nameChanged(QString)), this, SLOT(onScanDetailsChanged()));
 	connect(newScan, SIGNAL(numberChanged(int)), this, SLOT(onScanDetailsChanged()));
 	connect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
-	qDebug() << "should have been connected by addScan()"  << currentScan_;
 
 
 	emit scanAdded(this, newScan);
@@ -412,7 +411,7 @@ void AMGenericScanEditor::onCurrentChanged ( const QModelIndex & selected, const
 		connect(currentScan_, SIGNAL(nameChanged(QString)), this, SLOT(refreshWindowTitle()));
 		connect(currentScan_, SIGNAL(scanInitialConditionsChanged()), this, SLOT(refreshScanConditions()));
 		connect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
-		qDebug() << "should have been connected by onCurrentChanged()"  << currentScan_;
+
 
 		// \todo When migrating to multiple scan selection, this will need to be changed:
 		ui_.saveScanButton->setEnabled(true);


### PR DESCRIPTION
IDEASAppController::configureSingleSpectrumView() to check to see if the
generated list of +1 rank data sources is empty before grabbing the
first one from the list.

Cleanup:
Removed old qDebugs in AMGenericScanEditor
