### PR TITLE
Pull Request for Issue941: Cancelling scans inside of lists doesn't prompt cancel dialog

### DIFF
--- a/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
+++ b/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
@@ -151,7 +151,11 @@ void AMActionRunnerCurrentViewBase::onSkipButtonClicked()
 
 void AMActionRunnerCurrentViewBase::onCancelButtonClicked()
 {
-	if (qobject_cast<AMScanAction *>(actionRunner_->currentAction()) && showCancelPrompt_){
+	AMScanAction *scanAction = qobject_cast<AMScanAction *>(actionRunner_->currentAction());
+	AMListAction3 *listAction = qobject_cast<AMListAction3 *>(actionRunner_->currentAction());
+	bool scanActionRunning = (scanAction != 0) || (qobject_cast<AMScanAction *>(listAction->currentSubAction()) != 0);
+
+	if (scanActionRunning && showCancelPrompt_){
 
 		AMCancelActionPrompt cancelPrompt;
 		cancelPrompt.setWindowTitle("Cancel Scan");


### PR DESCRIPTION
Turns out it didn't do it for loops either, since loops inherit from lists this fixes both list and loops not prompting on cancel.
