### PR TITLE
Pull Request for Issue884:  Removing the animation from AMScanView

### DIFF
--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -176,14 +176,6 @@ AM2DScanView::AM2DScanView(AMScanSetModel* model, QWidget *parent)
 	multiScanBars_->setModel(scansModel_);
 
 	currentExclusiveDataSource_ = 0;
-
-	exclusiveModeAnim_ = new QPropertyAnimation(gExclusiveView_->graphicsWidget(), "geometry", this);
-	exclusiveModeAnim_->setDuration(500);
-	exclusiveModeAnim_->setEasingCurve(QEasingCurve::InOutCubic);
-
-	multiViewModeAnim_ = new QPropertyAnimation(gMultiView_->graphicsWidget(), "geometry", this);
-	multiViewModeAnim_->setDuration(500);
-	multiViewModeAnim_->setEasingCurve(QEasingCurve::InOutCubic);
 }
 
 AM2DScanView::~AM2DScanView()
@@ -417,13 +409,7 @@ void AM2DScanView::resizeExclusiveViews()
 	QSizeF mainWidgetSize = QSizeF(viewSize.width(), viewSize.height());
 
 	gExclusiveView_->setSceneRect(QRectF(QPointF(0,0), viewSize ));
-
-	QPointF pos = QPointF(-viewSize.width()*0, 0);
-
-	exclusiveModeAnim_->stop();
-	exclusiveModeAnim_->setStartValue(gExclusiveView_->graphicsWidget()->geometry());
-	exclusiveModeAnim_->setEndValue(QRectF(pos, mainWidgetSize));
-	exclusiveModeAnim_->start();
+	gExclusiveView_->graphicsWidget()->setGeometry(QRectF(QPointF(0,0), mainWidgetSize));
 }
 
 void AM2DScanView::resizeMultiViews()
@@ -432,13 +418,7 @@ void AM2DScanView::resizeMultiViews()
 	QSizeF mainWidgetSize = QSizeF(viewSize.width(), viewSize.height());
 
 	gMultiView_->setSceneRect(QRectF(QPointF(0,0), viewSize ));
-
-	QPointF pos = QPointF(-viewSize.width()*0, 0);
-
-	multiViewModeAnim_->stop();
-	multiViewModeAnim_->setStartValue(gMultiView_->graphicsWidget()->geometry());
-	multiViewModeAnim_->setEndValue(QRectF(pos, mainWidgetSize));
-	multiViewModeAnim_->start();
+	gMultiView_->graphicsWidget()->setGeometry(QRectF(QPointF(0,0), mainWidgetSize));
 }
 
 void AM2DScanView::onScanAdded(AMScan *scan)

--- a/source/ui/dataman/AM2DScanView.h
+++ b/source/ui/dataman/AM2DScanView.h
@@ -22,7 +22,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #define AM2DSCANVIEW_H
 
 #include <QWidget>
-#include <QPropertyAnimation>
 #include <QGroupBox>
 #include <QCheckBox>
 #include <QVBoxLayout>
@@ -233,9 +232,6 @@ protected:
 
 	QGroupBox *multiViewBox_;
 	QGroupBox *spectrumViewBox_;
-
-	QPropertyAnimation* exclusiveModeAnim_;
-	QPropertyAnimation *multiViewModeAnim_;
 };
 
 /// This class handles changes in the scan set model and propogates it to both views inside of it.

--- a/source/ui/dataman/AMScanView.h
+++ b/source/ui/dataman/AMScanView.h
@@ -141,8 +141,6 @@ signals:
 	void dataPositionChanged(const QPointF &);
 };
 
-#include <QPropertyAnimation>
-
 #define AM_SCAN_VIEW_HIDE_SCANBARS_AFTER_N_SCANS 7
 
 class QGroupBox;
@@ -238,8 +236,6 @@ protected:
 
 	AMScanViewModeBar* modeBar_;
 	AMScanViewSourceSelector* scanBars_;
-
-	QPropertyAnimation* modeAnim_;
 
 	AMScanViewSingleSpectrumView *spectrumView_;
 	QGroupBox *spectrumViewBox_;


### PR DESCRIPTION
I removed the property animation from AM2DScanView.  I would have removed it from AMScanView but it appears my performance OCD removed it a long time ago.
