### PR TITLE
Pull Request for Issue1005: Error when opening additional scans in GSE

### DIFF
--- a/source/dataman/AMLightweightScanInfoCollection.cpp
+++ b/source/dataman/AMLightweightScanInfoCollection.cpp
@@ -56,7 +56,6 @@ void AMLightweightScanInfoCollection::populateExperimentIds()
 		int objectId = selectQuery.value(0).toInt();
 		int experimentId = selectQuery.value(1).toInt();
 
-		if(objectId)
 		experimentIdMap_.insert(objectId, experimentId);
 	}
 }


### PR DESCRIPTION
Fixed a bug in the underlying AMLightweightScanInfoCollection where it was populating the table of known samples used in the AMScan_table with null entries where no sample was specified by the scan. Added a WHERE sample IS NOT NULL to the select query.
