### PR TITLE
Fixed crash bug in IDEASXRFDetailedDetectorViewWithSave

### DIFF
--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
@@ -45,13 +45,13 @@ IDEASXRFDetailedDetectorViewWithSave::~IDEASXRFDetailedDetectorViewWithSave(){}
 void IDEASXRFDetailedDetectorViewWithSave::buildDetectorView()
 {
 	// This is going to extend the base view, so we will simply call it's build method too.
-	AMXRFBaseDetectorView::buildDetectorView();
+	AMXRFDetailedDetectorView::buildDetectorView();
 
-	AMXRFDetailedDetectorView::buildPeriodicTableViewAndElementView();
-	AMXRFDetailedDetectorView::buildShowSpectraButtons();
-	AMXRFDetailedDetectorView::buildPileUpPeakButtons();
-	AMXRFDetailedDetectorView::buildDeadTimeView();
-	AMXRFDetailedDetectorView::buildRegionOfInterestViews();
+//	AMXRFDetailedDetectorView::buildPeriodicTableViewAndElementView();
+//	AMXRFDetailedDetectorView::buildShowSpectraButtons();
+//	AMXRFDetailedDetectorView::buildPileUpPeakButtons();
+//	AMXRFDetailedDetectorView::buildDeadTimeView();
+//	AMXRFDetailedDetectorView::buildRegionOfInterestViews();
 
 	buildScanSaveViews();
 

--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
@@ -47,12 +47,6 @@ void IDEASXRFDetailedDetectorViewWithSave::buildDetectorView()
 	// This is going to extend the base view, so we will simply call it's build method too.
 	AMXRFDetailedDetectorView::buildDetectorView();
 
-//	AMXRFDetailedDetectorView::buildPeriodicTableViewAndElementView();
-//	AMXRFDetailedDetectorView::buildShowSpectraButtons();
-//	AMXRFDetailedDetectorView::buildPileUpPeakButtons();
-//	AMXRFDetailedDetectorView::buildDeadTimeView();
-//	AMXRFDetailedDetectorView::buildRegionOfInterestViews();
-
 	buildScanSaveViews();
 
 }


### PR DESCRIPTION
IDEASXRFDetailedDetectorViewWithSave::buildDetectorView() to call parent
buildDetectorView() to fix crash bug resulting from changes to parent.