### PR TITLE
Pull Request for Issue894: Calling delete versus deleteLater

### DIFF
--- a/pluginProjects/FileLoaders/AMCDFv1FileLoader/AMCDFv1FileLoaderPlugin.cpp
+++ b/pluginProjects/FileLoaders/AMCDFv1FileLoader/AMCDFv1FileLoaderPlugin.cpp
@@ -23,13 +23,13 @@ bool AMCDFv1FileLoaderPlugin::load(AMScan *scan, const QString &userDataFolder, 
 	// for now, we create a new AMCDFDataStore by opening this CDF file in read-only mode.  If read-only is a problem in the future (ex: data sources writing to the data store for caching values) we'll need to adjust this strategy.
 	AMCDFDataStore* ds = new AMCDFDataStore(sourceFileInfo.filePath(), false, true);
 	if(!ds->isValid()) {
-		delete ds;
+		ds->deleteLater();
 		errorMonitor->exteriorReport(AMErrorReport(0, AMErrorReport::Serious, AMCDFV1FILELOADERPLUGIN_CANNOT_OPEN_FILE, QString("Could not open the CDF file at '%1'. It's possible that the file has been moved, or is corrupted.").arg(sourceFileInfo.filePath())));
 		return false;
 	}
 
 	if(!scan->replaceRawDataStore(ds)) {
-		delete ds;
+		ds->deleteLater();
 		errorMonitor->exteriorReport(AMErrorReport(0, AMErrorReport::Serious, AMCDFV1FILELOADERPLUGIN_CANNOT_USE_FILE, QString("Could not use the CDF file at '%1' for the scan '%2': it does not contain the correct measurements for the data sources that should exist in this scan.").arg(sourceFileInfo.filePath()).arg(scan->fullName())));
 		return false;
 	}

--- a/source/acquaman/AMListActionScanOptimizer.cpp
+++ b/source/acquaman/AMListActionScanOptimizer.cpp
@@ -49,7 +49,7 @@ void AMEmptyListScanOptimizer::optimizeImplementation(AMAction3 *scanActionTree)
 		}
 	}
 
-	delete templateListAction;
+	templateListAction->deleteLater();
 }
 
  AMSingleElementListOptimizer::~AMSingleElementListOptimizer(){}

