### PR TITLE
Pull request for Issue1031: Crashes in REIXSXESImageInterpolationAB

### DIFF
--- a/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
@@ -453,7 +453,7 @@ void REIXSXESImageInterpolationAB::computeCachedValues() const
 
 				int shiftOffset = qRound(shiftValueMapPointer[i*jSize+j] * interpolationLevel_);
 
-				if (((i - shiftOffset) < interpolatedISize) && ((i - shiftOffset) > 0))
+				if (((i + shiftOffset) < interpolatedISize) && ((i + shiftOffset) > 0))
 				{
 					//add only one pixel from the interpolated image to each pixel in the shifted image:
 					finalLargeImagePointer[j + i*jSize] = interpolatedImagePointer[j + (i + shiftOffset)*jSize];


### PR DESCRIPTION
The loop that actually shifts the individual pixels in
`computeCachedValues()` had a sign error when testing to ensure that
a the source pixel was valid before copying it to the destination image,
resulting in indexing out of bounds with extreme shifts.

Hasn't happened since this was implemented.  Calling it good.
