### PR TITLE
Pull Request for Issue1091: VESPERS scans are incorrectly setting the user scan name in copy constructors

### DIFF
--- a/source/acquaman/VESPERS/VESPERS2DScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanConfiguration.cpp
@@ -64,7 +64,7 @@ VESPERS2DScanConfiguration::VESPERS2DScanConfiguration(const VESPERS2DScanConfig
 	: AMStepScanConfiguration(original), VESPERSScanConfiguration(original)
 {
 	setName(original.name());
-	setUserScanName(original.userScanName());
+	setUserScanName(original.name());
 	dbObject_->setParent(this);
 	setExportAsAscii(original.exportAsAscii());
 	setExportSpectraSources(original.exportSpectraSources());
@@ -98,6 +98,16 @@ AMScanController *VESPERS2DScanConfiguration::createController()
 AMScanConfigurationView *VESPERS2DScanConfiguration::createView()
 {
 	return new VESPERS2DScanConfigurationView(this);
+}
+
+QString VESPERS2DScanConfiguration::technique() const
+{
+	return "2D Scan";
+}
+
+QString VESPERS2DScanConfiguration::description() const
+{
+	return "2D Scan";
 }
 
 QString VESPERS2DScanConfiguration::detailedDescription() const

--- a/source/acquaman/VESPERS/VESPERS2DScanConfiguration.h
+++ b/source/acquaman/VESPERS/VESPERS2DScanConfiguration.h
@@ -62,6 +62,10 @@ public:
 	/// Returns a pointer to a newly-created AMScanConfigurationView that is appropriate for viewing and editing this kind of scan configuration. Ownership of the new controller becomes the responsibility of the caller.
 	virtual AMScanConfigurationView* createView();
 
+	/// Returns the technique string.
+	QString technique() const;
+	/// A human-readable description of this scan configuration. Can be re-implemented to provide more details. Used by scan action to set the title for the action view.
+	virtual QString description() const;
 	/// A human-readable synopsis of this scan configuration. Can be re-implemented to proved more details. Used by scan action to set the main text in the action view.
 	virtual QString detailedDescription() const;
 

--- a/source/acquaman/VESPERS/VESPERS3DScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanConfiguration.cpp
@@ -71,7 +71,7 @@ VESPERS3DScanConfiguration::VESPERS3DScanConfiguration(const VESPERS3DScanConfig
 	: AMStepScanConfiguration(original), VESPERSScanConfiguration(original)
 {
 	setName(original.name());
-	setUserScanName(original.userScanName());
+	setUserScanName(original.name());
 	dbObject_->setParent(this);
 	setExportAsAscii(original.exportAsAscii());
 	setExportSpectraSources(original.exportSpectraSources());
@@ -108,6 +108,16 @@ AMScanController * VESPERS3DScanConfiguration::createController()
 AMScanConfigurationView * VESPERS3DScanConfiguration::createView()
 {
 	return new  VESPERS3DScanConfigurationView(this);
+}
+
+QString VESPERS3DScanConfiguration::technique() const
+{
+	return "3D Scan";
+}
+
+QString VESPERS3DScanConfiguration::description() const
+{
+	return "3D Scan";
 }
 
 QString  VESPERS3DScanConfiguration::detailedDescription() const

--- a/source/acquaman/VESPERS/VESPERS3DScanConfiguration.h
+++ b/source/acquaman/VESPERS/VESPERS3DScanConfiguration.h
@@ -63,6 +63,10 @@ public:
 	/// Returns a pointer to a newly-created AMScanConfigurationView that is appropriate for viewing and editing this kind of scan configuration. Ownership of the new controller becomes the responsibility of the caller.
 	virtual AMScanConfigurationView* createView();
 
+	/// Returns the technique string.
+	QString technique() const;
+	/// A human-readable description of this scan configuration. Can be re-implemented to provide more details. Used by scan action to set the title for the action view.
+	virtual QString description() const;
 	/// A human-readable synopsis of this scan configuration. Can be re-implemented to proved more details. Used by scan action to set the main text in the action view.
 	virtual QString detailedDescription() const;
 

--- a/source/acquaman/VESPERS/VESPERSEXAFSScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERSEXAFSScanConfiguration.cpp
@@ -65,7 +65,7 @@ VESPERSEXAFSScanConfiguration::VESPERSEXAFSScanConfiguration(const VESPERSEXAFSS
 	: AMStepScanConfiguration(original), VESPERSScanConfiguration(original)
 {
 	setName(original.name());
-	setUserScanName(original.userScanName());
+	setUserScanName(original.name());
 	dbObject_->setParent(this);
 	edge_ = original.edge();
 	energy_ = original.energy();
@@ -111,6 +111,16 @@ AMScanController *VESPERSEXAFSScanConfiguration::createController()
 AMScanConfigurationView *VESPERSEXAFSScanConfiguration::createView()
 {
 	return new VESPERSEXAFSScanConfigurationView(this);
+}
+
+QString VESPERSEXAFSScanConfiguration::technique() const
+{
+	return "XAS Scan";
+}
+
+QString VESPERSEXAFSScanConfiguration::description() const
+{
+	return "XAS Scan";
 }
 
 QString VESPERSEXAFSScanConfiguration::detailedDescription() const

--- a/source/acquaman/VESPERS/VESPERSEXAFSScanConfiguration.h
+++ b/source/acquaman/VESPERS/VESPERSEXAFSScanConfiguration.h
@@ -76,6 +76,10 @@ public:
 	/// Returns a pointer to a newly-created AMScanConfigurationView that is appropriate for viewing and editing this kind of scan configuration. Ownership of the new controller becomes the responsibility of the caller.
 	virtual AMScanConfigurationView* createView();
 
+	/// Returns the technique string.
+	QString technique() const;
+	/// A human-readable description of this scan configuration. Can be re-implemented to provide more details. Used by scan action to set the title for the action view.
+	virtual QString description() const;
 	/// A human-readable synopsis of this scan configuration. Can be re-implemented to proved more details. Used by scan action to set the main text in the action view.
 	virtual QString detailedDescription() const;
 

--- a/source/acquaman/VESPERS/VESPERSEnergyScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERSEnergyScanConfiguration.cpp
@@ -54,7 +54,7 @@ VESPERSEnergyScanConfiguration::VESPERSEnergyScanConfiguration(const VESPERSEner
 	: AMStepScanConfiguration(original), VESPERSScanConfiguration(original)
 {
 	setName(original.name());
-	setUserScanName(original.userScanName());
+	setUserScanName(original.name());
 	dbObject_->setParent(this);
 
 	goToPosition_ = original.goToPosition();
@@ -91,6 +91,16 @@ AMScanController *VESPERSEnergyScanConfiguration::createController()
 AMScanConfigurationView *VESPERSEnergyScanConfiguration::createView()
 {
 	return new VESPERSEnergyScanConfigurationView(this);
+}
+
+QString VESPERSEnergyScanConfiguration::technique() const
+{
+	return "Energy Scan";
+}
+
+QString VESPERSEnergyScanConfiguration::description() const
+{
+	return "Energy Scan";
 }
 
 QString VESPERSEnergyScanConfiguration::detailedDescription() const

--- a/source/acquaman/VESPERS/VESPERSEnergyScanConfiguration.h
+++ b/source/acquaman/VESPERS/VESPERSEnergyScanConfiguration.h
@@ -67,7 +67,9 @@ public:
 	virtual AMScanConfigurationView* createView();
 
 	/// Returns the technique string.
-	QString technique() const { return "Energy Scan"; }
+	QString technique() const;
+	/// A human-readable description of this scan configuration. Can be re-implemented to provide more details. Used by scan action to set the title for the action view.
+	virtual QString description() const;
 	/// A human-readable synopsis of this scan configuration. Can be re-implemented to proved more details. Used by scan action to set the main text in the action view.
 	virtual QString detailedDescription() const;
 

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanConfiguration.cpp
@@ -58,7 +58,7 @@ VESPERSSpatialLineScanConfiguration::VESPERSSpatialLineScanConfiguration(const V
 	: AMStepScanConfiguration(original), VESPERSScanConfiguration(original)
 {
 	setName(original.name());
-	setUserScanName(original.userScanName());
+	setUserScanName(original.name());
 	dbObject_->setParent(this);
 	setOtherPosition(original.otherPosition());
 	setExportSpectraSources(original.exportSpectraSources());
@@ -89,6 +89,16 @@ AMScanController *VESPERSSpatialLineScanConfiguration::createController()
 AMScanConfigurationView *VESPERSSpatialLineScanConfiguration::createView()
 {
 	return new VESPERSSpatialLineScanConfigurationView(this);
+}
+
+QString VESPERSSpatialLineScanConfiguration::technique() const
+{
+	return "Line Scan";
+}
+
+QString VESPERSSpatialLineScanConfiguration::description() const
+{
+	return "Line Scan";
 }
 
 QString VESPERSSpatialLineScanConfiguration::detailedDescription() const

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanConfiguration.h
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanConfiguration.h
@@ -76,6 +76,10 @@ public:
 	/// Returns a pointer to a newly-created AMScanConfigurationView that is appropriate for viewing and editing this kind of scan configuration. Ownership of the new controller becomes the responsibility of the caller.
 	virtual AMScanConfigurationView* createView();
 
+	/// Returns the technique string.
+	QString technique() const;
+	/// A human-readable description of this scan configuration. Can be re-implemented to provide more details. Used by scan action to set the title for the action view.
+	virtual QString description() const;
 	/// A human-readable synopsis of this scan configuration. Can be re-implemented to proved more details. Used by scan action to set the main text in the action view.
 	virtual QString detailedDescription() const;
 


### PR DESCRIPTION
Added proper technique and description to VESPERS scans so information
displayed is as correct as possible.  Pretty trivial change.
