### PR TITLE
Pull request for Issue1032: REIXS Crashing on export 

### DIFF
--- a/source/ui/dataman/AMExportWizard.cpp
+++ b/source/ui/dataman/AMExportWizard.cpp
@@ -420,6 +420,8 @@ void AMExportWizardOptionPage::populateOptionSelector()
 				optionSelector_->setCurrentIndex(iComboBoxOption);
 		}
 	}
+	else
+		optionSelector_->setCurrentIndex(optionSelector_->count()-1);
 
 	optionSelector_->blockSignals(false);
 


### PR DESCRIPTION
@davidChevrier's fix for #1032.  I don't think this has made it into master any other way yet?

Added else statement to hande case where no exporters are registered in
AMExportWizardOptionPage::populateOptionSelector()
