### PR TITLE
Pull Request for Issue1127: Make subdirectories for each scan when collecting XRD data

### DIFF
--- a/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
@@ -265,7 +265,9 @@ AMAction3* VESPERS2DScanActionController::createInitializationActions()
 	initializationActions->addSubAction(buildBaseInitializationAction(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
 
 	if (!configuration_->ccdDetector().testFlag(VESPERS::NoCCD))
-		initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(), configuration_->ccdFileName()));
+		initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(),
+										 configuration_->ccdFileName(),
+										 scan_->largestNumberInScansWhere(AMDatabase::database("user"), QString(" name = '%1'").arg(scan_->name()))+1));
 
 	if (configuration_->normalPosition() != 888888.88){
 

--- a/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
@@ -164,7 +164,9 @@ AMAction3* VESPERS3DScanActionController::createInitializationActions()
 {
 	AMSequentialListAction3 *initializationActions = new AMSequentialListAction3(new AMSequentialListActionInfo3("Initialization actions", "Initialization actions"));
 	initializationActions->addSubAction(buildBaseInitializationAction(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
-	initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(), configuration_->ccdFileName()));
+	initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(),
+									 configuration_->ccdFileName(),
+									 scan_->largestNumberInScansWhere(AMDatabase::database("user"), QString(" name = '%1'").arg(scan_->name()))+1));
 
 	return initializationActions;
 }

--- a/source/acquaman/VESPERS/VESPERSEnergyScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSEnergyScanActionController.cpp
@@ -87,11 +87,13 @@ void VESPERSEnergyScanActionController::buildScanControllerImplementation()
 
 AMAction3* VESPERSEnergyScanActionController::createInitializationActions()
 {
-	AMSequentialListAction3 *initializationList = new AMSequentialListAction3(new AMSequentialListActionInfo3("Initialization List"));
-	initializationList->addSubAction(buildBaseInitializationAction(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
-	initializationList->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(), configuration_->ccdFileName()));
+	AMSequentialListAction3 *initializationActions = new AMSequentialListAction3(new AMSequentialListActionInfo3("Initialization List"));
+	initializationActions->addSubAction(buildBaseInitializationAction(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
+	initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(),
+									 configuration_->ccdFileName(),
+									 scan_->largestNumberInScansWhere(AMDatabase::database("user"), QString(" name = '%1'").arg(scan_->name()))+1));
 
-	return initializationList;
+	return initializationActions;
 }
 
 AMAction3* VESPERSEnergyScanActionController::createCleanupActions()

--- a/source/acquaman/VESPERS/VESPERSScanController.cpp
+++ b/source/acquaman/VESPERS/VESPERSScanController.cpp
@@ -72,7 +72,7 @@ AMAction3 *VESPERSScanController::buildBaseInitializationAction(double firstRegi
 	return initializationAction;
 }
 
-AMAction3 *VESPERSScanController::buildCCDInitializationAction(VESPERS::CCDDetectors ccdChoice, const QString &ccdName)
+AMAction3 *VESPERSScanController::buildCCDInitializationAction(VESPERS::CCDDetectors ccdChoice, const QString &ccdName, int newScanNumber)
 {
 	AMParallelListAction3 *action = new AMParallelListAction3(new AMParallelListActionInfo3("CCD Setup Action", "Sets the path, base file name and file number to the detector."));
 
@@ -107,14 +107,11 @@ AMAction3 *VESPERSScanController::buildCCDInitializationAction(VESPERS::CCDDetec
 		QString dataFolder = AMUserSettings::userDataFolder;
 
 		if (dataFolder.contains(QRegExp("\\d{2,2}-\\d{4,4}")))
-			action->addSubAction(ccd->createFilePathAction("/ramdisk/" % dataFolder.mid(dataFolder.indexOf(QRegExp("\\d{2,2}-\\d{4,4}")), 7)));
+			action->addSubAction(ccd->createFilePathAction(QString("/ramdisk/%1/%2_%3").arg(dataFolder.mid(dataFolder.indexOf(QRegExp("\\d{2,2}-\\d{4,4}")), 7))
+													.arg(config_->ccdFileName())
+													.arg(newScanNumber)));
 
-		QString uniqueName = getUniqueCCDName(ccd->ccdFilePath(), ccdName);
-
-		if (config_->ccdFileName() != uniqueName)
-			config_->setCCDFileName(uniqueName);
-
-		action->addSubAction(ccd->createFileNameAction(uniqueName));
+		action->addSubAction(ccd->createFileNameAction(config_->ccdFileName()));
 		action->addSubAction(ccd->createFileNumberAction(1));
 	}
 

--- a/source/acquaman/VESPERS/VESPERSScanController.h
+++ b/source/acquaman/VESPERS/VESPERSScanController.h
@@ -44,8 +44,8 @@ public:
 protected:
 	/// Helper method that builds the base initialization actions.
 	AMAction3 *buildBaseInitializationAction(double firstRegionTime);
-	/// Helper method that builds the CCD file path, name, and number for the beginning of a scan.  Requires the detector enum, ccd file name from the configuration, AND must be called after buildInitializationActions() because it assumes the list has already been created.
-	AMAction3 *buildCCDInitializationAction(VESPERS::CCDDetectors ccdChoice, const QString &ccdName);
+	/// Helper method that builds the CCD file path, name, and number for the beginning of a scan.  Requires the detector enum, ccd file name from the configuration and the new scan number, AND must be called after buildInitializationActions() because it assumes the list has already been created.
+	AMAction3 *buildCCDInitializationAction(VESPERS::CCDDetectors ccdChoice, const QString &ccdName, int newScanNumber);
 	/// Helper method that builds all of the cleanup actions.
 	AMAction3 *buildCleanupAction();
 

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
@@ -301,7 +301,9 @@ AMAction3* VESPERSSpatialLineScanActionController::createInitializationActions()
 	initializationActions->addSubAction(buildBaseInitializationAction(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
 
 	if (!configuration_->ccdDetector().testFlag(VESPERS::NoCCD))
-		initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(), configuration_->ccdFileName()));
+		initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(),
+										 configuration_->ccdFileName(),
+										 scan_->largestNumberInScansWhere(AMDatabase::database("user"), QString(" name = '%1'").arg(scan_->name()))+1));
 
 	if (configuration_->normalPosition() != 888888.88){
 


### PR DESCRIPTION
Changed XRD image file saving paradigm.  Rather than putting all images in one folder and trying to guarantee unique names, I changed it to make a folder for each scan and put all the images associated with that scan in it.  This gets rid of the need for the unique name code. I haven't done the changes to the Roper and Mar detectors yet because I have no ability to test those.  As we use them (maybe?) I'll port over the change.