### PR TITLE
Pull Request for Issue981: Reset the tab order for AMEnergyListView

### DIFF
--- a/source/ui/util/AMEnergyListView.cpp
+++ b/source/ui/util/AMEnergyListView.cpp
@@ -108,7 +108,6 @@ void AMEnergyListView::onAddEnergyButtonClicked()
 
 			if (temp->text() == "Beginning"){
 
-
 				energyList_.insertEnergy(0, 0);
 				buildEnergyElementView(0, 0);
 			}
@@ -175,6 +174,21 @@ void AMEnergyListView::buildEnergyElementView(int index, double energy)
 	energyMap_.insert(deleteButton, elementView);
 	layoutMap_.insert(deleteButton, layout);
 	energyElementViewList_.insert(index, elementView);
+
+	resetEnergyElementViewTabOrder(index);
+}
+
+void AMEnergyListView::resetEnergyElementViewTabOrder(int index)
+{
+	AMEnergyListElementView * succeedingElementView = 0;
+	AMEnergyListElementView * modifiedElementView = energyElementViewList_.at(index);
+
+	int startIndex = index == 0 ? index : index - 1;
+	for (int i = startIndex; i < energyElementViewList_.count() - 1; i++) {
+		modifiedElementView = energyElementViewList_.at(i);
+		succeedingElementView = energyElementViewList_.at(i + 1);
+		setTabOrder(modifiedElementView->energySpinBox(), succeedingElementView->energySpinBox());
+	}
 }
 
 void AMEnergyListView::onElementEnergyChanged()

--- a/source/ui/util/AMEnergyListView.h
+++ b/source/ui/util/AMEnergyListView.h
@@ -24,6 +24,9 @@ public:
 	/// Returns the energy of view.
 	double energy() const { return energy_; }
 
+	/// Returns the energy spinbox of view
+	QDoubleSpinBox *energySpinBox() const { return energySpinBox_; }
+
 signals:
 	/// Notifier that the energy has changed.
 	void energyChanged(double);
@@ -39,7 +42,6 @@ protected slots:
 	void onEnergyUpdated();
 
 protected:
-
 	/// The energy.
 	double energy_;
 	/// The spin box that holds the energy.
@@ -80,6 +82,9 @@ protected slots:
 protected:
 	/// Helper method that builds and connects all the key aspects around a given an energy element.
 	void buildEnergyElementView(int index, double energy);
+
+	/// Reset the tab orders of the EnergyElementView
+	void resetEnergyElementViewTabOrder(int index);
 
 	/// Holds the list of energies.
 	AMEnergyList energyList_;


### PR DESCRIPTION
https://github.com/acquaman/acquaman/issues/981

Altered:
- When a new AMEnergyElementView is inserted into AMEnergyListView, reset the Tab Order for the AMEnergyElementView so that the user can use tab key to navigate among the Views

@dretrex @davidChevrier 
