### PR TITLE
Pull Request for Issue1110: add flag for AMSelectionDialog to control whether allows empty selected items

### DIFF
--- a/acquaman_suite.pro
+++ b/acquaman_suite.pro
@@ -7,34 +7,34 @@ SUBDIRS += \
 	Initialize.pro \
 	pluginProjects/FileLoaders/AMFileLoaderPlugins.pro \
 	# pluginProjects/AnalysisBlocks/AMAnalysisBlockPlugins.pro \
-	REIXSTest.pro \
-	REIXSAcquaman.pro \
-	SGMAcquaman.pro \
-	BareBonesAcquaman.pro \
-	acquamanTest.pro \
-	VESPERSAcquaman.pro \
-	MidIRBPM.pro \
-	CLSPGTDwellTimeCoordinator.pro \
-	SGMAddOnsCoordinator.pro \
-	SGMSSAAcquaman.pro \
 	EnsureHeaderNotice.pro \
-	VESPERSBendingMirrors.pro \
-	SGMAmptekCoordinator.pro \
-	SGMLookupTableCoordinator.pro \
 	AMCrashReporter.pro \
-	StripToolProject.pro \
-	IDEASAcquaman.pro \
-	BioXASSideAcquaman.pro \
+	CLSNetworkDirectorySynchronizer.pro \
 	BioXASMainAcquaman.pro \
+	BioXASSideAcquaman.pro \
 	BioXASImagingAcquaman.pro \
 	BioXASToolSuite.pro \
-	VESPERSDatabaseDuplicateEntryPatch.pro \
-	StripTool2.pro \
-	CLSNetworkDirectorySynchronizer.pro \
-	buildTests/AMBuildTest.pro \
-	XRDAnalysis.pro \
-	CLSSR570Coordinator.pro \
+	MidIRBPM.pro \
+	REIXSTest.pro \
+	REIXSAcquaman.pro \
+	IDEASAcquaman.pro \
+	SGMAcquaman.pro \
+	SGMAddOnsCoordinator.pro \
+	SGMAmptekCoordinator.pro \
+	SGMLookupTableCoordinator.pro \
+	SGMSSAAcquaman.pro \
 	SXRMBAcquaman.pro \
 	SXRMBAddOnsCoordinator.pro \
