### PR TITLE
Pull request for Issue1004: scan axis values not updating

### DIFF
--- a/source/analysis/AM1DCalibrationAB.cpp
+++ b/source/analysis/AM1DCalibrationAB.cpp
@@ -154,6 +154,7 @@ void AM1DCalibrationAB::setEnergyCalibrationOffset(double offset)
 	if(offset == energyCalibrationOffset_)
 		return;
 	energyCalibrationOffset_ = offset;
+	emitSizeChanged(0);
 	setModified(true);
 	emitValuesChanged();
 }
@@ -164,6 +165,7 @@ void AM1DCalibrationAB::setEnergyCalibrationScaling(double scaling)
 		return;
 
 	energyCalibrationScaling_ = scaling;
+	emitSizeChanged(0);
 	setModified(true);
 	emitValuesChanged();
 }
@@ -174,6 +176,7 @@ void AM1DCalibrationAB::setEnergyCalibrationReference(double reference)
 		return;
 
 	energyCalibrationReference_ = reference;
+	emitSizeChanged(0);
 	setModified(true);
 	emitValuesChanged();
 }

--- a/source/analysis/REIXS/REIXSXESImageAB.cpp
+++ b/source/analysis/REIXS/REIXSXESImageAB.cpp
@@ -750,7 +750,7 @@ void REIXSXESImageAB::setEnergyCalibrationOffset(double energyCalibrationOffset)
 	energyCalibrationOffset_ = energyCalibrationOffset;
 	axisValueCacheInvalid_ = true;
 	emitValuesChanged();
-
+	emitSizeChanged(0);
 	setModified(true);
 }
 
@@ -762,7 +762,7 @@ void REIXSXESImageAB::setTiltCalibrationOffset(double tiltCalibrationOffset)
 	tiltCalibrationOffset_ = tiltCalibrationOffset;
 	axisValueCacheInvalid_ = true;
 	emitValuesChanged();
-
+	emitSizeChanged(0);
 	setModified(true);
 }
 void REIXSXESImageAB::setCorrelationSmoothingType(int type)

--- a/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
@@ -1029,8 +1029,8 @@ void REIXSXESImageInterpolationAB::setEnergyCalibrationOffset(double energyCalib
 
 	energyCalibrationOffset_ = energyCalibrationOffset;
 	axisValueCacheInvalid_ = true;
+	emitSizeChanged(0);
 	emitValuesChanged();
-
 	setModified(true);
 }
 
@@ -1041,8 +1041,8 @@ void REIXSXESImageInterpolationAB::setTiltCalibrationOffset(double tiltCalibrati
 
 	tiltCalibrationOffset_ = tiltCalibrationOffset;
 	axisValueCacheInvalid_ = true;
+	emitSizeChanged(0);
 	emitValuesChanged();
-
 	setModified(true);
 }
 


### PR DESCRIPTION
#1004

AB methods that modifiy the values used to compute the energy axis
values must `emitSizeChanged(0)` for the plot to be updated as they
change.