--- a/source/acquaman/AMStepScanActionController.cpp
+++ b/source/acquaman/AMStepScanActionController.cpp
@@ -50,7 +50,7 @@ AMStepScanActionController::AMStepScanActionController(AMStepScanConfiguration *
 
 AMStepScanActionController::~AMStepScanActionController()
 {
-	delete fileWriterThread_;
+	fileWriterThread_->deleteLater();
 }
 
 void AMStepScanActionController::createScanAssembler()

--- a/source/acquaman/AMStepScanConfiguration.cpp
+++ b/source/acquaman/AMStepScanConfiguration.cpp
@@ -36,7 +36,7 @@ AMStepScanConfiguration::AMStepScanConfiguration(const AMStepScanConfiguration &
 AMStepScanConfiguration::~AMStepScanConfiguration()
 {
 	for (int i = 0, size = scanAxes_.count(); i < size; i++)
-		delete scanAxes_.at(i);
+		scanAxes_.at(i)->deleteLater();
 
 	scanAxes_.clear();
 }

--- a/source/acquaman/AMTimedScanActionController.cpp
+++ b/source/acquaman/AMTimedScanActionController.cpp
@@ -51,7 +51,7 @@ AMTimedScanActionController::AMTimedScanActionController(AMTimedRegionScanConfig
 
 AMTimedScanActionController::~AMTimedScanActionController()
 {
-	delete fileWriterThread_;
+	fileWriterThread_->deleteLater();
 }
 
 void AMTimedScanActionController::buildScanController()

--- a/source/acquaman/REIXS/REIXSXESScanActionController.cpp
+++ b/source/acquaman/REIXS/REIXSXESScanActionController.cpp
@@ -75,7 +75,7 @@ REIXSXESScanActionController::REIXSXESScanActionController(REIXSXESScanConfigura
 
 REIXSXESScanActionController::~REIXSXESScanActionController()
 {
-	delete fileWriterThread_;
+	fileWriterThread_->deleteLater();
 }
 
 void REIXSXESScanActionController::buildScanController()

--- a/source/acquaman/SGM/SGMFastScanActionController.cpp
+++ b/source/acquaman/SGM/SGMFastScanActionController.cpp
@@ -80,7 +80,7 @@ SGMFastScanActionController::SGMFastScanActionController(SGMFastScanConfiguratio
 
 SGMFastScanActionController::~SGMFastScanActionController()
 {
-	delete fileWriterThread_;
+	fileWriterThread_->deleteLater();
 }
 
 void SGMFastScanActionController::buildScanController()

--- a/source/actions3/AMAction3.cpp
+++ b/source/actions3/AMAction3.cpp
@@ -66,7 +66,7 @@ AMAction3::AMAction3(const AMAction3& other)
 // Destructor: deletes the info and prerequisites
 AMAction3::~AMAction3() {
 	if(info_){
-		delete info_;
+		info_->deleteLater();
 		info_ = 0;
 	}
 }

--- a/source/actions3/AMActionLog3.cpp
+++ b/source/actions3/AMActionLog3.cpp
@@ -94,7 +94,7 @@ AMActionLog3::AMActionLog3(const AMActionLog3 &other) :
 AMActionLog3::~AMActionLog3() {
 	disconnect(info_, SIGNAL(destroyed()), this, SLOT(onInfoDestroyed()));
 	if(loadedInfoFromDb_)
-		delete info_;
+		info_->deleteLater();
 	info_ = 0;
 }
 
@@ -162,7 +162,7 @@ void AMActionLog3::dbLoadInfo(AMDbObject *newInfo)
 	}
 	else {
 		// not doing anything with this object because it's the wrong type. However, it's our responsibility now, so delete it.
-		delete newInfo;
+		newInfo->deleteLater();
 	}
 }
 

--- a/source/actions3/AMActionRunner3.cpp
+++ b/source/actions3/AMActionRunner3.cpp
@@ -65,7 +65,7 @@ AMActionRunner3 * AMActionRunner3::workflow()
 
 void AMActionRunner3::releaseWorkflow()
 {
-	delete workflowInstance_;
+	workflowInstance_->deleteLater();
 	workflowInstance_ = 0;
 }
 
@@ -76,7 +76,7 @@ AMActionRunner3* AMActionRunner3::scanActionRunner(){
 }
 
 void AMActionRunner3::releaseScanActionRunner(){
-	delete scanActionRunnerInstance_;
+	scanActionRunnerInstance_->deleteLater();
 	scanActionRunnerInstance_ = 0;
 }
 
@@ -235,7 +235,7 @@ bool AMActionRunner3::deleteActionInQueue(int index)
 	emit queuedActionRemoved(index);
 	disconnect(action->info(), SIGNAL(infoChanged()), this, SIGNAL(queuedActionInfoChanged()));
 
-	delete action;
+	action->deleteLater();
 
 	return true;
 }

--- a/source/actions3/AMListAction3.cpp
+++ b/source/actions3/AMListAction3.cpp
@@ -159,7 +159,7 @@ void AMListAction3::setLoggingDatabase(AMDatabase *loggingDatabase){
 bool AMListAction3::deleteSubAction(int index)
 {
 	AMAction3* action = takeSubActionAt(index);
-	delete action;	// harmless if 0
+	action->deleteLater();	// harmless if 0
 
 	return (action != 0);
 }

--- a/source/actions3/actions/AMControlMoveActionInfo3.h
+++ b/source/actions3/actions/AMControlMoveActionInfo3.h
@@ -76,7 +76,7 @@ public:
 	/// For database storing only.
 	AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
 	/// For database loading only. This function will never be called since dbReadControlInfo() always returns a valid setpoint, but it needs to be here.
-	void dbLoadControlInfo(AMDbObject* newLoadedObject) { delete newLoadedObject; }
+	void dbLoadControlInfo(AMDbObject* newLoadedObject) { newLoadedObject->deleteLater(); }
 
 signals:
 

--- a/source/actions3/actions/AMControlStopActionInfo.h
+++ b/source/actions3/actions/AMControlStopActionInfo.h
@@ -56,7 +56,7 @@ public:
 	/// For database storing only.
 	AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
 	/// For database loading only. This function will never be called since dbReadControlInfo() always returns a valid setpoint, but it needs to be here.
-	void dbLoadControlInfo(AMDbObject* newLoadedObject) { delete newLoadedObject; }
+	void dbLoadControlInfo(AMDbObject* newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMControlInfo that specifies where to move to

--- a/source/actions3/actions/AMControlWaitActionInfo.h
+++ b/source/actions3/actions/AMControlWaitActionInfo.h
@@ -84,7 +84,7 @@ public:
     /// For database storing only.
     AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
     /// For database loading only. This function will never be called since dbReadControlInfo() always returns a valid setpoint, but it needs to be here.
-    void dbLoadControlInfo(AMDbObject* newLoadedObject) { delete newLoadedObject; }
+    void dbLoadControlInfo(AMDbObject* newLoadedObject) { newLoadedObject->deleteLater(); }
 
 signals:
 

--- a/source/actions3/actions/AMDetectorAcquisitionActionInfo.h
+++ b/source/actions3/actions/AMDetectorAcquisitionActionInfo.h
@@ -51,7 +51,7 @@ public:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMDetectorInfo that specifies which detector to acquire

--- a/source/actions3/actions/AMDetectorCleanupActionInfo.h
+++ b/source/actions3/actions/AMDetectorCleanupActionInfo.h
@@ -48,7 +48,7 @@ public:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMDetectorInfo that specifies which detector to initialize

--- a/source/actions3/actions/AMDetectorDwellTimeActionInfo.h
+++ b/source/actions3/actions/AMDetectorDwellTimeActionInfo.h
@@ -51,7 +51,7 @@ public:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMDetectorInfo that specifies which detector to acquire

--- a/source/actions3/actions/AMDetectorInitializeActionInfo.h
+++ b/source/actions3/actions/AMDetectorInitializeActionInfo.h
@@ -48,7 +48,7 @@ public:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMDetectorInfo that specifies which detector to initialize

--- a/source/actions3/actions/AMDetectorReadActionInfo.h
+++ b/source/actions3/actions/AMDetectorReadActionInfo.h
@@ -48,7 +48,7 @@ public:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMDetectorInfo that specifies which detector to acquire

--- a/source/actions3/actions/AMDetectorSetAsDarkCurrentCorrectionActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetAsDarkCurrentCorrectionActionInfo.h
@@ -48,7 +48,7 @@ public:
     /// For database storing only
     AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
     /// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-    void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+    void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
     /// The AMDetectorInfo that specifies which detector to initialize

--- a/source/actions3/actions/AMDetectorTriggerActionInfo.h
+++ b/source/actions3/actions/AMDetectorTriggerActionInfo.h
@@ -51,7 +51,7 @@ public:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
-	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { delete newLoadedObject; }
+	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 protected:
 	/// The AMDetectorInfo that specifies which detector to acquire

--- a/source/actions3/actions/AMScanAction.cpp
+++ b/source/actions3/actions/AMScanAction.cpp
@@ -57,7 +57,7 @@ AMScanAction::~AMScanAction()
 	if (controller_ && hasValidScanController_){
 
 		controller_->disconnect();
-		delete controller_;
+		controller_->deleteLater();
 	}
 }
 

--- a/source/actions3/actions/AMScanActionInfo.cpp
+++ b/source/actions3/actions/AMScanActionInfo.cpp
@@ -134,7 +134,7 @@ AMScanConfiguration *AMScanActionInfo::getConfigurationFromDb() const
 	if(!scan) {
 
 		AMErrorMon::alert(this, AMSCANACTIONINFO_DB_OBJECT_NOT_A_SCAN, "Object loaded from the database was not a scan.");
-		delete dbo;
+		dbo->deleteLater();
 		return 0; //NULL
 	}
 	// Does the scan have a configuration?

--- a/source/actions3/editors/AMScanActionEditor.cpp
+++ b/source/actions3/editors/AMScanActionEditor.cpp
@@ -56,7 +56,7 @@ AMScanActionEditor::~AMScanActionEditor()
 {
 	if (configView_){
 
-		delete configView_;
+		configView_->deleteLater();
 		configView_ = 0;
 	}
 }

--- a/source/analysis/AM1DCalibrationABEditor.cpp
+++ b/source/analysis/AM1DCalibrationABEditor.cpp
@@ -313,7 +313,7 @@ void AM1DCalibrationABEditor::onApplyToOtherScansChosen()
 	}
 
 	progressDialog->setValue(scans.count());
-	delete progressDialog;
+	progressDialog->deleteLater();
 
 	AMErrorMon::information(this, 0, QString("Batch Calibrating: set the calibration parameters successfully for %1 XAS scans.").arg(scansModified));
 	chooseScanDialog_->close();

--- a/source/analysis/AMExternalScanDataSourceAB.cpp
+++ b/source/analysis/AMExternalScanDataSourceAB.cpp
@@ -61,7 +61,7 @@ AMExternalScanDataSourceAB::AMExternalScanDataSourceAB(AMDatabase* sourceDatabas
 	}
 	catch(int errCode) {
 		if(dbObject) {
-			delete dbObject;
+			dbObject->deleteLater();
 		}
 		scan_ = 0;
 	}
@@ -132,7 +132,7 @@ bool AMExternalScanDataSourceAB::refreshData()
 		setState(scan_->dataSourceAt(dataSourceIndex)->state());
 
 		// delete the scan
-		delete scan_;
+		scan_->deleteLater();
 		scan_ = 0;
 
 		// signalling:
@@ -146,9 +146,9 @@ bool AMExternalScanDataSourceAB::refreshData()
 	}
 	catch(int errCode) {
 		if(dbObject)
-			delete dbObject;
+			dbObject->deleteLater();
 		if(scan_) {
-			delete scan_;
+			scan_->deleteLater();
 			scan_ = 0;
 		}
 		setState(AMDataSource::InvalidFlag);
@@ -364,7 +364,7 @@ bool AMExternalScanDataSourceAB::loadFromDb(AMDatabase *db, int id)
 	}
 
 	if(scan_) {	// don't want refreshData() to use an old scan object. This will ensure it loads a new one.
-		delete scan_;
+		scan_->deleteLater();
 		scan_ = 0;
 	}
 	// from this point on, we've actually made permanent modifications to our parameters. Which means that we need to change the state to invalid if anything goes wrong from here. This will be taken care of by refreshData().

--- a/source/analysis/REIXS/REIXSXESImageABEditor.cpp
+++ b/source/analysis/REIXS/REIXSXESImageABEditor.cpp
@@ -1046,7 +1046,7 @@ void REIXSXESImageABEditor::onApplyToOtherScansChosen()
 	}
 
 	progressDialog->setValue(scans.count());
-	delete progressDialog;
+	progressDialog->deleteLater();
 
 	// User feedback on what just happened:
 	QStringList operationsCompleted;

--- a/source/analysis/REIXS/REIXSXESImageInterpolationABEditor.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationABEditor.cpp
@@ -1043,7 +1043,7 @@ void REIXSXESImageInterpolationABEditor::onApplyToOtherScansChosen()
 	}
 
 	progressDialog->setValue(scans.count());
-	delete progressDialog;
+	progressDialog->deleteLater();
 
 	// User feedback on what just happened:
 	QStringList operationsCompleted;