-	VESPERSAddOnsCoordinator.pro
+	VESPERSAcquaman.pro \
+	VESPERSBendingMirrors.pro \
+	VESPERSDatabaseDuplicateEntryPatch.pro \
+	VESPERSAddOnsCoordinator.pro \
+	BareBonesAcquaman.pro \
+	acquamanTest.pro \
+	buildTests/AMBuildTest.pro \
+	XRDAnalysis.pro \
+	StripToolProject.pro \
+	StripTool2.pro \
+	CLSPGTDwellTimeCoordinator.pro \
+	CLSSR570Coordinator.pro
 

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -24,7 +24,7 @@ function buildProject() {
 
 	source /home/beamline/tools/qt/startup/startup.qt-4.7.3.sh
 	if [ $1 -ne 1 ]; then
-		qmake $2
+		qmake -r $2
 	fi
 
 	make -j 3

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -1,20 +1,15 @@
+# script to build Acquaman projects. Usage:
+#	"	buildProject.sh [-c] [-m] [-h] [-p project.pro]"
+#
+#	"	-h help"
+#	"	-c make a clean build"
+#	"	-m make the current project. No Makefile will be updated."
+#	"	-p make the given project. Makefile will be updated."
 
 function cleanBuild() {
 	echo $"Clean project files"
 	
 	make clean
-
-	echo rm *.o
-	rm *.o
-
-	echo rm moc_*
-	rm moc_*
-
-	echo rm qrc_*
-	rm qrc_*
-
-	echo rm ui_*
-	rm ui_*
 	
 	echo rm Makefile*
 	rm Makefile*
@@ -29,6 +24,7 @@ function buildProject() {
 	if [ $1 -ne 1 ]; then
 		qmake -r $2
 	fi
+
 	make -j 3
 
 	echo

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -4,17 +4,17 @@ function cleanBuild() {
 	
 	make clean
 
-	echo rm build_obj/*.o
-	rm build_obj/*.o
+	echo rm *.o
+	rm *.o
 
-	echo rm build_moc/moc_*
-	rm build_moc/moc_*
+	echo rm moc_*
+	rm moc_*
 
 	echo rm qrc_*
 	rm qrc_*
 
-	echo rm build_ui/ui_*
-	rm build_ui/ui_*
+	echo rm ui_*
+	rm ui_*
 	
 	echo rm Makefile*
 	rm Makefile*

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -1,3 +1,5 @@
+
+######
 # script to build Acquaman projects. Usage:
 #	"	buildProject.sh [-c] [-m] [-h] [-p project.pro]"
 #

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -4,17 +4,17 @@ function cleanBuild() {
 	
 	make clean
 
-	echo rm *.o
-	rm *.o
+	echo rm build_obj/*.o
+	rm build_obj/*.o
 
-	echo rm moc_*
-	rm moc_*
+	echo rm build_moc/moc_*
+	rm build_moc/moc_*
 
 	echo rm qrc_*
 	rm qrc_*
 
-	echo rm ui_*
-	rm ui_*
+	echo rm build_ui/ui_*
+	rm build_ui/ui_*
 	
 	echo rm Makefile*
 	rm Makefile*

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -24,7 +24,7 @@ function buildProject() {
 
 	source /home/beamline/tools/qt/startup/startup.qt-4.7.3.sh
 	if [ $1 -ne 1 ]; then
-		qmake -r $2
+		qmake $2
 	fi
 
 	make -j 3

--- a/compositeCommon/AMCommon.pri
+++ b/compositeCommon/AMCommon.pri
@@ -53,6 +53,10 @@ DEFINES *= AM_ENABLE_BOUNDS_CHECKING
 QT *= core gui
 
 DESTDIR = build
+OBJECTS_DIR=build_files
+MOC_DIR=build_files
+UI_DIR=build_files
+RCC_DIR=build_files
 
 HEADERS *= \
 	source/AMQEvents.h \

--- a/compositeCommon/AMCommon.pri
+++ b/compositeCommon/AMCommon.pri
@@ -53,9 +53,6 @@ DEFINES *= AM_ENABLE_BOUNDS_CHECKING
 QT *= core gui
 
 DESTDIR = build
-OBJECTS_DIR = build_obj
-MOC_DIR = build_moc
-UI_DIR = build_ui
 
 HEADERS *= \
 	source/AMQEvents.h \

--- a/compositeCommon/AMCommon.pri
+++ b/compositeCommon/AMCommon.pri
@@ -53,6 +53,9 @@ DEFINES *= AM_ENABLE_BOUNDS_CHECKING
 QT *= core gui
 
 DESTDIR = build
+OBJECTS_DIR = build_obj
+MOC_DIR = build_moc
+UI_DIR = build_ui
 
 HEADERS *= \
 	source/AMQEvents.h \

--- a/source/ui/AMSelectionDialog.cpp
+++ b/source/ui/AMSelectionDialog.cpp
@@ -32,10 +32,10 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 AMSelectionDialog::AMSelectionDialog(const QString &title, const QStringList &items, QWidget *parent)
 	: QDialog(parent)
 {
-	emptySelectedItemsAllowed_ = false;
-
 	setWindowTitle(title);
 	setModal(true);
+
+	setEmptySelectedItemsAllowed(false);
 
 	items_ = new QButtonGroup(this);
 	items_->setExclusive(false);
@@ -91,9 +91,9 @@ QStringList AMSelectionDialog::selectedItems() const
 	return names;
 }
 
-void AMSelectionDialog::enableEmptySelectedItemsAllowed()
+void AMSelectionDialog::setEmptySelectedItemsAllowed(bool allowed)
 {
-	emptySelectedItemsAllowed_ = true;
+	emptySelectedItemsAllowed_ = allowed;
 }
 
 void AMSelectionDialog::onItemCheckStateChanged()

--- a/source/ui/AMSelectionDialog.cpp
+++ b/source/ui/AMSelectionDialog.cpp
@@ -49,7 +49,7 @@ AMSelectionDialog::AMSelectionDialog(const QString &title, const QStringList &it
 		itemLayout->addWidget(item);
 		items_->addButton(item);
 
-		connect(item, SIGNAL(stateChanged(int)), this, SLOT(onItemCheckStateChanged(int)));
+		connect(item, SIGNAL(stateChanged(int)), this, SLOT(onItemCheckStateChanged()));
 	}
 
 	QGroupBox *itemBox = new QGroupBox;
@@ -77,7 +77,7 @@ AMSelectionDialog::AMSelectionDialog(const QString &title, const QStringList &it
 
 	setLayout(mainLayout);
 
-	onItemCheckStateChanged(Qt::Checked);
+	onItemCheckStateChanged();
 }
 
 QStringList AMSelectionDialog::selectedItems() const
@@ -96,10 +96,8 @@ void AMSelectionDialog::enableEmptySelectedItemsAllowed()
 	emptySelectedItemsAllowed_ = true;
 }
 
-void AMSelectionDialog::onItemCheckStateChanged(int state)
+void AMSelectionDialog::onItemCheckStateChanged()
 {
-	Q_UNUSED(state)
-
 	bool okEnabled = false;
 	if (emptySelectedItemsAllowed_)
 		okEnabled = true;

--- a/source/ui/AMSelectionDialog.h
+++ b/source/ui/AMSelectionDialog.h
@@ -39,8 +39,8 @@ public:
 	/// Returns the items that are selected as a string list.
 	QStringList selectedItems() const;
 
-	/// allows to select nothing
-	void enableEmptySelectedItemsAllowed();
+	/// config the emptySelectedItemsAllowed flag, default False
+	void setEmptySelectedItemsAllowed(bool allowed=false);
 
 protected slots:
 	void onItemCheckStateChanged();

--- a/source/ui/AMSelectionDialog.h
+++ b/source/ui/AMSelectionDialog.h
@@ -39,9 +39,21 @@ public:
 	/// Returns the items that are selected as a string list.
 	QStringList selectedItems() const;
 
+	/// allows to select nothing
+	void enableEmptySelectedItemsAllowed();
+
+protected slots:
+	void onItemCheckStateChanged(int state);
+
 protected:
+	/// Flag to mark whether allows select nothing (default False)
+	bool emptySelectedItemsAllowed_;
+
 	/// The button group that holds all of the check boxes.
 	QButtonGroup *items_;
+
+	/// The okeyButton, which is controlled by emptySelectedItemsAllowed_
+	QPushButton *okayButton_;
 };
 
 #endif // AMSELECTIONDIALOG_H

--- a/source/ui/AMSelectionDialog.h
+++ b/source/ui/AMSelectionDialog.h
@@ -43,7 +43,7 @@ public:
 	void enableEmptySelectedItemsAllowed();
 
 protected slots:
-	void onItemCheckStateChanged(int state);
+	void onItemCheckStateChanged();
 
 protected:
 	/// Flag to mark whether allows select nothing (default False)

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -673,7 +673,6 @@ void AMXRFDetailedDetectorView::onShowMultipleSpectraButtonClicked()
 		removeAllPlotItems(spectraPlotItems_);
 		spectraNames = dialog.selectedItems();
 
-
 		// These will still be in order.
 		int spectraNamesIterator = 0;
 

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -673,6 +673,7 @@ void AMXRFDetailedDetectorView::onShowMultipleSpectraButtonClicked()
 		removeAllPlotItems(spectraPlotItems_);
 		spectraNames = dialog.selectedItems();
 
+
 		// These will still be in order.
 		int spectraNamesIterator = 0;
 


### PR DESCRIPTION
-- Added: emptySelectedItemsAllowed feature for AMSelectionDialog. With this flag, if empty selected items is not allowed and no items are selected, then the Okay button will be greyed out. 
-- add compile setting to AMCommon.pri, so that all the files (.obj, moc_, ui_) generated by compiler will be stored in corresponding folders instead of the root folder

https://github.com/acquaman/acquaman/issues/1110

@dretrex @davidChevrier 