### PR TITLE
Pull Request for Issue674: Glitch data points in REIXS scans

### DIFF
--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -496,10 +496,8 @@ bool CLSSIS3820Scaler::triggerScalerAcquisition(bool isContinuous)
 	if(isContinuous)
 		return false;
 
-	// say that we're triggered and need to do some waiting
 	triggerSourceTriggered_ = true;
-	// connect to all of the enabled channels
-	// make of list of the enabled channels we're waiting for
+
 	for(int x = 0, size = scalerChannels_.count(); x < size; x++){
 		if(scalerChannels_.at(x)->isEnabled()){
 
@@ -519,10 +517,6 @@ void CLSSIS3820Scaler::onReadingChanged(double value)
 	Q_UNUSED(value)
 	emit readingChanged();
 
-	// check if we've even been trigged
-	// call a helper function to check if the all of the channels in the wait list have monitored
-	// if so, succeed
-
 	if(triggerSourceTriggered_ && waitingChannels_.count() == 0){
 
 		triggerSourceTriggered_ = false;
@@ -530,9 +524,6 @@ void CLSSIS3820Scaler::onReadingChanged(double value)
 	}
 }
 
-// get a monitor from one channel
-// say that that channel is good in the check list
-// call helper function to check on shiatzu
 void CLSSIS3820Scaler::onChannelReadingChanged(int channelIndex)
 {
 	if(waitingChannels_.contains(channelIndex)){

--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -41,6 +41,8 @@ CLSSIS3820Scaler::CLSSIS3820Scaler(const QString &baseName, QObject *parent) :
 	doingDarkCurrentCorrection_ = false;
 	triggerSourceTriggered_ = false;
 
+	triggerChannelMapper_ = new QSignalMapper(this);
+
 	triggerSource_ = new AMDetectorTriggerSource(QString("%1TriggerSource").arg(baseName), this);
 	connect(triggerSource_, SIGNAL(triggered(AMDetectorDefinitions::ReadMode)), this, SLOT(onTriggerSourceTriggered(AMDetectorDefinitions::ReadMode)));
 
@@ -55,7 +57,8 @@ CLSSIS3820Scaler::CLSSIS3820Scaler(const QString &baseName, QObject *parent) :
 		tmpChannel = new CLSSIS3820ScalerChannel(baseName, x, this);
 		scalerChannels_.append(tmpChannel);
 		connect(tmpChannel, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()));
-		connect( tmpChannel, SIGNAL(sensitivityChanged()), this, SIGNAL(sensitivityChanged()) );
+		connect(tmpChannel, SIGNAL(sensitivityChanged()), this, SIGNAL(sensitivityChanged()));
+		connect(tmpChannel, SIGNAL(readingChanged(int)), triggerChannelMapper_, SLOT(map()));
 		/*
 		connect( this, SIGNAL(newDarkCurrentMeasurementValue(double)), tmpChannel, SIGNAL(newDarkCurrentMeasurementValue(double)) );
 		connect( this, SIGNAL(newDarkCurrentMeasurementState(CLSSIS3820Scaler::DarkCurrentCorrectionState)), tmpChannel, SIGNAL(newDarkCurrentMeasurementState(CLSSIS3820Scaler::DarkCurrentCorrectionState)) );
@@ -487,7 +490,8 @@ void CLSSIS3820Scaler::onModeSwitchSignal(){
 	}
 }
 
-bool CLSSIS3820Scaler::triggerScalerAcquisition(bool isContinuous){
+bool CLSSIS3820Scaler::triggerScalerAcquisition(bool isContinuous)
+{
 	disconnect(this, SIGNAL(continuousChanged(bool)), this, SLOT(triggerScalerAcquisition(bool)));
 	if(isContinuous)
 		return false;
@@ -500,15 +504,18 @@ bool CLSSIS3820Scaler::triggerScalerAcquisition(bool isContinuous){
 		if(scalerChannels_.at(x)->isEnabled()){
 
 			waitingChannels_.append(x);
-			connect(scalerChannels_.at(x), SIGNAL(readingChanged(int)), this, SLOT(onChannelReadingChanged(int)));
+			triggerChannelMapper_->setMapping(scalerChannels_.at(x), x);
 		}
 	}
+
+	connect(triggerChannelMapper_, SIGNAL(mapped(int)), this, SLOT(onChannelReadingChanged(int)));
 
 	setScanning(true);
 	return true;
 }
 
-void CLSSIS3820Scaler::onReadingChanged(double value){
+void CLSSIS3820Scaler::onReadingChanged(double value)
+{
 	Q_UNUSED(value)
 	emit readingChanged();
 
@@ -526,19 +533,18 @@ void CLSSIS3820Scaler::onReadingChanged(double value){
 // get a monitor from one channel
 // say that that channel is good in the check list
 // call helper function to check on shiatzu
-void CLSSIS3820Scaler::onChannelReadingChanged(int value){
-	Q_UNUSED(value)
-	CLSSIS3820ScalerChannel *senderChannel = qobject_cast<CLSSIS3820ScalerChannel*>(QObject::sender());
+void CLSSIS3820Scaler::onChannelReadingChanged(int channelIndex)
+{
+	if(waitingChannels_.contains(channelIndex)){
 
-	if(waitingChannels_.contains(senderChannel->index())){
-
-		waitingChannels_.removeAll(senderChannel->index());
-		disconnect(senderChannel, SIGNAL(readingChanged(int)), this, SLOT(onChannelReadingChanged(int)));
+		waitingChannels_.removeAll(channelIndex);
+		triggerChannelMapper_->removeMappings(channelAt(channelIndex));
 	}
 
 	if(triggerSourceTriggered_ && waitingChannels_.count() == 0){
 
 		triggerSourceTriggered_ = false;
+		disconnect(triggerChannelMapper_, SIGNAL(mapped(int)), this, SLOT(onChannelReadingChanged(int)));
 		triggerSource_->setSucceeded();
 	}
 }

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -171,6 +171,7 @@ protected slots:
 	void onModeSwitchSignal();
 	bool triggerScalerAcquisition(bool isContinuous);
 	void onReadingChanged(double value);
+	void onChannelReadingChanged(int value);
 
 	void onDwellTimeSourceSetDwellTime(double dwellSeconds);
 	void onDwellTimeSourceSetDarkCurrentCorrectionTime(double timeSeconds);
@@ -217,6 +218,8 @@ protected:
 	bool doingDarkCurrentCorrection_;
 	double lastDwellTime_;
 
+	bool triggerSourceTriggered_;
+	QList<int> waitingChannels_;
 };
 
 /// This class is an abstraction of an individual channel for the scaler class.

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -37,6 +37,8 @@ class AMCurrentAmplifier;
 #include "actions3/AMListAction3.h"
 #include "source/beamline/AMDetector.h"
 
+#include <QSignalMapper>
+
 /*!
   Builds an abstraction for the SIS 3820 scaler used throughout the CLS.  It takes in a base name of the PV's and builds all the PV's
   and makes the necessary connections.
@@ -171,7 +173,7 @@ protected slots:
 	void onModeSwitchSignal();
 	bool triggerScalerAcquisition(bool isContinuous);
 	void onReadingChanged(double value);
-	void onChannelReadingChanged(int value);
+	void onChannelReadingChanged(int channelIndex);
 
 	void onDwellTimeSourceSetDwellTime(double dwellSeconds);
 	void onDwellTimeSourceSetDarkCurrentCorrectionTime(double timeSeconds);
@@ -218,7 +220,11 @@ protected:
 	bool doingDarkCurrentCorrection_;
 	double lastDwellTime_;
 
+	/// Holds the mapping of the enabled channels during an acquisition.
+	QSignalMapper *triggerChannelMapper_;
+	/// Flag for knowing if the scaler has been triggered.
 	bool triggerSourceTriggered_;
+	/// The list of channels we are still waiting to get their monitor before emitting that the scaler acquisition has finished.
 	QList<int> waitingChannels_;
 };
 


### PR DESCRIPTION
This is a fix for the scaler to stop it from getting bad data points.  It waits until all the channels have monitored before passing on that it's acquisition has "finished".