### PR TITLE
Pull Request for Issue1050 - SGM Copied Scans are losing their name

### DIFF
--- a/source/actions3/actions/AMScanActionInfo.cpp
+++ b/source/actions3/actions/AMScanActionInfo.cpp
@@ -61,7 +61,10 @@ AMScanActionInfo::AMScanActionInfo(const AMScanActionInfo &other)
 	setExpectedDuration(config_->expectedDuration());
 
 	if(!config_->detailedDescription().isEmpty()){
-		setShortDescription(config_->userScanName()%"\n"%config_->description());
+		QString scanName = config_->userScanName();
+		if(scanName.isEmpty())
+			scanName = other.shortDescription();
+		setShortDescription(scanName);
 		setLongDescription(config_->detailedDescription());
 	}
 }


### PR DESCRIPTION
Changed the copy constructor of AMScanActionInfo to obtain the shortDescription from other.shortDescription() where config->userScanName() has not been set. 

Not sure if this is going to have side effects on other beamlines, owing to the differences between how scans are named across the board.
