### PR TITLE
Pull request for Issue982: Remove UI Files for AMImportControllerWidget 

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -851,7 +851,8 @@ SOURCES += \
     source/dataman/export/AMExporter2DAscii.cpp \
     source/util/AMEnergyList.cpp \
     source/ui/util/AMEnergyListView.cpp \
-    source/dataman/export/AMExporterOptionSMAK.cpp
+    source/dataman/export/AMExporterOptionSMAK.cpp \
+    source/ui/dataman/AMImportControllerWidget.cpp
 
 RESOURCES *= source/icons/icons.qrc \
 		source/configurationFiles/configurationFiles.qrc \

--- a/source/dataman/AMImportController.cpp
+++ b/source/dataman/AMImportController.cpp
@@ -153,9 +153,9 @@ AMImportController::AMImportController(QObject *parent) :
 	connect(importWidget_, SIGNAL(cancelClicked()), this, SLOT(onCancelButtonClicked()));
 	connect(importWidget_, SIGNAL(selectedFormatChanged(int)), this, SLOT(onFileTypeComboBoxChanged(int)));
 
-	connect(importWidget_, SIGNAL(includeNameChanged(bool)), this, SLOT(onIncludeNameChanged(bool)));
-	connect(importWidget_, SIGNAL(includeNumberChanged(bool)), this, SLOT(onIncludeNumberChanged(bool)));
-	connect(importWidget_, SIGNAL(includeDateTimeChanged(bool)), this, SLOT(onIncludeDateTimeChanged(bool)));
+	connect(importWidget_, SIGNAL(customizeNameChanged(bool)), this, SLOT(onCustomizeNameChanged(bool)));
+	connect(importWidget_, SIGNAL(customizeNumberChanged(bool)), this, SLOT(onCustomizeNumberChanged(bool)));
+	connect(importWidget_, SIGNAL(customizeDateTimeChanged(bool)), this, SLOT(onCustomizeDateTimeChanged(bool)));
 
 	onStart();
 }
