### PR TITLE
Pull Request for Issue928: VESPERS scans missing initialization motor moves

### DIFF
--- a/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
@@ -257,6 +257,22 @@ AMAction3* VESPERS2DScanActionController::createInitializationActions()
 	if (!configuration_->ccdDetector().testFlag(VESPERS::NoCCD))
 		initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(), configuration_->ccdFileName()));
 
+	if (configuration_->normalPosition() != 888888.88){
+
+		VESPERS::Motors motor = configuration_->motor();
+
+		if (motor.testFlag(VESPERS::H) || motor.testFlag(VESPERS::V)
+				|| motor.testFlag(VESPERS::AttoH) || motor.testFlag(VESPERS::AttoV))
+			initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoSampleStageMotorGroupObject()->createNormalMoveAction(configuration_->normalPosition()));
+
+		else if (motor.testFlag(VESPERS::X) || motor.testFlag(VESPERS::Z)
+				 || motor.testFlag(VESPERS::AttoX) || motor.testFlag(VESPERS::AttoZ))
+			initializationActions->addSubAction(VESPERSBeamline::vespers()->realSampleStageMotorGroupObject()->createNormalMoveAction(configuration_->normalPosition()));
+
+		else if (motor.testFlag(VESPERS::WireH) || motor.testFlag(VESPERS::WireV))
+			initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoWireStageMotorGroupObject()->createNormalMoveAction(configuration_->normalPosition()));
+	}
+
 	return initializationActions;
 }
 

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
@@ -286,6 +286,60 @@ AMAction3* VESPERSSpatialLineScanActionController::createInitializationActions()
 	if (!configuration_->ccdDetector().testFlag(VESPERS::NoCCD))
 		initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(), configuration_->ccdFileName()));
 
+	if (configuration_->normalPosition() != 888888.88){
+
+		VESPERS::Motors motor = configuration_->motor();
+
+		if (motor.testFlag(VESPERS::H) || motor.testFlag(VESPERS::V)
+				|| motor.testFlag(VESPERS::AttoH) || motor.testFlag(VESPERS::AttoV))
+			initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoSampleStageMotorGroupObject()->createNormalMoveAction(configuration_->normalPosition()));
+
+		else if (motor.testFlag(VESPERS::X) || motor.testFlag(VESPERS::Z)
+				 || motor.testFlag(VESPERS::AttoX) || motor.testFlag(VESPERS::AttoZ))
+			initializationActions->addSubAction(VESPERSBeamline::vespers()->realSampleStageMotorGroupObject()->createNormalMoveAction(configuration_->normalPosition()));
+
+		else if (motor.testFlag(VESPERS::WireH) || motor.testFlag(VESPERS::WireV))
+			initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoWireStageMotorGroupObject()->createNormalMoveAction(configuration_->normalPosition()));
+	}
+
+	VESPERS::Motors otherMotor = configuration_->otherMotor(configuration_->motor());
+
+	if (otherMotor.testFlag(VESPERS::H))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoSampleStageMotorGroupObject()->createHorizontalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::V))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoSampleStageMotorGroupObject()->createVerticalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::X))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->realSampleStageMotorGroupObject()->createHorizontalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::Z))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->realSampleStageMotorGroupObject()->createVerticalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::AttoH))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoAttocubeStageMotorGroupObject()->createHorizontalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::AttoV))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoAttocubeStageMotorGroupObject()->createVerticalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::AttoX))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->realAttocubeStageMotorGroupObject()->createHorizontalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::AttoZ))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->realAttocubeStageMotorGroupObject()->createVerticalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::BigBeamX))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->bigBeamMotorGroupObject()->createHorizontalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::BigBeamZ))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->bigBeamMotorGroupObject()->createVerticalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::WireH))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoWireStageMotorGroupObject()->createHorizontalMoveAction(configuration_->otherPosition()));
+
+	else if (otherMotor.testFlag(VESPERS::WireV))
+		initializationActions->addSubAction(VESPERSBeamline::vespers()->pseudoWireStageMotorGroupObject()->createVerticalMoveAction(configuration_->otherPosition()));
+
 	return initializationActions;
 }
 

--- a/source/ui/VESPERS/VESPERSSpatialLineScanConfigurationView.cpp
+++ b/source/ui/VESPERS/VESPERSSpatialLineScanConfigurationView.cpp
@@ -87,6 +87,18 @@ VESPERSSpatialLineScanConfigurationView::VESPERSSpatialLineScanConfigurationView
 	otherPositionLayout->addWidget(otherPosition_);
 	otherPositionLayout->addStretch();
 
+	normalPosition_ = createPositionDoubleSpinBox("N: ", " mm", configuration_->normalPosition(), 3);
+	connect(normalPosition_, SIGNAL(editingFinished()), this, SLOT(onNormalPositionChanged()));
+	connect(configuration_->dbObject(), SIGNAL(normalPositionChanged(double)), normalPosition_, SLOT(setValue(double)));
+
+	QPushButton *updateNormalPosition = new QPushButton("Set Normal");
+	connect(updateNormalPosition, SIGNAL(clicked()), this, SLOT(onSetNormalPosition()));
+
+	QHBoxLayout *normalLayout = new QHBoxLayout;
+	normalLayout->addWidget(new QLabel("Focus Position:"));
+	normalLayout->addWidget(normalPosition_);
+	normalLayout->addWidget(updateNormalPosition);
+
 	mapInfo_ = new QLabel;
 	updateMapInfo();
 
@@ -95,6 +107,7 @@ VESPERSSpatialLineScanConfigurationView::VESPERSSpatialLineScanConfigurationView
 	positionsLayout->addLayout(endPointLayout);
 	positionsLayout->addLayout(stepSizeLayout);
 	positionsLayout->addLayout(otherPositionLayout);
+	positionsLayout->addLayout(normalLayout);
 	positionsLayout->addWidget(mapInfo_);
 
 	positionsBox->setLayout(positionsLayout);

--- a/source/ui/VESPERS/VESPERSSpatialLineScanConfigurationView.h
+++ b/source/ui/VESPERS/VESPERSSpatialLineScanConfigurationView.h
@@ -107,6 +107,8 @@ protected:
 	QLabel *otherPositionLabel_;
 	/// Pointer to the spin box holding the other position.
 	QDoubleSpinBox *otherPosition_;
+	/// Pointer to the normal position used for the scan.
+	QDoubleSpinBox *normalPosition_;
 
 	/// Pointer to the CCD help group box.
 	QGroupBox *ccdTextBox_;


### PR DESCRIPTION
Added in the necessary initialization actions to 2D scans and line scans.
