### PR TITLE
Pull Request for Issue1008: Resuming paused scans causes scans to be re-added to the open scans tab

### DIFF
--- a/source/actions3/AMListAction3.cpp
+++ b/source/actions3/AMListAction3.cpp
@@ -388,7 +388,7 @@ void AMListAction3::internalOnSubActionStateChanged(int newState, int oldState)
 			return;
 		case Running:
 
-			if (isScanAction())
+			if (isScanAction() && state() != Resuming)
 				emit scanActionStarted((AMScanAction *)currentSubAction());
 
 			// If we had a current action paused:

--- a/source/application/AMAppController.cpp
+++ b/source/application/AMAppController.cpp
@@ -144,7 +144,7 @@ bool AMAppController::startupCreateUserInterface() {
 		mw_->windowPaneModel()->removeRow(scanEditorsParentItem_->row());
 		scanEditorsParentItem_ = mw_->windowPaneModel()->headingItem("Open Scans", QModelIndex(), mw_->windowPaneModel()->rowCount()-1);
 
-		connect(AMActionRunner3::workflow(), SIGNAL(scanActionCreated(AMScanAction*)), this, SLOT(onCurrentScanActionStarted(AMScanAction*)));
+		connect(AMActionRunner3::workflow(), SIGNAL(scanActionStarted(AMScanAction*)), this, SLOT(onCurrentScanActionStarted(AMScanAction*)));
 		connect(AMActionRunner3::workflow(), SIGNAL(scanActionFinished(AMScanAction *)), this, SLOT(onCurrentScanActionFinished(AMScanAction*)));
 
 		AMStartScreen* chooseRunDialog = new AMStartScreen(true, mw_);


### PR DESCRIPTION
Had to add an extra condition to AMListAction to make sure it didn't emit the scanStarted signal when it is coming back from paused.