@@ -263,13 +263,13 @@ void AMImportController::setupNextFile() {
 
 	/// todo: you could generalize this for meta-data types, instead of doing them all separately.
 	///////////////////////
-	if(importWidget_->isIncludeNameChecked() && currentScan_)
+	if(!importWidget_->isCustomizeNameChecked() && currentScan_)
 		importWidget_->setName(currentScan_->name());
 
-	if(importWidget_->isIncludeNumberChecked() && currentScan_)
+	if(!importWidget_->isCustomizeNumberChecked() && currentScan_)
 		importWidget_->setNumber(currentScan_->number());
 
-	if(importWidget_->isIncludeDataTimeChecked() && currentScan_)
+	if(!importWidget_->isCustomizeDataTimeChecked() && currentScan_)
 		importWidget_->setDateTime(currentScan_->dateTime());
 	/////////////////////////////
 
@@ -304,13 +304,13 @@ void AMImportController::finalizeImport() {
 
 	// success:
 	else {
-		if(!importWidget_->isIncludeNameChecked())
+		if(importWidget_->isCustomizeNameChecked())
 			currentScan_->setName(importWidget_->name());
 
-		if(!importWidget_->isIncludeNumberChecked())
+		if(importWidget_->isCustomizeNumberChecked())
 			currentScan_->setNumber(importWidget_->number());
 
-		if(!importWidget_->isIncludeDataTimeChecked())
+		if(importWidget_->isCustomizeDataTimeChecked())
 			currentScan_->setDateTime(importWidget_->dateTime());
 
 		currentScan_->setSampleId(importWidget_->sampleId());
@@ -418,20 +418,20 @@ void AMImportController::onFileTypeComboBoxChanged(int index) {
 	setupNextFile();
 }
 
-void AMImportController::onIncludeNameChanged(bool)
+void AMImportController::onCustomizeNameChanged(bool)
 {
 	if(currentScan_)
 		importWidget_->setName(currentScan_->name());
 }
 
-void AMImportController::onIncludeNumberChanged(bool)
+void AMImportController::onCustomizeNumberChanged(bool)
 {
 	if(currentScan_)
 		importWidget_->setNumber(currentScan_->number());
 
 }
 
-void AMImportController::onIncludeDateTimeChanged(bool)
+void AMImportController::onCustomizeDateTimeChanged(bool)
 {
 	if(currentScan_)
 		importWidget_->setDateTime(currentScan_->dateTime());

--- a/source/dataman/AMImportController.h
+++ b/source/dataman/AMImportController.h
@@ -131,12 +131,12 @@ protected slots:
 	void onFinished();
 	/// while reviewing, the file type sets the method used to import. If it's changed, need to retry.
 	void onFileTypeComboBoxChanged(int index);
-	/// Called when the user changes the state of the Include Name checkbox in the Widget
-	void onIncludeNameChanged(bool);
-	/// Called when the user changes the state of the Include Number checkbox in the Widget
-	void onIncludeNumberChanged(bool);
-	/// Called when the user changes the state of the Include DateTime checkbox in the Widget
-	void onIncludeDateTimeChanged(bool);
+	/// Called when the user changes the state of the Customize Name checkbox in the Widget
+	void onCustomizeNameChanged(bool);
+	/// Called when the user changes the state of the Customize Number checkbox in the Widget
+	void onCustomizeNumberChanged(bool);
+	/// Called when the user changes the state of the Customize DateTime checkbox in the Widget
+	void onCustomizeDateTimeChanged(bool);
 
 	/// Temporary solution only: Identifies what looks like a "spectra" file: an auxiliary file used by the CLS dacq library, which shouldn't be imported on its own.
 	bool isAuxiliaryFile(const QString& fullFileName);

--- a/source/dataman/AMImportController.h
+++ b/source/dataman/AMImportController.h
@@ -131,9 +131,12 @@ protected slots:
 	void onFinished();
 	/// while reviewing, the file type sets the method used to import. If it's changed, need to retry.
 	void onFileTypeComboBoxChanged(int index);
-	/// This slot is called from the signal mapper whenever any of the check-boxes are changed, indicating whether to get
-	void onGetInfoFromFileBoxChecked(const QString& key);
-
+	/// Called when the user changes the state of the Include Name checkbox in the Widget
+	void onIncludeNameChanged(bool);
+	/// Called when the user changes the state of the Include Number checkbox in the Widget
+	void onIncludeNumberChanged(bool);
+	/// Called when the user changes the state of the Include DateTime checkbox in the Widget
+	void onIncludeDateTimeChanged(bool);
 
 	/// Temporary solution only: Identifies what looks like a "spectra" file: an auxiliary file used by the CLS dacq library, which shouldn't be imported on its own.
 	bool isAuxiliaryFile(const QString& fullFileName);
@@ -151,7 +154,7 @@ protected:
 	bool applyToAll_;
 
 	QFileDialog* fileDialog_;
-	AMImportControllerWidget* w_;
+	AMImportControllerWidget* importWidget_;
 
 
 

--- a/source/ui/dataman/AMImportControllerWidget.cpp
+++ b/source/ui/dataman/AMImportControllerWidget.cpp
@@ -1,0 +1,363 @@
+#include "ui/dataman/AMImportControllerWidget.h"
+
+
+AMImportControllerWidget::AMImportControllerWidget(QWidget *parent)
+	: QWidget(parent)
+{
+	setupUi();
+	connectSignals();
+	thumbnailViewer_ = new AMThumbnailScrollWidget();
+	verticalLayoutLeft->insertWidget(0, thumbnailViewer_);
+
+	runEdit_ = new AMRunSelector(AMDatabase::database("user"));
+	gridLayout->addWidget(runEdit_, 3, 2);
+}
+
+AMThumbnailScrollWidget *AMImportControllerWidget::thumbnailViewer()
+{
+	return thumbnailViewer_;
+}
+
+AMRunSelector *AMImportControllerWidget::runEdit()
+{
+	return runEdit_;
+}
+
+QProgressBar *AMImportControllerWidget::progressBar()
+{
+	return progressBar_;
+}
+
+void AMImportControllerWidget::setName(const QString &name)
+{
+	nameEdit_->setText(name);
+}
+
+void AMImportControllerWidget::setNumber(int number)
+{
+	numberEdit_->setValue(number);
+}
+
+void AMImportControllerWidget::setDateTime(QDateTime dateTime)
+{
+	dateTimeEdit_->setDateTime(dateTime);
+}
+
+void AMImportControllerWidget::setProgressLabel(const QString &progress)
+{
+	progressLabel_->setText(progress);
+}
+
+void AMImportControllerWidget::setLoadingStatus(const QString &status)
+{
+	loadingStatusLabel_->setText(status);
+	if(status == "Could not load this file.")
+		loadingStatusLabel_->setStyleSheet("color: red;");
+	else
+		loadingStatusLabel_->setStyleSheet("color: black");
+}
+
+void AMImportControllerWidget::addFormat(const QString &format)
+{
+	formatComboBox_->addItem(format);
+}
+
+QString AMImportControllerWidget::name()
+{
+	return nameEdit_->text();
+}
+
+int AMImportControllerWidget::number()
+{
+	return numberEdit_->value();
+}
+
+QDateTime AMImportControllerWidget::dateTime()
+{
+	return dateTimeEdit_->dateTime();
+}
+
+int AMImportControllerWidget::sampleId()
+{
+	return sampleEdit_->value();
+}
+
+QString AMImportControllerWidget::format()
+{
+	return formatComboBox_->currentText();
+}
+
+int AMImportControllerWidget::selectedFormatIndex()
+{
+	return formatComboBox_->currentIndex();
+}
+
+bool AMImportControllerWidget::isIncludeNameChecked()
+{
+	return checkName_->isChecked();
+}
+
+bool AMImportControllerWidget::isIncludeNumberChecked()
+{
+	return checkNumber_->isChecked();
+}
+
+bool AMImportControllerWidget::isIncludeDataTimeChecked()
+{
+	return checkDateTime_->isChecked();
+}
+
+void AMImportControllerWidget::setupUi()
+{
+	if (objectName().isEmpty())
+		setObjectName(QString::fromUtf8("AMImportControllerWidget"));
+	resize(642, 380);
+	setMinimumSize(QSize(0, 380));
+	verticalLayout_3 = new QVBoxLayout(this);
+	verticalLayout_3->setObjectName(QString::fromUtf8("verticalLayout_3"));
+	AMImportControllerWidgetFrame1 = new QFrame(this);
+	AMImportControllerWidgetFrame1->setObjectName(QString::fromUtf8("AMImportControllerWidgetFrame1"));
+	AMImportControllerWidgetFrame1->setStyleSheet(QString::fromUtf8("QFrame#AMImportControllerWidgetFrame1 {\n"
+"background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(206, 206, 206, 255), stop:0.502513 rgba(188, 188, 188, 255), stop:1 rgba(168, 168, 168, 255));\n"
+"\n"
+"border: 1px solid rgb(168,168,168);\n"
+"}\n"
+""));
+	AMImportControllerWidgetFrame1->setFrameShape(QFrame::StyledPanel);
+	horizontalLayout_2 = new QHBoxLayout(AMImportControllerWidgetFrame1);
+	horizontalLayout_2->setObjectName(QString::fromUtf8("horizontalLayout_2"));
+	verticalLayoutLeft = new QVBoxLayout();
+	verticalLayoutLeft->setSpacing(1);
+	verticalLayoutLeft->setObjectName(QString::fromUtf8("verticalLayoutLeft"));
+	verticalSpacer_2 = new QSpacerItem(1, 5, QSizePolicy::Minimum, QSizePolicy::MinimumExpanding);
+
+	verticalLayoutLeft->addItem(verticalSpacer_2);
+
+	progressBar_ = new QProgressBar(AMImportControllerWidgetFrame1);
+	progressBar_->setObjectName(QString::fromUtf8("progressBar"));
+	progressBar_->setValue(24);
+
+	verticalLayoutLeft->addWidget(progressBar_);
+
+	progressLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	progressLabel_->setObjectName(QString::fromUtf8("progressLabel"));
+	progressLabel_->setAlignment(Qt::AlignCenter);
+
+	verticalLayoutLeft->addWidget(progressLabel_);
+
+
+	horizontalLayout_2->addLayout(verticalLayoutLeft);
+
+	verticalLayoutRight = new QVBoxLayout();
+	verticalLayoutRight->setSpacing(2);
+	verticalLayoutRight->setObjectName(QString::fromUtf8("verticalLayoutRight"));
+	horizontalLayout = new QHBoxLayout();
+	horizontalLayout->setObjectName(QString::fromUtf8("horizontalLayout"));
+	formatLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	formatLabel_->setObjectName(QString::fromUtf8("formatLabel"));
+
+	horizontalLayout->addWidget(formatLabel_);
+
+	formatComboBox_ = new QComboBox(AMImportControllerWidgetFrame1);
+	formatComboBox_->setObjectName(QString::fromUtf8("formatComboBox"));
+	QSizePolicy sizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+	sizePolicy.setHorizontalStretch(0);
+	sizePolicy.setVerticalStretch(0);
+	sizePolicy.setHeightForWidth(formatComboBox_->sizePolicy().hasHeightForWidth());
+	formatComboBox_->setSizePolicy(sizePolicy);
+
+	horizontalLayout->addWidget(formatComboBox_);
+
+
+	verticalLayoutRight->addLayout(horizontalLayout);
+
+	loadingStatusLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	loadingStatusLabel_->setObjectName(QString::fromUtf8("loadingStatusLabel"));
+	loadingStatusLabel_->setAlignment(Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter);
+
+	verticalLayoutRight->addWidget(loadingStatusLabel_);
+
+	verticalSpacer = new QSpacerItem(2, 5, QSizePolicy::Minimum, QSizePolicy::MinimumExpanding);
+
+	verticalLayoutRight->addItem(verticalSpacer);
+
+	checkInstructionLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	checkInstructionLabel_->setObjectName(QString::fromUtf8("checkInstructionLabel"));
+
+	verticalLayoutRight->addWidget(checkInstructionLabel_);
+
+	gridLayout = new QGridLayout();
+	gridLayout->setObjectName(QString::fromUtf8("gridLayout"));
+	checkName_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkName_->setObjectName(QString::fromUtf8("checkName"));
+	checkName_->setChecked(true);
+
+	gridLayout->addWidget(checkName_, 0, 0, 1, 1);
+
+	nameLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	nameLabel_->setObjectName(QString::fromUtf8("nameLabel"));
+
+	gridLayout->addWidget(nameLabel_, 0, 1, 1, 1);
+
+	nameEdit_ = new QLineEdit(AMImportControllerWidgetFrame1);
+	nameEdit_->setObjectName(QString::fromUtf8("nameEdit"));
+	nameEdit_->setEnabled(false);
+
+	gridLayout->addWidget(nameEdit_, 0, 2, 1, 1);
+
+	checkNumber_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkNumber_->setObjectName(QString::fromUtf8("checkNumber"));
+	checkNumber_->setChecked(true);
+
+	gridLayout->addWidget(checkNumber_, 1, 0, 1, 1);
+
+	numberLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	numberLabel_->setObjectName(QString::fromUtf8("numberLabel"));
+
+	gridLayout->addWidget(numberLabel_, 1, 1, 1, 1);
+
+	numberEdit_ = new QSpinBox(AMImportControllerWidgetFrame1);
+	numberEdit_->setObjectName(QString::fromUtf8("numberEdit"));
+	numberEdit_->setMaximum(999999999);
+
+	gridLayout->addWidget(numberEdit_, 1, 2, 1, 1);
+
+	checkDateTime_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkDateTime_->setObjectName(QString::fromUtf8("checkDateTime"));
+	checkDateTime_->setChecked(true);
+
+	gridLayout->addWidget(checkDateTime_, 2, 0, 1, 1);
+
+	dateTimeLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	dateTimeLabel_->setObjectName(QString::fromUtf8("dateTimeLabel"));
+
+	gridLayout->addWidget(dateTimeLabel_, 2, 1, 1, 1);
+
+	dateTimeEdit_ = new QDateTimeEdit(AMImportControllerWidgetFrame1);
+	dateTimeEdit_->setObjectName(QString::fromUtf8("dateTimeEdit"));
+	dateTimeEdit_->setEnabled(false);
+	dateTimeEdit_->setCalendarPopup(true);
+
+	gridLayout->addWidget(dateTimeEdit_, 2, 2, 1, 1);
+
+	checkRun_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkRun_->setObjectName(QString::fromUtf8("checkRun"));
+	checkRun_->setEnabled(false);
+
+	gridLayout->addWidget(checkRun_, 3, 0, 1, 1);
+
+	runLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	runLabel_->setObjectName(QString::fromUtf8("runLabel"));
+
+	gridLayout->addWidget(runLabel_, 3, 1, 1, 1);
+
+	checkSample_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkSample_->setObjectName(QString::fromUtf8("checkSample"));
+	checkSample_->setEnabled(false);
+
+	gridLayout->addWidget(checkSample_, 4, 0, 1, 1);
+
+	sampleLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	sampleLabel_->setObjectName(QString::fromUtf8("sampleLabel"));
+
+	gridLayout->addWidget(sampleLabel_, 4, 1, 1, 1);
+
+	sampleEdit_ = new QSpinBox(AMImportControllerWidgetFrame1);
+	sampleEdit_->setObjectName(QString::fromUtf8("sampleEdit"));
+	sampleEdit_->setMinimum(-1);
+	sampleEdit_->setMaximum(999999999);
+	sampleEdit_->setValue(-1);
+
+	gridLayout->addWidget(sampleEdit_, 4, 2, 1, 1);
+
+
+	verticalLayoutRight->addLayout(gridLayout);
+
+
+	horizontalLayout_2->addLayout(verticalLayoutRight);
+
+
+	verticalLayout_3->addWidget(AMImportControllerWidgetFrame1);
+
+	horizontalLayout_3 = new QHBoxLayout();
+	horizontalLayout_3->setObjectName(QString::fromUtf8("horizontalLayout_3"));
+	cancelButton_ = new QPushButton(this);
+	cancelButton_->setObjectName(QString::fromUtf8("cancelButton"));
+	cancelButton_->setAutoDefault(true);
+
+	horizontalLayout_3->addWidget(cancelButton_);
+
+	horizontalSpacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
+
+	horizontalLayout_3->addItem(horizontalSpacer);
+
+	nextButton_ = new QPushButton(this);
+	nextButton_->setObjectName(QString::fromUtf8("nextButton"));
+	nextButton_->setAutoDefault(true);
+	nextButton_->setDefault(true);
+	nextButton_->setFlat(false);
+
+	horizontalLayout_3->addWidget(nextButton_);
+
+	applyAllButton_ = new QPushButton(this);
+	applyAllButton_->setObjectName(QString::fromUtf8("applyAllButton"));
+	applyAllButton_->setAutoDefault(true);
+
+	horizontalLayout_3->addWidget(applyAllButton_);
+
+
+	verticalLayout_3->addLayout(horizontalLayout_3);
+
+	setWindowTitle(QApplication::translate("AMImportControllerWidget", "Reviewing files to import...", 0, QApplication::UnicodeUTF8));
+	progressLabel_->setText(QApplication::translate("AMImportControllerWidget", "File 3 of 10", 0, QApplication::UnicodeUTF8));
+	formatLabel_->setText(QApplication::translate("AMImportControllerWidget", "File Format:", 0, QApplication::UnicodeUTF8));
+	loadingStatusLabel_->setText(QApplication::translate("AMImportControllerWidget", "Loaded successfully", 0, QApplication::UnicodeUTF8));
+	checkInstructionLabel_->setText(QApplication::translate("AMImportControllerWidget", "Check to use values in the data file:", 0, QApplication::UnicodeUTF8));
+	checkName_->setText(QString());
+	nameLabel_->setText(QApplication::translate("AMImportControllerWidget", "Name:", 0, QApplication::UnicodeUTF8));
+	checkNumber_->setText(QString());
+	numberLabel_->setText(QApplication::translate("AMImportControllerWidget", "Number:", 0, QApplication::UnicodeUTF8));
+	checkDateTime_->setText(QString());
+	dateTimeLabel_->setText(QApplication::translate("AMImportControllerWidget", "Date / Time:", 0, QApplication::UnicodeUTF8));
+	dateTimeEdit_->setDisplayFormat(QApplication::translate("AMImportControllerWidget", "MMM d (yyyy), h:mm AP", 0, QApplication::UnicodeUTF8));
+	checkRun_->setText(QString());
+	runLabel_->setText(QApplication::translate("AMImportControllerWidget", "Run:", 0, QApplication::UnicodeUTF8));
+	checkSample_->setText(QString());
+	sampleLabel_->setText(QApplication::translate("AMImportControllerWidget", "Sample:", 0, QApplication::UnicodeUTF8));
+	cancelButton_->setText(QApplication::translate("AMImportControllerWidget", "Cancel", 0, QApplication::UnicodeUTF8));
+	nextButton_->setText(QApplication::translate("AMImportControllerWidget", "Next", 0, QApplication::UnicodeUTF8));
+	applyAllButton_->setText(QApplication::translate("AMImportControllerWidget", "Apply to All", 0, QApplication::UnicodeUTF8));
+}
+
+void AMImportControllerWidget::connectSignals()
+{
+	connect(nextButton_, SIGNAL(clicked()), this, SIGNAL(nextClicked()));
+	connect(applyAllButton_, SIGNAL(clicked()), this, SIGNAL(nextClicked()));
+	connect(cancelButton_, SIGNAL(clicked()), this, SIGNAL(cancelClicked()));
+	connect(formatComboBox_, SIGNAL(currentIndexChanged(int)), this, SIGNAL(selectedFormatChanged(int)));
+	connect(checkName_, SIGNAL(clicked(bool)), this, SLOT(onNameIncludeCheckboxChecked(bool)));
+	connect(checkNumber_, SIGNAL(clicked(bool)), this, SLOT(onNumberIncludeCheckboxChecked(bool)));
+	connect(checkDateTime_, SIGNAL(clicked(bool)), this, SLOT(onDateTimeIncludeCheckboxChanged(bool)));
+}
+
+
+void AMImportControllerWidget::onNameIncludeCheckboxChecked(bool include)
+{
+	nameEdit_->setEnabled(include);
+	emit includeNameChanged(include);
+}
+
+void AMImportControllerWidget::onNumberIncludeCheckboxChecked(bool include)
+{
+	numberEdit_->setEnabled(include);
+	emit includeNumberChanged(include);
+}
+
+void AMImportControllerWidget::onDateTimeIncludeCheckboxChanged(bool include)
+{
+	dateTimeEdit_->setEnabled(include);
+	emit includeDateTimeChanged(include);
+}
+
+
+

--- a/source/ui/dataman/AMImportControllerWidget.cpp
+++ b/source/ui/dataman/AMImportControllerWidget.cpp
@@ -92,17 +92,17 @@ int AMImportControllerWidget::selectedFormatIndex()
 	return formatComboBox_->currentIndex();
 }
 
-bool AMImportControllerWidget::isIncludeNameChecked()
+bool AMImportControllerWidget::isCustomizeNameChecked()
 {
 	return checkName_->isChecked();
 }
 
-bool AMImportControllerWidget::isIncludeNumberChecked()
+bool AMImportControllerWidget::isCustomizeNumberChecked()
 {
 	return checkNumber_->isChecked();
 }
 
-bool AMImportControllerWidget::isIncludeDataTimeChecked()
+bool AMImportControllerWidget::isCustomizeDataTimeChecked()
 {
 	return checkDateTime_->isChecked();
 }
@@ -190,7 +190,7 @@ void AMImportControllerWidget::setupUi()
 	gridLayout->setObjectName(QString::fromUtf8("gridLayout"));
 	checkName_ = new QCheckBox(AMImportControllerWidgetFrame1);
 	checkName_->setObjectName(QString::fromUtf8("checkName"));
-	checkName_->setChecked(true);
+	checkName_->setChecked(false);
 
 	gridLayout->addWidget(checkName_, 0, 0, 1, 1);
 
@@ -207,7 +207,7 @@ void AMImportControllerWidget::setupUi()
 
 	checkNumber_ = new QCheckBox(AMImportControllerWidgetFrame1);
 	checkNumber_->setObjectName(QString::fromUtf8("checkNumber"));
-	checkNumber_->setChecked(true);
+	checkNumber_->setChecked(false);
 
 	gridLayout->addWidget(checkNumber_, 1, 0, 1, 1);
 
@@ -219,12 +219,13 @@ void AMImportControllerWidget::setupUi()
 	numberEdit_ = new QSpinBox(AMImportControllerWidgetFrame1);
 	numberEdit_->setObjectName(QString::fromUtf8("numberEdit"));
 	numberEdit_->setMaximum(999999999);
+	numberEdit_->setEnabled(false);
 
 	gridLayout->addWidget(numberEdit_, 1, 2, 1, 1);
 
 	checkDateTime_ = new QCheckBox(AMImportControllerWidgetFrame1);
 	checkDateTime_->setObjectName(QString::fromUtf8("checkDateTime"));
-	checkDateTime_->setChecked(true);
+	checkDateTime_->setChecked(false);
 
 	gridLayout->addWidget(checkDateTime_, 2, 0, 1, 1);
 
@@ -312,7 +313,7 @@ void AMImportControllerWidget::setupUi()
 	progressLabel_->setText(QApplication::translate("AMImportControllerWidget", "File 3 of 10", 0, QApplication::UnicodeUTF8));
 	formatLabel_->setText(QApplication::translate("AMImportControllerWidget", "File Format:", 0, QApplication::UnicodeUTF8));
 	loadingStatusLabel_->setText(QApplication::translate("AMImportControllerWidget", "Loaded successfully", 0, QApplication::UnicodeUTF8));
-	checkInstructionLabel_->setText(QApplication::translate("AMImportControllerWidget", "Check to use values in the data file:", 0, QApplication::UnicodeUTF8));
+	checkInstructionLabel_->setText(QApplication::translate("AMImportControllerWidget", "Check to set customized values:", 0, QApplication::UnicodeUTF8));
 	checkName_->setText(QString());
 	nameLabel_->setText(QApplication::translate("AMImportControllerWidget", "Name:", 0, QApplication::UnicodeUTF8));
 	checkNumber_->setText(QString());
@@ -335,28 +336,28 @@ void AMImportControllerWidget::connectSignals()
 	connect(applyAllButton_, SIGNAL(clicked()), this, SIGNAL(nextClicked()));
 	connect(cancelButton_, SIGNAL(clicked()), this, SIGNAL(cancelClicked()));
 	connect(formatComboBox_, SIGNAL(currentIndexChanged(int)), this, SIGNAL(selectedFormatChanged(int)));
-	connect(checkName_, SIGNAL(clicked(bool)), this, SLOT(onNameIncludeCheckboxChecked(bool)));
-	connect(checkNumber_, SIGNAL(clicked(bool)), this, SLOT(onNumberIncludeCheckboxChecked(bool)));
-	connect(checkDateTime_, SIGNAL(clicked(bool)), this, SLOT(onDateTimeIncludeCheckboxChanged(bool)));
+	connect(checkName_, SIGNAL(clicked(bool)), this, SLOT(onNameCustomizeCheckboxChecked(bool)));
+	connect(checkNumber_, SIGNAL(clicked(bool)), this, SLOT(onNumberCustomizeCheckboxChecked(bool)));
+	connect(checkDateTime_, SIGNAL(clicked(bool)), this, SLOT(onDateTimeCustomizeCheckboxChanged(bool)));
 }
 
 
-void AMImportControllerWidget::onNameIncludeCheckboxChecked(bool include)
+void AMImportControllerWidget::onNameCustomizeCheckboxChecked(bool include)
 {
 	nameEdit_->setEnabled(include);
-	emit includeNameChanged(include);
+	emit customizeNameChanged(include);
 }
 
-void AMImportControllerWidget::onNumberIncludeCheckboxChecked(bool include)
+void AMImportControllerWidget::onNumberCustomizeCheckboxChecked(bool include)
 {
 	numberEdit_->setEnabled(include);
-	emit includeNumberChanged(include);
+	emit customizeNumberChanged(include);
 }
 
-void AMImportControllerWidget::onDateTimeIncludeCheckboxChanged(bool include)
+void AMImportControllerWidget::onDateTimeCustomizeCheckboxChanged(bool include)
 {
 	dateTimeEdit_->setEnabled(include);
-	emit includeDateTimeChanged(include);
+	emit customizeDateTimeChanged(include);
 }
 
 

--- a/source/ui/dataman/AMImportControllerWidget.cpp
+++ b/source/ui/dataman/AMImportControllerWidget.cpp
@@ -113,9 +113,10 @@ void AMImportControllerWidget::setupUi()
 		setObjectName(QString::fromUtf8("AMImportControllerWidget"));
 	resize(642, 380);
 	setMinimumSize(QSize(0, 380));
-	verticalLayout_3 = new QVBoxLayout(this);
+	verticalLayout_3 = new QVBoxLayout();
 	verticalLayout_3->setObjectName(QString::fromUtf8("verticalLayout_3"));
-	AMImportControllerWidgetFrame1 = new QFrame(this);
+
+	AMImportControllerWidgetFrame1 = new QFrame();
 	AMImportControllerWidgetFrame1->setObjectName(QString::fromUtf8("AMImportControllerWidgetFrame1"));
 	AMImportControllerWidgetFrame1->setStyleSheet(QString::fromUtf8("QFrame#AMImportControllerWidgetFrame1 {\n"
 "background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(206, 206, 206, 255), stop:0.502513 rgba(188, 188, 188, 255), stop:1 rgba(168, 168, 168, 255));\n"
@@ -124,8 +125,11 @@ void AMImportControllerWidget::setupUi()
 "}\n"
 ""));
 	AMImportControllerWidgetFrame1->setFrameShape(QFrame::StyledPanel);
-	horizontalLayout_2 = new QHBoxLayout(AMImportControllerWidgetFrame1);
+
+	horizontalLayout_2 = new QHBoxLayout();
 	horizontalLayout_2->setObjectName(QString::fromUtf8("horizontalLayout_2"));
+	AMImportControllerWidgetFrame1->setLayout(horizontalLayout_2);
+
 	verticalLayoutLeft = new QVBoxLayout();
 	verticalLayoutLeft->setSpacing(1);
 	verticalLayoutLeft->setObjectName(QString::fromUtf8("verticalLayoutLeft"));
@@ -133,13 +137,13 @@ void AMImportControllerWidget::setupUi()
 
 	verticalLayoutLeft->addItem(verticalSpacer_2);
 
-	progressBar_ = new QProgressBar(AMImportControllerWidgetFrame1);
+	progressBar_ = new QProgressBar();
 	progressBar_->setObjectName(QString::fromUtf8("progressBar"));
 	progressBar_->setValue(24);
 
 	verticalLayoutLeft->addWidget(progressBar_);
 
-	progressLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	progressLabel_ = new QLabel();
 	progressLabel_->setObjectName(QString::fromUtf8("progressLabel"));
 	progressLabel_->setAlignment(Qt::AlignCenter);
 
@@ -158,7 +162,7 @@ void AMImportControllerWidget::setupUi()
 
 	horizontalLayout->addWidget(formatLabel_);
 
-	formatComboBox_ = new QComboBox(AMImportControllerWidgetFrame1);
+	formatComboBox_ = new QComboBox();
 	formatComboBox_->setObjectName(QString::fromUtf8("formatComboBox"));
 	QSizePolicy sizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
 	sizePolicy.setHorizontalStretch(0);
@@ -171,7 +175,7 @@ void AMImportControllerWidget::setupUi()
 
 	verticalLayoutRight->addLayout(horizontalLayout);
 
-	loadingStatusLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	loadingStatusLabel_ = new QLabel();
 	loadingStatusLabel_->setObjectName(QString::fromUtf8("loadingStatusLabel"));
 	loadingStatusLabel_->setAlignment(Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter);
 
@@ -181,89 +185,89 @@ void AMImportControllerWidget::setupUi()
 
 	verticalLayoutRight->addItem(verticalSpacer);
 
-	checkInstructionLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	checkInstructionLabel_ = new QLabel();
 	checkInstructionLabel_->setObjectName(QString::fromUtf8("checkInstructionLabel"));
 
 	verticalLayoutRight->addWidget(checkInstructionLabel_);
 
 	gridLayout = new QGridLayout();
 	gridLayout->setObjectName(QString::fromUtf8("gridLayout"));
-	checkName_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkName_ = new QCheckBox();
 	checkName_->setObjectName(QString::fromUtf8("checkName"));
 	checkName_->setChecked(false);
 
 	gridLayout->addWidget(checkName_, 0, 0, 1, 1);
 
-	nameLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	nameLabel_ = new QLabel();
 	nameLabel_->setObjectName(QString::fromUtf8("nameLabel"));
 
 	gridLayout->addWidget(nameLabel_, 0, 1, 1, 1);
 
-	nameEdit_ = new QLineEdit(AMImportControllerWidgetFrame1);
+	nameEdit_ = new QLineEdit();
 	nameEdit_->setObjectName(QString::fromUtf8("nameEdit"));
 	nameEdit_->setEnabled(false);
 
 	gridLayout->addWidget(nameEdit_, 0, 2, 1, 1);
 
-	checkNumber_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkNumber_ = new QCheckBox();
 	checkNumber_->setObjectName(QString::fromUtf8("checkNumber"));
 	checkNumber_->setChecked(false);
 
 	gridLayout->addWidget(checkNumber_, 1, 0, 1, 1);
 
-	numberLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	numberLabel_ = new QLabel();
 	numberLabel_->setObjectName(QString::fromUtf8("numberLabel"));
 
 	gridLayout->addWidget(numberLabel_, 1, 1, 1, 1);
 
-	numberEdit_ = new QSpinBox(AMImportControllerWidgetFrame1);
+	numberEdit_ = new QSpinBox();
 	numberEdit_->setObjectName(QString::fromUtf8("numberEdit"));
 	numberEdit_->setMaximum(999999999);
 	numberEdit_->setEnabled(false);
 
 	gridLayout->addWidget(numberEdit_, 1, 2, 1, 1);
 
-	checkDateTime_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkDateTime_ = new QCheckBox();
 	checkDateTime_->setObjectName(QString::fromUtf8("checkDateTime"));
 	checkDateTime_->setChecked(false);
 
 	gridLayout->addWidget(checkDateTime_, 2, 0, 1, 1);
 
-	dateTimeLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	dateTimeLabel_ = new QLabel();
 	dateTimeLabel_->setObjectName(QString::fromUtf8("dateTimeLabel"));
 
 	gridLayout->addWidget(dateTimeLabel_, 2, 1, 1, 1);
 
-	dateTimeEdit_ = new QDateTimeEdit(AMImportControllerWidgetFrame1);
+	dateTimeEdit_ = new QDateTimeEdit();
 	dateTimeEdit_->setObjectName(QString::fromUtf8("dateTimeEdit"));
 	dateTimeEdit_->setEnabled(false);
 	dateTimeEdit_->setCalendarPopup(true);
 
 	gridLayout->addWidget(dateTimeEdit_, 2, 2, 1, 1);
 
-	checkRun_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkRun_ = new QCheckBox();
 	checkRun_->setObjectName(QString::fromUtf8("checkRun"));
 	checkRun_->setEnabled(false);
 
 	gridLayout->addWidget(checkRun_, 3, 0, 1, 1);
 
-	runLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	runLabel_ = new QLabel();
 	runLabel_->setObjectName(QString::fromUtf8("runLabel"));
 
 	gridLayout->addWidget(runLabel_, 3, 1, 1, 1);
 
-	checkSample_ = new QCheckBox(AMImportControllerWidgetFrame1);
+	checkSample_ = new QCheckBox();
 	checkSample_->setObjectName(QString::fromUtf8("checkSample"));
 	checkSample_->setEnabled(false);
 
 	gridLayout->addWidget(checkSample_, 4, 0, 1, 1);
 
-	sampleLabel_ = new QLabel(AMImportControllerWidgetFrame1);
+	sampleLabel_ = new QLabel();
 	sampleLabel_->setObjectName(QString::fromUtf8("sampleLabel"));
 
 	gridLayout->addWidget(sampleLabel_, 4, 1, 1, 1);
 
-	sampleEdit_ = new QSpinBox(AMImportControllerWidgetFrame1);
+	sampleEdit_ = new QSpinBox();
 	sampleEdit_->setObjectName(QString::fromUtf8("sampleEdit"));
 	sampleEdit_->setMinimum(-1);
 	sampleEdit_->setMaximum(999999999);
@@ -282,7 +286,7 @@ void AMImportControllerWidget::setupUi()
 
 	horizontalLayout_3 = new QHBoxLayout();
 	horizontalLayout_3->setObjectName(QString::fromUtf8("horizontalLayout_3"));
-	cancelButton_ = new QPushButton(this);
+	cancelButton_ = new QPushButton();
 	cancelButton_->setObjectName(QString::fromUtf8("cancelButton"));
 	cancelButton_->setAutoDefault(true);
 
@@ -292,7 +296,7 @@ void AMImportControllerWidget::setupUi()
 
 	horizontalLayout_3->addItem(horizontalSpacer);
 
-	nextButton_ = new QPushButton(this);
+	nextButton_ = new QPushButton();
 	nextButton_->setObjectName(QString::fromUtf8("nextButton"));
 	nextButton_->setAutoDefault(true);
 	nextButton_->setDefault(true);
@@ -300,7 +304,7 @@ void AMImportControllerWidget::setupUi()
 
 	horizontalLayout_3->addWidget(nextButton_);
 
-	applyAllButton_ = new QPushButton(this);
+	applyAllButton_ = new QPushButton();
 	applyAllButton_->setObjectName(QString::fromUtf8("applyAllButton"));
 	applyAllButton_->setAutoDefault(true);
 
@@ -308,6 +312,8 @@ void AMImportControllerWidget::setupUi()
 
 
 	verticalLayout_3->addLayout(horizontalLayout_3);
+
+	setLayout(verticalLayout_3);
 
 	setWindowTitle(QApplication::translate("AMImportControllerWidget", "Reviewing files to import...", 0, QApplication::UnicodeUTF8));
 	progressLabel_->setText(QApplication::translate("AMImportControllerWidget", "File 3 of 10", 0, QApplication::UnicodeUTF8));

--- a/source/ui/dataman/AMImportControllerWidget.h
+++ b/source/ui/dataman/AMImportControllerWidget.h
@@ -23,25 +23,107 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #define AMIMPORTCONTROLLERWIDGET_H
 
 #include <QWidget>
-#include "ui_AMImportControllerWidget.h"
+#include <QVBoxLayout>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QSpacerItem>
+#include <QProgressBar>
+#include <QLabel>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QSpinBox>
+#include <QDateTimeEdit>
+#include <QPushButton>
+#include <QApplication>
+
 #include "ui/AMThumbnailScrollViewer.h"
 #include "ui/dataman/AMRunSelector.h"
 
-class AMImportControllerWidget : public QWidget, public Ui::AMImportControllerWidget {
+class AMImportControllerWidget : public QWidget {
 public:
  	virtual ~AMImportControllerWidget(){}
-	explicit AMImportControllerWidget(QWidget* parent = 0) : QWidget(parent) {
-		setupUi(this);
-		thumbnailViewer = new AMThumbnailScrollWidget();
-		verticalLayoutLeft->insertWidget(0, thumbnailViewer);
+	explicit AMImportControllerWidget(QWidget* parent = 0);
 
-		runEdit = new AMRunSelector(AMDatabase::database("user"));
-		gridLayout->addWidget(runEdit, 3, 2);
-	}
+	AMThumbnailScrollWidget* thumbnailViewer();
+	AMRunSelector* runEdit();
 
-	// UI elements (public within this widget class)
-	AMThumbnailScrollWidget* thumbnailViewer;
-	AMRunSelector* runEdit;
+	QProgressBar* progressBar();
+
+	void setName(const QString& name);
+	void setNumber(int number);
+	void setDateTime(QDateTime dateTime);
+	void setProgressLabel(const QString& progress);
+	void setLoadingStatus(const QString& status);
+	void addFormat(const QString& format);
+
+	QString name();
+	int number();
+	QDateTime dateTime();
+	int sampleId();
+	QString format();
+	int selectedFormatIndex();
+
+	bool isIncludeNameChecked();
+	bool isIncludeNumberChecked();
+	bool isIncludeDataTimeChecked();
+	// UI elements
+signals:
+	void nextClicked();
+	void applyAllClicked();
+	void cancelClicked();
+	void selectedFormatChanged(int);
+	void includeNameChanged(bool);
+	void includeNumberChanged(bool);
+	void includeDateTimeChanged(bool);
+
+protected:
+	AMThumbnailScrollWidget* thumbnailViewer_;
+	AMRunSelector* runEdit_;
+
+	QVBoxLayout *verticalLayout_3;
+	QFrame *AMImportControllerWidgetFrame1;
+	QHBoxLayout *horizontalLayout_2;
+	QVBoxLayout *verticalLayoutLeft;
+	QSpacerItem *verticalSpacer_2;
+	QProgressBar *progressBar_;
+	QLabel *progressLabel_;
+	QVBoxLayout *verticalLayoutRight;
+	QHBoxLayout *horizontalLayout;
+	QLabel *formatLabel_;
+	QComboBox *formatComboBox_;
+	QLabel *loadingStatusLabel_;
+	QSpacerItem *verticalSpacer;
+	QLabel *checkInstructionLabel_;
+	QGridLayout *gridLayout;
+	QCheckBox *checkName_;
+	QLabel *nameLabel_;
+	QLineEdit *nameEdit_;
+	QCheckBox *checkNumber_;
+	QLabel *numberLabel_;
+	QSpinBox *numberEdit_;
+	QCheckBox *checkDateTime_;
+	QLabel *dateTimeLabel_;
+	QDateTimeEdit *dateTimeEdit_;
+	QCheckBox *checkRun_;
+	QLabel *runLabel_;
+	QCheckBox *checkSample_;
+	QLabel *sampleLabel_;
+	QSpinBox *sampleEdit_;
+	QHBoxLayout *horizontalLayout_3;
+	QPushButton *cancelButton_;
+	QSpacerItem *horizontalSpacer;
+	QPushButton *nextButton_;
+	QPushButton *applyAllButton_;
+protected slots:
+	void onNameIncludeCheckboxChecked(bool);
+	void onNumberIncludeCheckboxChecked(bool);
+	void onDateTimeIncludeCheckboxChanged(bool);
+
+private:
+	void setupUi();
+	void connectSignals();
 };
 
 #endif // AMIMPORTCONTROLLERWIDGET_H

--- a/source/ui/dataman/AMImportControllerWidget.h
+++ b/source/ui/dataman/AMImportControllerWidget.h
@@ -42,6 +42,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/dataman/AMRunSelector.h"
 
 class AMImportControllerWidget : public QWidget {
+	Q_OBJECT
 public:
  	virtual ~AMImportControllerWidget(){}
 	explicit AMImportControllerWidget(QWidget* parent = 0);
@@ -65,18 +66,18 @@ public:
 	QString format();
 	int selectedFormatIndex();
 
-	bool isIncludeNameChecked();
-	bool isIncludeNumberChecked();
-	bool isIncludeDataTimeChecked();
+	bool isCustomizeNameChecked();
+	bool isCustomizeNumberChecked();
+	bool isCustomizeDataTimeChecked();
 	// UI elements
 signals:
 	void nextClicked();
 	void applyAllClicked();
 	void cancelClicked();
 	void selectedFormatChanged(int);
-	void includeNameChanged(bool);
-	void includeNumberChanged(bool);
-	void includeDateTimeChanged(bool);
+	void customizeNameChanged(bool);
+	void customizeNumberChanged(bool);
+	void customizeDateTimeChanged(bool);
 
 protected:
 	AMThumbnailScrollWidget* thumbnailViewer_;
@@ -117,9 +118,9 @@ protected:
 	QPushButton *nextButton_;
 	QPushButton *applyAllButton_;
 protected slots:
-	void onNameIncludeCheckboxChecked(bool);
-	void onNumberIncludeCheckboxChecked(bool);
-	void onDateTimeIncludeCheckboxChanged(bool);
+	void onNameCustomizeCheckboxChecked(bool);
+	void onNumberCustomizeCheckboxChecked(bool);
+	void onDateTimeCustomizeCheckboxChanged(bool);
 
 private:
 	void setupUi();


### PR DESCRIPTION
Moved all the ui logic from the old ui files into the cpp and h files, where they belong. Also changed some of the access logic between AMImportController and AMImportControllerWidget which were very tightly coupled. The situation for this still isn't ideal, but this isn't the current paradigm for imports. Either way AMImportController and AMImportControllerWidget might need a code review at some stage in the near future.