### PR TITLE
Pull Request for Issue707: IDEAS XAS scan name issue

### DIFF
--- a/source/acquaman/IDEAS/IDEASXASScanConfiguration.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanConfiguration.cpp
@@ -69,16 +69,14 @@ IDEASXASScanConfiguration::IDEASXASScanConfiguration(const IDEASXASScanConfigura
 	AMStepScanConfiguration(original)
 {
 	setAutoExportEnabled(false);
-//	qDebug() << original.name() << original.userScanName();
-//	setName(original.name());
-//	setUserScanName(original.userScanName());
+	setName(original.name());
+	setUserScanName(original.userScanName());
 	isXRFScan_ = original.isXRFScan();
 	isTransScan_ = original.isTransScan();
 	useRef_ = original.useRef();
 	timeOffset_ = original.timeOffset();
 	totalTime_ = original.totalTime();
 
-	name_ = original.setName();
 
 	edge_ = original.edge();
 	energy_ = original.energy();

--- a/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
@@ -53,7 +53,7 @@ IDEASXASScanConfigurationView::IDEASXASScanConfigurationView(IDEASXASScanConfigu
 	connect(pseudoXAFSButton_, SIGNAL(clicked()), this, SLOT(setupDefaultEXAFSScanRegions()));
 
 	scanName_ = new QLineEdit();
-	scanName_->setText(configuration_->userScanName());
+	scanName_->setText(configuration_->name());
 
 	connect(scanName_, SIGNAL(editingFinished()), this, SLOT(onScanNameEdited()));
 	connect(configuration_, SIGNAL(nameChanged(QString)), scanName_, SLOT(setText(QString)));


### PR DESCRIPTION
 Modified:

IDEASXASScanConfigurationView's constructor to grab the configuration's
`name()` instead of it's `userScanName()`.

For some reason, userScanName is not updating properly and is always
"Unnamed Scan".  This doesn't actually matter since userScanName isn't
used anywhere...now.
