### PR TITLE
Pull Request for Issue977: CLSNetworkDirectorySynchronizer Race Condition

### DIFF
--- a/source/ui/util/AMDirectorySynchronizerDialog.cpp
+++ b/source/ui/util/AMDirectorySynchronizerDialog.cpp
@@ -242,8 +242,18 @@ void AMDirectorySynchronizerDialog::prepare(){
 	QTimer::singleShot(0, synchronizer_, SLOT(prepare()));
 }
 
+void AMDirectorySynchronizerDialog::onPreparedHelper(){
+	onPrepared(lastCompareResult_);
+}
+
 void AMDirectorySynchronizerDialog::onPrepared(AMRecursiveDirectoryCompare::DirectoryCompareResult comparisonResult){
 	lastCompareResult_ = comparisonResult;
+
+	if(synchronizer_->thread() != thread()){
+		QTimer::singleShot(10, this, SLOT(onPreparedHelper()));
+		return;
+	}
+
 
 	overallTransferProgressBar_->setMinimum(100);
 	overallTransferProgressBar_->setMaximum(100);

--- a/source/ui/util/AMDirectorySynchronizerDialog.h
+++ b/source/ui/util/AMDirectorySynchronizerDialog.h
@@ -86,6 +86,8 @@ protected slots:
 	/// Handles decrementing the delay countdown when delayedStart() is called with a non-zero time
 	void onDelayCountdown();
 
+	/// Sometime we get into a race condition with regard to prepare, this helps us wait until we can successfully proceed
+	void onPreparedHelper();
 	/// Handles the prepared() signal from the synchronizer and emits our prepared() signal at the end
 	void onPrepared(AMRecursiveDirectoryCompare::DirectoryCompareResult comparisonResult);
 	/// Handles calling the rest of the start routine after start first calls prepare()
@@ -140,6 +142,7 @@ protected:
 	AMDirectorySynchronizer *synchronizer_;
 	/// The result of the last prepare() comparison
 	AMRecursiveDirectoryCompare::DirectoryCompareResult lastCompareResult_;
+
 
 	/// Button to call prepare
 	QPushButton *prepareButton_;

--- a/source/util/AMDirectorySynchronizer.cpp
+++ b/source/util/AMDirectorySynchronizer.cpp
@@ -1,9 +1,7 @@
 #include "AMDirectorySynchronizer.h"
-//#include "dataman/database/AMDatabase.h"
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
-#include <QDebug>
 
 AMDirectorySynchronizer::AMDirectorySynchronizer(const QString &side1Directory, const QString &side2Directory, QObject *parent)
 	:QObject(parent)


### PR DESCRIPTION
Fixed the problem by manually checking the thread affinity of the synchronizer_ object. If it's not back in the main thread (yet), then we wait for another 10msec before calling the new helper function. I think this could be set down to 0msec and just wait for the next event loop, but I'm not sure if it might take more than one event loop for the queued messages from other threads to get delivered. This seems to work just fine. Tested on SGM and the warnings are gone.