--- a/source/application/AMAppController.cpp
+++ b/source/application/AMAppController.cpp
@@ -315,7 +315,7 @@ void AMAppController::launchScanConfigurationFromDb(const QUrl &url)
 
 	AMScanConfigurationView *view = config->createView();
 	if(!view) {
-		delete config;
+		config->deleteLater();
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Alert, -401, "Unable to create view from the scan configuration loaded from the database.  Contact Acquaman developers."));
 		return;
 	}

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -971,7 +971,7 @@ void AMDatamanAppController::shutdown() {
 	isShuttingDown_ = true;
 
 	// destroy the main window. This will delete everything else within it.
-	delete mw_;
+	mw_->deleteLater();
 
 	// Close down connection to the user Database
 	AMDatabase::deleteDatabase("user");
@@ -1105,7 +1105,7 @@ void AMDatamanAppController::launchScanConfigurationFromDb(const QUrl &url)
 
 	AMScanConfigurationView *view = config->createView();
 	if(!view) {
-		delete config;
+		config->deleteLater();
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Alert, -401, "Unable to create view from the scan configuration loaded from the database.  Contact Acquaman developers."));
 		return;
 	}
@@ -1194,7 +1194,7 @@ void AMDatamanAppController::onIssueSubmissionViewFinished(){
 		return;
 
 	disconnect(issueSubmissionView_, SIGNAL(finished()), this, SLOT(onIssueSubmissionViewFinished()));
-	delete issueSubmissionView_;
+	issueSubmissionView_->deleteLater();
 	issueSubmissionView_ = 0;
 }
 
@@ -1534,7 +1534,7 @@ AMScan *AMDatamanAppController::dropScanURL(const QUrl &url)
 	// Is it a scan?
 	AMScan* scan = qobject_cast<AMScan*>( dbo );
 	if(!scan) {
-		delete dbo;
+		dbo->deleteLater();
 		return 0;
 	}
 
@@ -1545,7 +1545,7 @@ AMScan *AMDatamanAppController::dropScanURL(const QUrl &url)
 		scan->storeToDb(AMDatabase::database("user"));
 
 		/// \todo DH: I'm sure I should just make a function to do things like this, but for now I'm just duplicating code because it's easy.
-		delete dbo;
+		dbo->deleteLater();
 
 		dbo = AMDbObjectSupport::s()->createAndLoadObjectAt(db, tableName, id);
 		if(!dbo)
@@ -1554,7 +1554,7 @@ AMScan *AMDatamanAppController::dropScanURL(const QUrl &url)
 		// Is it a scan?
 		scan = qobject_cast<AMScan*>( dbo );
 		if(!scan) {
-			delete dbo;
+			dbo->deleteLater();
 			return 0;
 		}
 	}

--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -217,7 +217,7 @@ bool VESPERSAppController::ensureProgramStructure()
 
 void VESPERSAppController::shutdown() {
 	// Make sure we release/clean-up the beamline interface
-	delete attoHack_;
+	attoHack_->deleteLater();
 	AMBeamline::releaseBl();
 	AMAppController::shutdown();
 }

--- a/source/beamline/AMBeamline.cpp
+++ b/source/beamline/AMBeamline.cpp
@@ -47,7 +47,7 @@ AMBeamline::~AMBeamline()
 void AMBeamline::releaseBl() {
 
 	if(instance_) {
-		delete instance_;
+		instance_->deleteLater();
 		instance_ = 0;
 		}
 

--- a/source/beamline/AMOldDetector.cpp
+++ b/source/beamline/AMOldDetector.cpp
@@ -60,7 +60,7 @@ AMOldDetector::AMOldDetector(const QString &name, AMOldDetector::ReadMethod read
 
 AMOldDetector::~AMOldDetector() {
 	signalSource_->emitDeleted();
-	delete signalSource_;
+	signalSource_->deleteLater();
 	signalSource_ = 0;
 }
 

--- a/source/beamline/AMProcessVariablePrivate.cpp
+++ b/source/beamline/AMProcessVariablePrivate.cpp
@@ -68,7 +68,7 @@ AMProcessVariableSupport::~AMProcessVariableSupport()
 
 void AMProcessVariableSupport::shutdownChannelAccess()
 {
-	delete instance_;
+	instance_->deleteLater();
 	instance_ = 0;
 }
 
@@ -295,7 +295,7 @@ void AMProcessVariablePrivate::detachProcessVariable(AMProcessVariable *pv)
 	reviewMonitoring();
 
 	if(attachedProcessVariables_.isEmpty())
-		delete this;	 // we can do this (carefully), since it is the last thing we do, and nothing will ever use us anymore.
+		this->deleteLater();	 // we can do this (carefully), since it is the last thing we do, and nothing will ever use us anymore.
 }
 
 

--- a/source/beamline/AMStorageRing.cpp
+++ b/source/beamline/AMStorageRing.cpp
@@ -28,7 +28,7 @@ void AMStorageRing::releaseStorageRing()
 {
 	if (instance_){
 
-		delete instance_;
+		instance_->deleteLater();
 		instance_ = 0;
 	}
 }

--- a/source/beamline/REIXS/REIXSBeamline.cpp
+++ b/source/beamline/REIXS/REIXSBeamline.cpp
@@ -591,7 +591,7 @@ bool REIXSSpectrometer::stop()
 	if(moveInProgress()) {
 		moveAction_->cancel();
 		/// \todo Actually, have to flag that a stop has started, and also catch when the stop is finished... Motors will take a while to actually receive and decelerate.
-		delete moveAction_;
+		moveAction_->deleteLater();
 		moveAction_ = 0;
 		emit moveFailed(AMControl::WasStoppedFailure);
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Alert, AMControl::WasStoppedFailure, "Spectrometer Move Stopped."));
@@ -937,7 +937,7 @@ void REIXSBrokenMonoControl::onMonoAngleError(double error)
 
 
 REIXSBrokenMonoControl::~REIXSBrokenMonoControl() {
-	delete control_;
+	control_->deleteLater();
 	control_ = 0;
 }
 

--- a/source/beamline/camera/AMSampleCamera.cpp
+++ b/source/beamline/camera/AMSampleCamera.cpp
@@ -1065,7 +1065,7 @@ void AMSampleCamera::deleteRectangle(QPointF position)
 			{
 				if(polygon == calibrationPoints_[j])
 				{
-					delete calibrationPoints_[j];
+					calibrationPoints_[j]->deleteLater();
 					calibrationPoints_[j] = 0;
 					j = SAMPLEPOINTS;
 					deleted = true;
@@ -1075,7 +1075,7 @@ void AMSampleCamera::deleteRectangle(QPointF position)
 				{
 					if(polygon == beamMarkers_[j])
 					{
-						delete beamMarkers_[j];
+						beamMarkers_[j]->deleteLater();
 						beamMarkers_[j] = 0;
 						j = SAMPLEPOINTS;
 						deleted = true;
@@ -1084,13 +1084,13 @@ void AMSampleCamera::deleteRectangle(QPointF position)
 			}
 			if(!deleted && (polygon == samplePlateShape_))
 			{
-				delete samplePlateShape_;
+				samplePlateShape_->deleteLater();
 				samplePlateShape_ = 0;
 				deleted = true;
 			}
 			if(!deleted && (polygon == cameraConfigurationShape_))
 			{
-				delete cameraConfigurationShape_;
+				cameraConfigurationShape_->deleteLater();
 				cameraConfigurationShape_ = 0;
 				deleted = true;
 			}

--- a/source/dataman/AMImportController.cpp
+++ b/source/dataman/AMImportController.cpp
@@ -78,7 +78,7 @@ AMScan* SGMLegacyImporter::createScanAndImport(const QString& fullPath) {
 		return rv;
 	}
 	else {
-		delete rv;
+		rv->deleteLater();
 		return 0;
 	}
 }
@@ -119,7 +119,7 @@ AMScan* ALSBL8XASImporter::createScanAndImport(const QString& fullPath) {
 		return rv;
 	}
 	else {
-		delete rv;
+		rv->deleteLater();
 		return 0;
 	}
 }
@@ -130,8 +130,8 @@ AMImportController::~AMImportController() {
 	for(int i=0; i<importers_.count(); i++)
 		delete importers_[i];
 
-	delete fileDialog_;
-	delete w_;
+	fileDialog_->deleteLater();
+	w_->deleteLater();
 }
 
 AMImportController::AMImportController(QObject *parent) :
@@ -368,7 +368,7 @@ void AMImportController::finalizeImport() {
 		}
 
 		w_->thumbnailViewer->setSource(0);
-		delete currentScan_;
+		currentScan_->deleteLater();
 		currentScan_ = 0;
 	}
 }

