### PR TITLE
Pull Request for Issue 904:  Wire pseudo stage reset control is missing

### DIFF
--- a/source/beamline/VESPERS/VESPERSBeamline.cpp
+++ b/source/beamline/VESPERS/VESPERSBeamline.cpp
@@ -229,6 +229,7 @@ void VESPERSBeamline::setupSampleStage()
 	realSampleStageResetControl_ = new AMSinglePVControl("Real Sample Stage Reset Control", "TS1607-2-B21-02:XYZ:loadOffsets.PROC", this, 0.1);
 	pseudoAttoStageResetControl_ = new AMSinglePVControl("Pseudo Atto Stage Reset Control", "TS1607-2-B21-07:HNV:loadOffsets.PROC", this, 0.1);
 	realAttoStageResetControl_ = new AMSinglePVControl("Real Atto Stage Reset Control", "TS1607-2-B21-07:XYZ:loadOffsets.PROC", this, 0.1);
+	pseudoWireStageResetControl_ = new AMSinglePVControl("Pseudo Wire Stage Reset Control", "TS1607-2-B21-01:HNV:loadOffsets.PROC", this, 0.1);
 }
 
 void VESPERSBeamline::setupMotorGroup()
@@ -261,7 +262,7 @@ void VESPERSBeamline::setupMotorGroup()
 										 QList<AMControl *>() << wireStageHorizontal_ << wireStageVertical_ << wireStageNormal_,
 										 QList<AMMotorGroupObject::Orientation>() << AMMotorGroupObject::Horizontal << AMMotorGroupObject::Vertical << AMMotorGroupObject::Normal,
 										 QList<AMMotorGroupObject::MotionType>() << AMMotorGroupObject::Translational << AMMotorGroupObject::Translational << AMMotorGroupObject::Translational,
-										 pseudoSampleStageResetControl_,
+										 pseudoWireStageResetControl_,
 										 this);
 	motorGroup_->addMotorGroupObject(motorObject->name(), motorObject);
 	motorObject = new CLSPseudoMotorGroupObject("Attocube Stage - H, V, N",

--- a/source/beamline/VESPERS/VESPERSBeamline.h
+++ b/source/beamline/VESPERS/VESPERSBeamline.h
@@ -472,6 +472,8 @@ public:
 	AMControl *pseudoAttoStageResetControl() const { return pseudoAttoStageResetControl_; }
 	/// Returns the real attocube stage reset control.
 	AMControl *realAttoStageResetControl() const { return realAttoStageResetControl_; }
+	/// Returns the pseudo wire stage reset control.
+	AMControl *pseudoWireStageResetControl() const { return pseudoWireStageResetControl_; }
 
 	// Sample stage PID controls.
 	/// Returns the PID control for the x-direction of the sample stage.
@@ -838,6 +840,7 @@ protected:
 	AMControl *realSampleStageResetControl_;
 	AMControl *pseudoAttoStageResetControl_;
 	AMControl *realAttoStageResetControl_;
+	AMControl *pseudoWireStageResetControl_;
 
 	// Motor group.  Binds all the motors for scanning together.
 	CLSPseudoMotorGroup *motorGroup_;


### PR DESCRIPTION
Simple addition of the appropriate reset control for the wire stage.

Completes #904 once merged.
