### PR TITLE
Pull Request for Issue905: add 'ID' to the keyword replacer in AMExporter

### DIFF
--- a/source/dataman/export/AMExporter.cpp
+++ b/source/dataman/export/AMExporter.cpp
@@ -111,7 +111,7 @@ void AMExporter::loadKeywordReplacementDictionary()
 	keywordDictionary_.insert("date", new AMTagReplacementFunctor<AMExporter>(this, &AMExporter::krDate));
 	keywordDictionary_.insert("time", new AMTagReplacementFunctor<AMExporter>(this, &AMExporter::krTime));
 	keywordDictionary_.insert("dateTime", new AMTagReplacementFunctor<AMExporter>(this, &AMExporter::krDateTime));
-	keywordDictionary_.insert("ID", new AMTagReplacementFunctor<AMExporter>(this, &AMExporter::krID));
+	keywordDictionary_.insert("serial", new AMTagReplacementFunctor<AMExporter>(this, &AMExporter::krSerial));
 
 
 	keywordDictionary_.insert("run", new AMTagReplacementFunctor<AMExporter>(this, &AMExporter::krRun));
@@ -165,7 +165,7 @@ QString AMExporter::krNumber(const QString& arg) {
 	return "[??]";
 }
 
-QString AMExporter::krID(const QString& arg) {
+QString AMExporter::krSerial(const QString& arg) {
 	Q_UNUSED(arg)
 	if(currentScan_)
 		return QString::number(currentScan_->id());

--- a/source/dataman/export/AMExporter.h
+++ b/source/dataman/export/AMExporter.h
@@ -157,7 +157,7 @@ protected:
 	QString krDate(const QString& arg = QString());
 	QString krTime(const QString& arg = QString());
 	QString krDateTime(const QString& arg = QString());
-	QString krID(const QString& arg = QString());
+	QString krSerial(const QString& arg = QString());
 
 
 	QString krRun(const QString& arg = QString());


### PR DESCRIPTION
ADDED:
`AMExporter::krID` to add 'ID' (`scan->id()`)keyword to the
keyword replacer in AMExporter