--- a/source/dataman/AMSamplePlatePre2013.cpp
+++ b/source/dataman/AMSamplePlatePre2013.cpp
@@ -316,7 +316,7 @@ void AMSamplePlatePre2013::dbLoadPositions(const AMDbObjectList& newPositions) {
 		}
 
 		if(newPositions.at(i))
-			delete newPositions.at(i);	// we're copying these. Don't need to keep these ones around. Our responsibility to delete.
+			newPositions.at(i)->deleteLater();	// we're copying these. Don't need to keep these ones around. Our responsibility to delete.
 	}
 }
 

--- a/source/dataman/AMScan.cpp
+++ b/source/dataman/AMScan.cpp
@@ -94,12 +94,12 @@ AMScan::~AMScan() {
 
 	// delete the scan configuration, if we have one
 	if(configuration_) {
-		delete configuration_;
+		configuration_->deleteLater();
 		configuration_ = 0;
 	}
 
 	// delete the raw data store, which was allocated in the constructor.
-	delete data_;
+	data_->deleteLater();
 }
 
 
@@ -294,7 +294,7 @@ bool AMScan::loadFromDb(AMDatabase* db, int sourceId) {
 		}
 	}
 
-	delete nameDictionary_;
+	nameDictionary_->deleteLater();
 	nameDictionary_ = new AMScanDictionary(this, this);
 
 	return true;
@@ -307,7 +307,7 @@ void AMScan::dbLoadScanInitialConditions(AMDbObject* newLoadedObject) {
 
 	// delete newLoadedObject, since we don't intend to do anything with it, but we're responsible for it.
 	if(newLoadedObject)
-		delete newLoadedObject;
+		newLoadedObject->deleteLater();
 }
 
 // Returns a list of pointers to the raw data sources, to support db storage.
@@ -332,7 +332,7 @@ void AMScan::dbLoadRawDataSources(const AMDbObjectList& newRawSources) {
 	while( (count = rawDataSources_.count()) ) {
 		AMRawDataSource* deleteMe = rawDataSources_.at(count-1);
 		rawDataSources_.remove(count-1);	// removing at the end is fastest.
-		delete deleteMe;
+		deleteMe->deleteLater();
 	}
 
 	// add new sources. Simply adding these to rawDataSources_ will be enough to emit the signals that tell everyone watching we have new data channels.
@@ -356,7 +356,7 @@ void AMScan::dbLoadAnalyzedDataSources(const AMDbObjectList& newAnalyzedSources)
 	while( (count = analyzedDataSources_.count()) ) {
 		AMAnalysisBlock* deleteMe = analyzedDataSources_.at(count-1);
 		analyzedDataSources_.remove(count-1);	// removing at the end is fastest.
-		delete deleteMe;
+		deleteMe->deleteLater();
 	}
 
 	// Simply adding these to analyzedDataSources_ will be enough to emit the signals that tell everyone watching we have new data channels.
@@ -468,7 +468,7 @@ void AMScan::setScanConfiguration(AMScanConfiguration* newConfiguration) {
 	if(configuration_ == newConfiguration)
 		return;
 	if(configuration_)
-		delete configuration_;
+		configuration_->deleteLater();
 	configuration_ = newConfiguration;
 	setModified(true);
 	emit scanConfigurationChanged();
@@ -840,7 +840,7 @@ bool AMScan::replaceRawDataStore(AMDataStore *dataStore)
 		rawDataSources_[i]->setDataStore(dataStore);
 	}
 
-	delete data_;
+	data_->deleteLater();
 	data_ = dataStore;
 
 	return true;
@@ -902,7 +902,7 @@ AMScan * AMScan::createFromDatabaseUrl(const QUrl &url, bool allowIfScanning, bo
 
 	AMScan* scan = qobject_cast<AMScan*>( dbo );
 	if(!scan) {
-		delete dbo;
+		dbo->deleteLater();
 		return 0;
 	}
 

--- a/source/dataman/AMScan.h
+++ b/source/dataman/AMScan.h
@@ -201,7 +201,7 @@ public:
 	/// This overloaded function calls addRawDataSource() after setting the visibleInPlots() and hiddenFromUsers() hints of the data source.
 	bool addRawDataSource(AMRawDataSource* newRawDataSource, bool visibleInPlots, bool hiddenFromUsers);
 	/// Delete and remove an existing raw data source.  \c id is the idnex of the source in rawDataSources().
-	bool deleteRawDataSource(int id) { if((unsigned)id >= (unsigned)rawDataSources_.count()) return false; delete rawDataSources_.takeAt(id); return true; }
+	bool deleteRawDataSource(int id) { if((unsigned)id >= (unsigned)rawDataSources_.count()) return false; rawDataSources_.takeAt(id)->deleteLater(); return true; }
 
 	/// Returns read-only access to the set of analyzed data sources. (Analyzed data sources are built on either raw data sources, or other analyzed sources, by applying an AMAnalysisBlock.)
 	const AMAnalyzedDataSourceSet* analyzedDataSources() const { return &analyzedDataSources_; }
@@ -211,7 +211,7 @@ public:
 	/// This overloaded function calls addAnalyzedDataSource() after setting the visibleInPlots() and hiddenFromUsers() hints of the data source.
 	bool addAnalyzedDataSource(AMAnalysisBlock *newAnalyzedDataSource, bool visibleInPlots, bool hiddenFromUsers);
 	/// Delete and remove an existing analysis block. \c id is the index of the source in analyzedDataSources().
-	bool deleteAnalyzedDataSource(int id) { if((unsigned)id >= (unsigned)analyzedDataSources_.count()) return false; delete analyzedDataSources_.takeAt(id); return true; }
+	bool deleteAnalyzedDataSource(int id) { if((unsigned)id >= (unsigned)analyzedDataSources_.count()) return false; analyzedDataSources_.takeAt(id)->deleteLater(); return true; }
 
 	// Provides a simple access model to all the data sources (combination of rawDataSources() and analyzedDataSources()
 
@@ -260,12 +260,12 @@ public:
 			return false;
 		int rawCount = rawDataSources_.count();
 		if(index < rawCount)	{ // is a raw data source.
-			delete rawDataSources_.takeAt(index);
+			rawDataSources_.takeAt(index)->deleteLater();
 			return true;
 		}
 		index -= rawCount;
 		if(index < analyzedDataSources_.count()) {
-			delete analyzedDataSources_.takeAt(index);
+			analyzedDataSources_.takeAt(index)->deleteLater();
 			return true;
 		}
 		return false;
@@ -324,7 +324,7 @@ Returns false and does nothing if the new \c dataStore is incompatible with any 
 	/// Clears the scan's rawData() completely, including all measurements configured within the data store. Also deletes all rawDataSources() that expose this data.
 	void clearRawDataPointsAndMeasurementsAndDataSources() {
 		while(rawDataSources_.count())
-			delete rawDataSources_.takeAt(rawDataSources_.count()-1);
+			rawDataSources_.takeAt(rawDataSources_.count()-1)->deleteLater();
 
 		data_->clearAllMeasurements();
 	}

--- a/source/dataman/AMUser.h
+++ b/source/dataman/AMUser.h
@@ -42,7 +42,7 @@ public:
 	/// Release and delete the singleton instance
 	static void releaseUser() {
 		if(instance_) {
-			delete instance_;
+			instance_->deleteLater();
 			instance_ = 0;
 		}
 	}

--- a/source/dataman/REIXS/REIXSXESCalibration2.cpp
+++ b/source/dataman/REIXS/REIXSXESCalibration2.cpp
@@ -100,7 +100,7 @@ void REIXSXESCalibration2::dbLoadGratings(const AMDbObjectList& newGratings)
 		if(g)
 			gratings_ << *g;
 
-		delete dbo;
+		dbo->deleteLater();
 	}
 }
 

--- a/source/dataman/database/AMDatabase.cpp
+++ b/source/dataman/database/AMDatabase.cpp
@@ -94,7 +94,7 @@ void AMDatabase::deleteDatabase(const QString& connectionName) {
 		ml.unlock();
 
 		db->qdb().close();
-		delete db;
+		db->deleteLater();
 	}
 }
 

--- a/source/dataman/database/AMDbObject.cpp
+++ b/source/dataman/database/AMDbObject.cpp
@@ -787,7 +787,7 @@ void AMDbObject::updateThumbnailsInSeparateThread(AMDatabase *db, int id, const 
 	QCoreApplication::postEvent(AMDbObjectSupport::s(), new AMDbThumbnailsGeneratedEvent(thumbnails, db, dbTableName, id, neverSavedHereBefore));
 
 	// And now we're done with the object...
-	delete object;
+	object->deleteLater();
 }
 
 void AMDbObject::updateThumbnailsInCurrentThread(bool neverSavedHereBefore)

--- a/source/dataman/database/AMDbObjectSupport.cpp
+++ b/source/dataman/database/AMDbObjectSupport.cpp
@@ -802,7 +802,7 @@ AMDbObject* AMDbObjectSupport::createAndLoadObjectAt(AMDatabase* db, const QStri
 		if(newObject->loadFromDb(db, id))
 			return newObject;
 		else {
-			delete newObject;	// loading failed, and we're not going to return anything. Make sure not to leak the newly-created object.
+			newObject->deleteLater();	// loading failed, and we're not going to return anything. Make sure not to leak the newly-created object.
 			AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, AMDBOBJECTSUPPORT_CANNOT_LOAD_OBJECT_LOAD_CALL_FAILED, QString("[AMDbObjectSupport] Could not load the object with ID %1 from the table '%2': loadFromDb() failed. Please report this bug to the Acquaman developers").arg(id).arg(tableName)));
 		}
 	}

--- a/source/dataman/datasource/AMDataSource.cpp
+++ b/source/dataman/datasource/AMDataSource.cpp
@@ -41,7 +41,7 @@ AMDataSource::AMDataSource(const QString& name)
 
 AMDataSource::~AMDataSource() {
 	signalSource_->emitDeleted();
-	delete signalSource_;
+	signalSource_->deleteLater();
 	signalSource_ = 0;
 }
 

--- a/source/dataman/export/AMExportController.cpp
+++ b/source/dataman/export/AMExportController.cpp
@@ -85,7 +85,7 @@ bool AMExportController::chooseExporter(const QString &exporterClassName)
 		return false;
 
 	if(exporter_)
-		delete exporter_;
+		exporter_->deleteLater();
 
 	exporter_ = qobject_cast<AMExporter*>(registeredExporters_.value(exporterClassName).metaObject->newInstance());
 	exporter_->setParent(this);
@@ -281,7 +281,7 @@ void AMExportController::continueScanExport()
 			scan = qobject_cast<AMScan*>(databaseObject);
 
 			if(!scan) {
-				delete databaseObject;
+				databaseObject->deleteLater();
 				throw QString("The export system couldn't load a scan out of the database (" % url.toString() % "), so this scan has not been exported.");
 			}
 		}
@@ -337,7 +337,7 @@ void AMExportController::continueScanExport()
 }
 
 void AMExportController::setOption(AMExporterOption *option) {
-	delete option_;
+	option_->deleteLater();
 	option_ = option;
 	if(option_)
 		option_->setAvailableDataSourcesModel(availableDataSourcesModel());

--- a/source/dataman/import/AMScanDatabaseImportController.cpp
+++ b/source/dataman/import/AMScanDatabaseImportController.cpp
@@ -73,7 +73,7 @@ bool AMScanDatabaseImportController::setSourceFolderAndLoadDatabase(const QStrin
 
 
 	if(!AMDbObjectSupport::s()->registerDatabase(sourceDb_)) {
-		delete sourceDb_;
+		sourceDb_->deleteLater();
 		sourceDb_ = 0;
 		return false;
 	}
@@ -432,7 +432,7 @@ void AMScanDatabaseImportController::copyScans()
 											 AMErrorReport::Alert,
 											 -4,
 											 QString("Error copying the scan with ID '%1' out of the import database: it wasn't a scan object. Your database might be corrupted. Please report this problem to the Acquaman developers.").arg(scanIds.at(i))));
-			delete object;
+			object->deleteLater();
 			continue;
 		}
 

--- a/source/dataman/info/AMControlInfoList.cpp
+++ b/source/dataman/info/AMControlInfoList.cpp
@@ -113,7 +113,7 @@ void AMControlInfoList::dbLoadControlInfos(const AMDbObjectList& newControlInfos
 			append(*newControlInfo);	// note: makes a copy of object pointed to by newControlInfo, and stores in our internal list.
 		}
 
-		delete newControlInfos.at(i);	// we're copying these. Don't need to keep these ones around. They're our responsibility to delete.
+		newControlInfos.at(i)->deleteLater();	// we're copying these. Don't need to keep these ones around. They're our responsibility to delete.
 	}
 }
 

--- a/source/dataman/info/AMDetectorInfoSet.cpp
+++ b/source/dataman/info/AMDetectorInfoSet.cpp
@@ -93,7 +93,7 @@ void AMDetectorInfoSet::dbLoadDetectorInfos(const AMDbObjectList& newDetectorInf
 		if(newDetectorInfo)
 			append(*newDetectorInfo, newDetectorInfo->name());
 
-		delete newDetectorInfos.at(x);
+		newDetectorInfos.at(x)->deleteLater();
 	}
 }
 

--- a/source/ui/AMMainWindow.cpp
+++ b/source/ui/AMMainWindow.cpp
@@ -92,13 +92,13 @@ AMMainWindow::~AMMainWindow() {
 	QList<QWidget*> panes = model_->allPanes();
 
 	// get rid of the sidebar, so that it's not emitting signals and causing changes while we delete the widgets themselves.
-	delete sidebar_;
+	sidebar_->deleteLater();
 
 	// delete the model.
-	delete model_;
+	model_->deleteLater();
 
 	foreach(QWidget* pane, panes) {
-		delete pane;
+		pane->deleteLater();
 	}
 }
 
@@ -118,7 +118,7 @@ void AMMainWindow::deletePane(QWidget* pane) {
 	removePane(pane);
 
 	// delete actual widget:
-	delete pane;
+	pane->deleteLater();
 }
 
 

--- a/source/ui/AMOverlayVideoWidget.cpp
+++ b/source/ui/AMOverlayVideoWidget.cpp
@@ -62,8 +62,8 @@ AMOverlayVideoWidget::~AMOverlayVideoWidget() {
 	#ifdef AM_MOBILITY_VIDEO_ENABLED
 	mediaPlayer_->setMedia(QMediaContent());
 
-	delete videoItem_;
-	delete mediaPlayer_;
+	videoItem_->deleteLater();
+	mediaPlayer_->deleteLater();
 	#endif
 }
 

--- a/source/ui/AMOverlayVideoWidget2.cpp
+++ b/source/ui/AMOverlayVideoWidget2.cpp
@@ -63,8 +63,8 @@ AMOverlayVideoWidget2::~AMOverlayVideoWidget2() {
   */
 	#ifdef AM_MOBILITY_VIDEO_ENABLED
 	mediaPlayer_->setMedia(QMediaContent());
-	delete videoItem_;
-	delete mediaPlayer_;
+	videoItem_->deleteLater();
+	mediaPlayer_->deleteLater();
 	#endif
 }
 

--- a/source/ui/AMVerticalStackWidget.cpp
+++ b/source/ui/AMVerticalStackWidget.cpp
@@ -114,7 +114,7 @@ QWidget* AMVerticalStackWidget::takeItem(int index) {
 	vl_->takeAt(2*index);
 	vl_->takeAt(2*index);
 
-	delete b;
+	b->deleteLater();
 	delete item;
 
 	w->removeEventFilter(this);

--- a/source/ui/AMVerticalStackWidget.h
+++ b/source/ui/AMVerticalStackWidget.h
@@ -98,7 +98,7 @@ public:
 
 	/// Remove a widget, and delete it
 	void deleteItem(int index) {
-		delete takeItem(index);
+		takeItem(index)->deleteLater();
 	}
 
 	/// Remove a widget and return it. Ownership becomes the responsibility of the caller.

--- a/source/ui/SGM/SGMPeriodicTableView.cpp
+++ b/source/ui/SGM/SGMPeriodicTableView.cpp
@@ -72,7 +72,7 @@ void SGMPeriodicTableView::onClicked(int atomicNumber){
 	QList<SGMFastScanParameters*> allFastScans = SGMPeriodicTable::sgmTable()->fastScanPresets(SGMPeriodicTable::SGMPeriodicTableAllDatabasesConnectionName());
 
 	if(availableScansMenu_)
-		delete availableScansMenu_;
+		availableScansMenu_->deleteLater();
 	availableScansMenu_ = new QMenu();
 	QAction *tempAction;
 	bool foundOne = false;

--- a/source/ui/VESPERS/VESPERSEndstationView.cpp
+++ b/source/ui/VESPERS/VESPERSEndstationView.cpp
@@ -153,7 +153,7 @@ VESPERSEndstationView::VESPERSEndstationView(VESPERSEndstation *endstation, QWid
 
 VESPERSEndstationView::~VESPERSEndstationView()
 {
-	delete config_;
+	config_->deleteLater();
 }
 
 void VESPERSEndstationView::onLaserDistanceChanged()

--- a/source/ui/VESPERS/VESPERSMotorView.cpp
+++ b/source/ui/VESPERS/VESPERSMotorView.cpp
@@ -105,7 +105,7 @@ void VESPERSMotorView::setControl(AMControl *control)
 	connect(jogLeft_, SIGNAL(clicked()), this, SLOT(jogLeft()));
 	connect(jogRight_, SIGNAL(clicked()), this, SLOT(jogRight()));
 
-	delete this->layout();
+	this->layout()->deleteLater();
 
 	QGridLayout *layout = new QGridLayout;
 	layout->addWidget(title_, 0, 0, 1, 6);
@@ -166,7 +166,7 @@ void VESPERSMotorView::setControl(AMControl *control, double lowLimit, double hi
 	connect(jogLeft_, SIGNAL(clicked()), this, SLOT(jogLeft()));
 	connect(jogRight_, SIGNAL(clicked()), this, SLOT(jogRight()));
 
-	delete this->layout();
+	this->layout()->deleteLater();
 
 	QGridLayout *layout = new QGridLayout;
 	layout->addWidget(title_, 0, 0, 1, 6);
@@ -219,7 +219,7 @@ void VESPERSMotorView::setControl(AMControl *control, double firstSetpoint, doub
 	connect(firstSetpointButton_, SIGNAL(clicked()), this, SLOT(moveToFirstSetpoint()));
 	connect(secondSetpointButton_, SIGNAL(clicked()), this, SLOT(moveToSecondSetpoint()));
 
-	delete this->layout();
+	this->layout()->deleteLater();
 
 	QGridLayout *layout = new QGridLayout;
 	layout->addWidget(title_, 0, 0, 1, 4);

--- a/source/ui/VESPERS/VESPERSPIDLoopControlView.cpp
+++ b/source/ui/VESPERS/VESPERSPIDLoopControlView.cpp
@@ -57,7 +57,7 @@ VESPERSPIDLoopControlView::VESPERSPIDLoopControlView(VESPERSPIDLoopControl *pid,
 
 VESPERSPIDLoopControlView::~VESPERSPIDLoopControlView()
 {
-	delete timer_;
+	timer_->deleteLater();
 }
 
 void VESPERSPIDLoopControlView::toggleButtonColor()

--- a/source/ui/acquaman/AMScanConfigurationViewHolder3.cpp
+++ b/source/ui/acquaman/AMScanConfigurationViewHolder3.cpp
@@ -54,7 +54,7 @@ AMScanConfigurationViewHolder3::AMScanConfigurationViewHolder3(AMScanConfigurati
 void AMScanConfigurationViewHolder3::setView(AMScanConfigurationView *view) {
 	// delete old view, if it exists
 	if(view_)
-		delete view_;
+		view_->deleteLater();
 
 	view_ = view;
 	if(view_) {

--- a/source/ui/actions3/AMActionHistoryModel.cpp
+++ b/source/ui/actions3/AMActionHistoryModel.cpp
@@ -750,11 +750,11 @@ bool AMActionHistoryModel3::updateCompletedAction(const AMAction3 *completedActi
 			// OK, this is a specific update.
 			idsRequiringRefresh_ << actionLog->id();
 			specificRefreshFunctionCall_.schedule();
-			delete actionLog;
+			actionLog->deleteLater();
 			return true;
 		}
 
-		delete actionLog;
+		actionLog->deleteLater();
 		return false;
 	}
 	else {

--- a/source/ui/actions3/AMActionHistoryView3.cpp
+++ b/source/ui/actions3/AMActionHistoryView3.cpp
@@ -390,7 +390,7 @@ bool AMActionHistoryView3::recurseDbLoadIndex(const QModelIndex &index, AMListAc
 	if(!action) {
 		QMessageBox::warning(this, "Cannot re-run this action", "Could not re-run this action because running the '" % info->typeDescription() %  "' action isn't enabled for your beamline's version of Acquaman. If you don't think this should be the case, please report this to the Acquaman developers.");
 		AMErrorMon::debug(this, AMACTIONHISTORYVIEW_COULD_NOT_CREATE_ACTION, "Could not re-run this action because running '" % actionLog.name() % "' isn't enabled for your beamline's version of Acquaman. If you don't think this should be the case, please report this to the Acquaman developers.");
-		delete info;
+		info->deleteLater();
 		return false;
 	}
 
@@ -407,7 +407,7 @@ bool AMActionHistoryView3::recurseDbLoadIndex(const QModelIndex &index, AMListAc
 	}
 	if(!childrenSuccess){
 		if(!parentAction)
-			delete action;
+			action->deleteLater();
 		AMErrorMon::alert(this, AMACTIONHISTORYVIEW_COULD_NOT_LOAD_CHILD, "Could not re-run this action because running one or more children failed to load. Please report this to the Acquaman developers.");
 		return false;
 	}

--- a/source/ui/beamline/AMControlMoveButton.cpp
+++ b/source/ui/beamline/AMControlMoveButton.cpp
@@ -61,7 +61,7 @@ void AMControlMoveButton::setControl(AMControl *control)
 
 	// in the future: if we wanted to be slightly more efficient, could update the context menu to give it an editor for the new control instead of just deleting it and letting a new one be created.
 	if(contextMenu_) {
-		delete contextMenu_;
+		contextMenu_->deleteLater();
 		contextMenu_ = 0;
 	}
 
@@ -112,7 +112,7 @@ bool AMControlMoveButton::setStepSizes(const QList<double> &stepSizes)
 
 	// in the future: if we wanted to be slightly more efficient, could update the context menu instead of letting a whole new one be created.
 	if(contextMenu_) {
-		delete contextMenu_;
+		contextMenu_->deleteLater();
 		contextMenu_ = 0;
 	}
 

--- a/source/ui/beamline/AMRegionOfInterestView.cpp
+++ b/source/ui/beamline/AMRegionOfInterestView.cpp
@@ -159,5 +159,5 @@ void AMRegionOfInterestView::removeRegionOfInterest(AMRegionOfInterest *region)
 	AMRegionOfInterestElementView *view = regionsAndViews_.take(region);
 
 	if (view)
-		delete view;
+		view->deleteLater();
 }

--- a/source/ui/beamline/camera/AMGraphicsViewWizard.cpp
+++ b/source/ui/beamline/camera/AMGraphicsViewWizard.cpp
@@ -92,8 +92,8 @@ AMGraphicsViewWizard::~AMGraphicsViewWizard()
 		QMediaPlayer* player = (QMediaPlayer*)videoItem->mediaObject();
 		player->stop();
 		view_->scene()->removeItem(videoItem);
-		delete player;
-		delete videoItem;
+		player->deleteLater();
+		videoItem->deleteLater();
 	}
 	#endif
 }
@@ -474,7 +474,7 @@ void AMGraphicsViewWizard::mediaPlayerErrorChanged(QMediaPlayer::Error state)
 		// attempt to restart player
 		if(success)
 		{
-			delete mediaPlayer_;
+			mediaPlayer_->deleteLater();
 			mediaPlayer_ = new QMediaPlayer();
 			mediaPlayer_->setMedia(mediaUrl);
 			mediaPlayer_->setVideoOutput(videoItem);
@@ -891,7 +891,7 @@ void AMWizardOptionPage::initializePage()
 void AMWizardOptionPage::cleanupPage()
 {
 	layout()->removeWidget(coordinateFrame_);
-	delete coordinateFrame_;
+	coordinateFrame_->deleteLater();
 }
 
 bool AMWizardOptionPage::isComplete() const

--- a/source/ui/beamline/camera/AMSampleCameraGraphicsView.cpp
+++ b/source/ui/beamline/camera/AMSampleCameraGraphicsView.cpp
@@ -90,7 +90,7 @@ void AMSampleCameraGraphicsView::setVideoItem(QGraphicsVideoItem *item)
 {
 	if(videoItem_)
 		scene()->removeItem(videoItem_);
-	delete videoItem_;
+	videoItem_->deleteLater();
 	videoItem_ = item;
 	scene()->addItem(videoItem_);
 	mediaPlayer()->setVideoOutput(videoItem_);

--- a/source/ui/beamline/camera/AMSampleCameraView.cpp
+++ b/source/ui/beamline/camera/AMSampleCameraView.cpp
@@ -1340,7 +1340,7 @@ bool AMSampleCameraView::loadRotationalOffset(int databaseId)
 	if(!rotationalOffset->loadFromDb(db, id))
 		return false;
 	shapeModel_->setRotationalOffset(rotationalOffset->rotationalOffset());
-	delete rotationalOffset;
+	rotationalOffset->deleteLater();
 	refreshSceneView();
 
 	if(showGrid_){
@@ -2004,7 +2004,7 @@ void AMSampleCameraView::deleteShape()
 	textItems_.removeAt(index_);
 	index_--;
 	delete polygon;
-	delete text;
+	text->deleteLater();
 }
 
 /// change the currently selected item, outline it in blue

--- a/source/ui/beamline/camera/AMShapeDataView.cpp
+++ b/source/ui/beamline/camera/AMShapeDataView.cpp
@@ -369,7 +369,7 @@ void AMShapeDataView::updateCoordinateLabels()
 	int points = count();// ignore the closing point of the shape
 	if(points != oldCount_)
 	{
-		delete coordinateFrame_;
+		coordinateFrame_->deleteLater();
 		coordinateFrame_ = new QFrame();
 		if(coordinateEdit_)
 		{

--- a/source/ui/beamline/camera/AMWizardManager.cpp
+++ b/source/ui/beamline/camera/AMWizardManager.cpp
@@ -198,7 +198,7 @@ void AMWizardManager::cameraWizardUpdate()
 		AMSampleCameraGraphicsView *view = new AMSampleCameraGraphicsView();
 		view->setScene(parentView_->scene());
 		cameraWizard_->updateScene(view);
-		delete view;
+		view->deleteLater();
 	}
 }
 
@@ -209,7 +209,7 @@ void AMWizardManager::beamWizardUpdate()
 		AMSampleCameraGraphicsView *view = new AMSampleCameraGraphicsView();
 		view->setScene(parentView_->scene());
 		beamWizard_->updateScene(view);
-		delete view;
+		view->deleteLater();
 	}
 }
 
@@ -220,7 +220,7 @@ void AMWizardManager::sampleWizardUpdate()
 		AMSampleCameraGraphicsView *view = new AMSampleCameraGraphicsView();
 		view->setScene(parentView_->scene());
 		samplePlateWizard_->updateScene(view);
-		delete view;
+		view->deleteLater();
 	}
 }
 
@@ -231,7 +231,7 @@ void AMWizardManager::rotationWizardUpdate()
 		AMSampleCameraGraphicsView *view = new AMSampleCameraGraphicsView();
 		view->setScene(parentView_->scene());
 		rotationWizard_->updateScene(view);
-		delete view;
+		view->deleteLater();
 	}
 }
 
@@ -243,14 +243,14 @@ void AMWizardManager::updateBeamWizardShape(QGraphicsPolygonItem *item)
 void AMWizardManager::cameraWizardDone()
 {
 	emit cameraWizardFinished();
-	delete cameraWizard_;
+	cameraWizard_->deleteLater();
 	cameraWizard_ = 0;
 }
 
 void AMWizardManager::beamWizardDone()
 {
 	emit beamWizardFinished();
-	delete beamWizard_;
+	beamWizard_->deleteLater();
 	beamWizard_ = 0;
 }
 
@@ -260,13 +260,13 @@ void AMWizardManager::sampleWizardDone()
 		emit sampleWizardFinished();
 	else if(samplePlateWizardType() == SIMPLE)
 		emit simpleSampleWizardFinished();
-	delete samplePlateWizard_;
+	samplePlateWizard_->deleteLater();
 	samplePlateWizard_ = 0;
 }
 
 void AMWizardManager::rotationWizardDone()
 {
 	emit rotationWizardFinished();
-	delete rotationWizard_;
+	rotationWizard_->deleteLater();
 	rotationWizard_ = 0;
 }

--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -677,7 +677,7 @@ AM2DScanViewExclusiveView::AM2DScanViewExclusiveView(AM2DScanView* masterView)
 AM2DScanViewExclusiveView::~AM2DScanViewExclusiveView()
 {
 	// PlotSeries's will be deleted as children items of the plot.
-	delete plot_;
+	plot_->deleteLater();
 }
 
 void AM2DScanViewExclusiveView::onRowInserted(const QModelIndex& parent, int start, int end)
@@ -946,7 +946,7 @@ AM2DScanViewMultiSourcesView::~AM2DScanViewMultiSourcesView()
 {
 	/* NOT necessary to delete all plotSeries. As long as they are added to a plot, they will be deleted when the plot is deleted (below).*/
 	foreach(MPlotGW* plot, dataSource2Plot_)
-		delete plot;
+		plot->deleteLater();
 }
 
 void AM2DScanViewMultiSourcesView::onRowInserted(const QModelIndex& parent, int start, int end)
@@ -1119,7 +1119,7 @@ bool AM2DScanViewMultiSourcesView::reviewDataSources() {
 			firstPlotEmpty_ = true;
 		}
 		else
-			delete dataSource2Plot_[sourceName];
+			dataSource2Plot_[sourceName]->deleteLater();
 
 		// remove pointer to deleted plot, and pointers to deleted series
 		dataSource2Plot_.remove(sourceName);

--- a/source/ui/dataman/AMDataSourcesEditor.h
+++ b/source/ui/dataman/AMDataSourcesEditor.h
@@ -95,7 +95,7 @@ protected:
 	/// Helper function: removes and deletes any current 'detail editors' (data source-specific parameter editors)
 	void removeDetailEditor() {
 		if(detailEditor_) {
-			delete detailEditor_;
+			detailEditor_->deleteLater();
 			detailEditor_ = 0;
 		}
 	}

--- a/source/ui/dataman/AMExportWizard.cpp
+++ b/source/ui/dataman/AMExportWizard.cpp
@@ -352,7 +352,7 @@ void AMExportWizardOptionPage::initializePage()
 
 void AMExportWizardOptionPage::onOptionSelectorIndexChanged(int index)
 {
-	delete optionView_;	// might be 0 if no option yet... or if last option couldn't create an editor. but that's okay.
+	optionView_->deleteLater();	// might be 0 if no option yet... or if last option couldn't create an editor. but that's okay.
 
 	// add new option...
 	if(index < 1) {

--- a/source/ui/dataman/AMSamplePre2013Editor.cpp
+++ b/source/ui/dataman/AMSamplePre2013Editor.cpp
@@ -283,7 +283,7 @@ void AMSamplePre2013Editor::onCBCurrentIndexChanged(int index) {
 void AMSamplePre2013Editor::createNewSample() {
 	static int sampleNum = 1;
 
-	delete sample_;
+	sample_->deleteLater();
 	sample_ = new AMSamplePre2013(QString("New Sample %1").arg(sampleNum++), this);
 	sample_->setDateTime(QDateTime::currentDateTime());
 	sample_->storeToDb(db_);

--- a/source/ui/dataman/AMScanSearchView.cpp
+++ b/source/ui/dataman/AMScanSearchView.cpp
@@ -280,7 +280,7 @@ AMScanSearchInfoListModel::AMScanSearchInfoListModel(QObject *parent) :
 AMScanSearchInfoListModel::~AMScanSearchInfoListModel()
 {
 	for (int iCache = 0; iCache < scanIds_.count(); iCache++)
-		delete scanCache_[iCache];
+		scanCache_[iCache]->deleteLater();
 	delete[] scanCache_;
 }
 

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -55,7 +55,7 @@ void AMScanViewSourceSelector::setModel(AMScanSetModel* model) {
 	if(model_) {
 
 		while(!scanBars_.isEmpty()) {
-			delete scanBars_.takeLast();
+			scanBars_.takeLast()->deleteLater();
 		}
 
 		disconnect(model_, 0, this, 0);
@@ -102,7 +102,7 @@ void AMScanViewSourceSelector::onRowAboutToBeRemoved(const QModelIndex& parent, 
 	// invalid (top-level) parent: means we're removing scans
 	if(!parent.isValid()){
 		for(int si=end; si>=start; si--) {
-			delete scanBars_.takeAt(si);
+			scanBars_.takeAt(si)->deleteLater();
 			// all the scans above this one need to move their scan index down:
 			for(int i=si; i<scanBars_.count(); i++)
 				scanBars_[i]->scanIndex_--;
@@ -240,7 +240,7 @@ AMScanView::AMScanView(AMScanSetModel* model, QWidget *parent) :
 
 AMScanView::~AMScanView() {
 	for(int i=0; i<views_.count(); i++)
-		delete views_.at(i);
+		views_.at(i)->deleteLater();
 }
 
 void AMScanView::setupUI() {
@@ -702,7 +702,7 @@ AMScanViewExclusiveView::AMScanViewExclusiveView(AMScanView* masterView) : AMSca
 AMScanViewExclusiveView::~AMScanViewExclusiveView() {
 	// PlotSeries's will be deleted as children items of the plot.
 
-	delete plot_;
+	plot_->deleteLater();
 }
 
 void AMScanViewExclusiveView::setPlotCursorVisibility(bool visible)
@@ -1104,7 +1104,7 @@ AMScanViewMultiView::~AMScanViewMultiView() {
  delete plotSeries_[si][ci];
    }*/
 
-	delete plot_;
+	plot_->deleteLater();
 }
 
 
@@ -1415,7 +1415,7 @@ void AMScanViewMultiScansView::addScan(int si) {
 
 AMScanViewMultiScansView::~AMScanViewMultiScansView() {
 	for(int pi=0; pi<plots_.count(); pi++)
-		delete plots_.at(pi);
+		plots_.at(pi)->deleteLater();
 }
 
 
@@ -1484,7 +1484,7 @@ void AMScanViewMultiScansView::onRowAboutToBeRemoved(const QModelIndex& parent, 
 				plots_.at(si)->plot()->legend()->setTitleText("");
 			}
 			else {
-				delete plots_.takeAt(si);
+				plots_.takeAt(si)->deleteLater();
 			}
 		}
 		reLayout();
@@ -1708,7 +1708,7 @@ AMScanViewMultiSourcesView::~AMScanViewMultiSourcesView() {
 	/* NOT necessary to delete all plotSeries. As long as they are added to a plot, they will be deleted when the plot is deleted (below).*/
 
 	foreach(MPlotGW* plot, dataSource2Plot_)
-		delete plot;
+		plot->deleteLater();
 }
 
 
@@ -1913,7 +1913,7 @@ bool AMScanViewMultiSourcesView::reviewDataSources() {
 			firstPlotEmpty_ = true;
 		}
 		else
-			delete dataSource2Plot_[sourceName];
+			dataSource2Plot_[sourceName]->deleteLater();
 
 		// remove pointer to deleted plot, and pointers to deleted series
 		dataSource2Plot_.remove(sourceName);

--- a/source/ui/dataman/AMScanViewUtilities.cpp
+++ b/source/ui/dataman/AMScanViewUtilities.cpp
@@ -152,7 +152,7 @@ void AMScanViewScanBar::onRowAboutToBeRemoved(const QModelIndex& parent, int sta
 	for(int di = end; di>=start; di-- ) {
 
 		sourceButtons_.button(di)->disconnect();
-		delete sourceButtons_.button(di);
+		sourceButtons_.button(di)->deleteLater();
 		// the button group's id's from "start+1" to "count+1" are too high now...
 		for(int i=di+1; i<sourceButtons_.buttons().count()+1; i++)
 			sourceButtons_.setId(sourceButtons_.button(i), i-1);
@@ -758,7 +758,7 @@ void AMScanViewSingleSpectrumView::setDataSources(QList<AMDataSource *> sources)
 
 		sourceButtons_->removeButton(button);
 		sourceButtonsLayout_->removeWidget(button);
-		delete button;
+		button->deleteLater();
 	}
 
 	buttons.clear();

--- a/source/ui/dataman/AMScanViewUtilities.h
+++ b/source/ui/dataman/AMScanViewUtilities.h
@@ -173,8 +173,8 @@ public:
 
 
 	virtual ~AMGraphicsViewAndWidget() {
-		delete graphicsWidget_;
-		delete scene_;
+		graphicsWidget_->deleteLater();
+		scene_->deleteLater();
 	}
 
 	QGraphicsWidget* graphicsWidget() const { return graphicsWidget_;}

--- a/source/util/AMOrderedList.h
+++ b/source/util/AMOrderedList.h
@@ -68,7 +68,7 @@ public:
 	}
 
 	/// Destructor
-	virtual ~AMOrderedList() { delete signalSource_; }
+	virtual ~AMOrderedList() { signalSource_->deleteLater(); }
 
 	// const access functions:
 	//=====================================

--- a/source/util/AMOrderedSet.h
+++ b/source/util/AMOrderedSet.h
@@ -81,7 +81,7 @@ public:
 	}
 
 	/// Destructor
-	virtual ~AMOrderedSet() { delete signalSource_; }
+	virtual ~AMOrderedSet() { signalSource_->deleteLater(); }
 
 	// const access functions:
 	//=====================================

--- a/source/util/AMPointerTree.cpp
+++ b/source/util/AMPointerTree.cpp
@@ -74,7 +74,7 @@ QList<void*> AMPointerTreeNode::clearNode(){
 	while(!childrenNodes_.isEmpty()){
 		descendantItems.append(childrenNodes_.last()->clearNode());
 		AMPointerTreeNode *lastChildNode = childrenNodes_.takeLast();
-		delete lastChildNode;
+		lastChildNode->deleteLater();
 	}
 	if(item_){
 		descendantItems.append(item_);

--- a/source/util/SGM/SGMElementInfo.cpp
+++ b/source/util/SGM/SGMElementInfo.cpp
@@ -370,7 +370,7 @@ void SGMElementInfo::dbLoadSGMEdgeInfos(const AMDbObjectList &sgmEdgeInfos){
 		if(newEdgeInfo)
 			sgmEdgeInfos_.append(*newEdgeInfo, newEdgeInfo->edge());// note: makes a copy of object pointed to by newStandardScanInfo, and stores in our internal list.
 
-		delete sgmEdgeInfos.at(x); // we're copying these, don't need to keep these ones around. They're our responsibility to delete.
+		sgmEdgeInfos.at(x)->deleteLater(); // we're copying these, don't need to keep these ones around. They're our responsibility to delete.
 	}
 }
 


### PR DESCRIPTION
Changed all available instances of calls to the delete operator on QObjects to deleteLater() functions calls. Ran on SGM Acquaman. Everything starts up. Cannot scan beamline right now, but opening and closing scans works. Running motor move actions in the workflow also works.
