### PR TITLE
Pull Request for Issue1040: AMControlWaitAction Crash

### DIFF
--- a/source/actions3/actions/AMControlMoveAction3.cpp
+++ b/source/actions3/actions/AMControlMoveAction3.cpp
@@ -32,7 +32,7 @@ AMControlMoveAction3::AMControlMoveAction3(AMControlMoveActionInfo3 *info, AMCon
 	if (control)
 		control_ = control;
 	else
-		control_ = AMBeamline::bl()->exposedControlByInfo(*(info->controlInfo()));
+		control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
 }
 
 AMControlMoveAction3::AMControlMoveAction3(const AMControlMoveAction3 &other)
@@ -41,18 +41,18 @@ AMControlMoveAction3::AMControlMoveAction3(const AMControlMoveAction3 &other)
 	const AMControlMoveActionInfo3 *info = qobject_cast<const AMControlMoveActionInfo3*>(other.info());
 
 	if (info)
-		control_ = AMBeamline::bl()->exposedControlByInfo(*(info->controlInfo()));
+		control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
 	else
 		control_ = 0;
 }
 
 void AMControlMoveAction3::startImplementation()
 {
-	const AMControlInfo& setpoint = *(controlMoveInfo()->controlInfo());
+	const AMControlInfo& setpoint = controlMoveInfo()->controlInfo();
 
 	// If you still don't have a control, check the exposed controls one last time.
 	if (!control_)
-		control_ = AMBeamline::bl()->exposedControlByInfo(*(controlMoveInfo()->controlInfo()));
+		control_ = AMBeamline::bl()->exposedControlByInfo(controlMoveInfo()->controlInfo());
 
 	// Must have a control, and it must be able to move.
 	if(!control_) {
@@ -167,7 +167,7 @@ void AMControlMoveAction3::onMoveSucceeded()
 
 	if(generateScanActionMessages_){
 
-		AMAgnosticDataAPIControlMovedMessage controlMovedMessage(control_->name(), "INVALIDMOVEMENTTYPE", controlMoveInfo()->controlInfo()->value(), control_->value());
+		AMAgnosticDataAPIControlMovedMessage controlMovedMessage(control_->name(), "INVALIDMOVEMENTTYPE", controlMoveInfo()->controlInfo().value(), control_->value());
 		if(controlMoveInfo()->isRelativeMove())
 			controlMovedMessage.setControlMovementType("Relative");
 		else

--- a/source/actions3/actions/AMControlMoveActionInfo3.cpp
+++ b/source/actions3/actions/AMControlMoveActionInfo3.cpp
@@ -34,7 +34,7 @@ AMControlMoveActionInfo3::AMControlMoveActionInfo3(const AMControlInfo &setpoint
 AMControlMoveActionInfo3::AMControlMoveActionInfo3(const AMControlMoveActionInfo3 &other)
 	: AMActionInfo3(other)
 {
-	controlInfo_.setValuesFrom(*(other.controlInfo()));
+	controlInfo_.setValuesFrom(other.controlInfo());
 	isRelative_ = other.isRelativeMove();
 	isRelativeFromSetpoint_ = other.isRelativeFromSetpoint();
 }

--- a/source/actions3/actions/AMControlMoveActionInfo3.h
+++ b/source/actions3/actions/AMControlMoveActionInfo3.h
@@ -54,7 +54,8 @@ public:
 	//////////////////////////
 
 	/// Returns a pointer to our move destination setpoint
-	const AMControlInfo* controlInfo() const { return &controlInfo_; }
+//	const AMControlInfo* controlInfo() const { return &controlInfo_; }
+	AMControlInfo controlInfo() const { return controlInfo_; }
 	/// Returns true if this is to be a relative move (otherwise returns false for absolute).
 	bool isRelativeMove() const { return isRelative_; }
 	/// Returns true if this is to be a relative move from the setpoint as opposed to the feedback value
@@ -70,6 +71,11 @@ public:
 	/// Sets whether this should be a relative move from the setpoint as opposed to the feedback value.
 	void setIsRelativeFromSetpoint(bool isRelativeFromSetpoint);
 
+public slots:
+
+signals:
+
+protected:
 	// Database loading/storing
 	////////////////////////////
 
@@ -77,10 +83,6 @@ public:
 	AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
 	/// For database loading only. This function will never be called since dbReadControlInfo() always returns a valid setpoint, but it needs to be here.
 	void dbLoadControlInfo(AMDbObject* newLoadedObject) { newLoadedObject->deleteLater(); }
-
-signals:
-
-public slots:
 
 protected:
 	/// The AMControlInfo that specifies where to move to

--- a/source/actions3/actions/AMControlMoveActionInfo3.h
+++ b/source/actions3/actions/AMControlMoveActionInfo3.h
@@ -54,7 +54,6 @@ public:
 	//////////////////////////
 
 	/// Returns a pointer to our move destination setpoint
-//	const AMControlInfo* controlInfo() const { return &controlInfo_; }
 	AMControlInfo controlInfo() const { return controlInfo_; }
 	/// Returns true if this is to be a relative move (otherwise returns false for absolute).
 	bool isRelativeMove() const { return isRelative_; }

--- a/source/actions3/actions/AMControlMoveActionInfo3.h
+++ b/source/actions3/actions/AMControlMoveActionInfo3.h
@@ -54,7 +54,7 @@ public:
 	//////////////////////////
 
 	/// Returns a pointer to our move destination setpoint
-	AMControlInfo controlInfo() const { return controlInfo_; }
+	const AMControlInfo& controlInfo() const { return controlInfo_; }
 	/// Returns true if this is to be a relative move (otherwise returns false for absolute).
 	bool isRelativeMove() const { return isRelative_; }
 	/// Returns true if this is to be a relative move from the setpoint as opposed to the feedback value

--- a/source/actions3/actions/AMControlStopAction.cpp
+++ b/source/actions3/actions/AMControlStopAction.cpp
@@ -33,7 +33,7 @@ AMControlStopAction::AMControlStopAction(AMControlStopActionInfo *info, AMContro
 		control_ = control;
 
 	else
-		control_ = AMBeamline::bl()->exposedControlByInfo(*(info->controlInfo()));
+		control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
 }
 
 AMControlStopAction::AMControlStopAction(const AMControlStopAction &other)
@@ -42,7 +42,7 @@ AMControlStopAction::AMControlStopAction(const AMControlStopAction &other)
 	const AMControlStopActionInfo *info = qobject_cast<const AMControlStopActionInfo *>(other.info());
 
 	if (info)
-		control_ = AMBeamline::bl()->exposedControlByInfo(*(info->controlInfo()));
+		control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
 	else
 		control_ = 0;
 }
@@ -50,7 +50,7 @@ AMControlStopAction::AMControlStopAction(const AMControlStopAction &other)
 void AMControlStopAction::startImplementation()
 {
 	AMControlStopActionInfo *controlStopInfo = qobject_cast<AMControlStopActionInfo *>(info());
-	const AMControlInfo& setpoint = *(controlStopInfo->controlInfo());
+	const AMControlInfo& setpoint = controlStopInfo->controlInfo();
 
 	// If you still don't have a control, check the exposed controls one last time.
 	if (!control_)

--- a/source/actions3/actions/AMControlStopActionInfo.cpp
+++ b/source/actions3/actions/AMControlStopActionInfo.cpp
@@ -31,7 +31,7 @@ AMControlStopActionInfo::AMControlStopActionInfo(const AMControlInfo &setpoint, 
 AMControlStopActionInfo::AMControlStopActionInfo(const AMControlStopActionInfo &other)
 	: AMActionInfo3(other)
 {
-	controlInfo_.setValuesFrom(*(other.controlInfo()));
+	controlInfo_.setValuesFrom(other.controlInfo());
 }
 
 AMActionInfo3 *AMControlStopActionInfo::createCopy() const

--- a/source/actions3/actions/AMControlStopActionInfo.h
+++ b/source/actions3/actions/AMControlStopActionInfo.h
@@ -45,7 +45,7 @@ public:
 	virtual QString typeDescription() const { return "Control Stop"; }
 
 	/// Returns a pointer to our move destination setpoint
-	AMControlInfo controlInfo() const { return controlInfo_; }
+	const AMControlInfo& controlInfo() const { return controlInfo_; }
 	/// Set the move destination setpoint, including the control name, value, and description.
 	/*! \note We make a copy of \c controlInfo's values, and do not retain any reference to it afterward. */
 	void setControlInfo(const AMControlInfo& controlInfo);

--- a/source/actions3/actions/AMControlStopActionInfo.h
+++ b/source/actions3/actions/AMControlStopActionInfo.h
@@ -45,11 +45,13 @@ public:
 	virtual QString typeDescription() const { return "Control Stop"; }
 
 	/// Returns a pointer to our move destination setpoint
-	const AMControlInfo* controlInfo() const { return &controlInfo_; }
+//	const AMControlInfo* controlInfo() const { return &controlInfo_; }
+	AMControlInfo controlInfo() const { return controlInfo_; }
 	/// Set the move destination setpoint, including the control name, value, and description.
 	/*! \note We make a copy of \c controlInfo's values, and do not retain any reference to it afterward. */
 	void setControlInfo(const AMControlInfo& controlInfo);
 
+protected:
 	// Database loading/storing
 	////////////////////////////
 

--- a/source/actions3/actions/AMControlStopActionInfo.h
+++ b/source/actions3/actions/AMControlStopActionInfo.h
@@ -45,7 +45,6 @@ public:
 	virtual QString typeDescription() const { return "Control Stop"; }
 
 	/// Returns a pointer to our move destination setpoint
-//	const AMControlInfo* controlInfo() const { return &controlInfo_; }
 	AMControlInfo controlInfo() const { return controlInfo_; }
 	/// Set the move destination setpoint, including the control name, value, and description.
 	/*! \note We make a copy of \c controlInfo's values, and do not retain any reference to it afterward. */

--- a/source/actions3/actions/AMControlWaitAction.cpp
+++ b/source/actions3/actions/AMControlWaitAction.cpp
@@ -31,7 +31,7 @@ AMControlWaitAction::AMControlWaitAction(AMControlWaitActionInfo *info, AMContro
    if (control)
        control_ = control;
    else
-       control_ = AMBeamline::bl()->exposedControlByInfo(*(info->controlInfo()));
+       control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
 
    info->setShortDescription(QString("Wait for Control: %1").arg(control_->name()));
 }
@@ -45,7 +45,7 @@ AMControlWaitAction::AMControlWaitAction(const AMControlWaitAction &other)
    const AMControlWaitActionInfo *info = qobject_cast<const AMControlWaitActionInfo*>(other.info());
 
    if (info)
-       control_ = AMBeamline::bl()->exposedControlByInfo(*(info->controlInfo()));
+       control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
    else
        control_ = 0;
 }
@@ -53,11 +53,11 @@ AMControlWaitAction::AMControlWaitAction(const AMControlWaitAction &other)
 
 void AMControlWaitAction::startImplementation()
 {
-    const AMControlInfo& setpoint = *(controlWaitInfo()->controlInfo());
+    const AMControlInfo& setpoint = controlWaitInfo()->controlInfo();
 
     // If you still don't have a control, check the exposed controls one last time.
     if (!control_)
-        control_ = AMBeamline::bl()->exposedControlByInfo(*(controlWaitInfo()->controlInfo()));
+	control_ = AMBeamline::bl()->exposedControlByInfo(controlWaitInfo()->controlInfo());
 
     // Must have a control, and it must be able to move.
     if(!control_) {
@@ -139,7 +139,7 @@ void AMControlWaitAction::onTimeoutTimerTimedOut()
 
 bool AMControlWaitAction::checkCurrentControlValue()
 {
-    const AMControlInfo& setpoint = *(controlWaitInfo()->controlInfo());
+    const AMControlInfo& setpoint = controlWaitInfo()->controlInfo();
 
     qDebug() << control_->name() << " Current: " << control_->value() << " New: " << setpoint.value();
 

--- a/source/actions3/actions/AMControlWaitActionInfo.cpp
+++ b/source/actions3/actions/AMControlWaitActionInfo.cpp
@@ -35,7 +35,7 @@ AMControlWaitActionInfo::~AMControlWaitActionInfo(){}
 AMControlWaitActionInfo::AMControlWaitActionInfo(const AMControlWaitActionInfo &other) :
 	AMActionInfo3(other)
 {
-	controlInfo_.setValuesFrom(*(other.controlInfo()));
+	controlInfo_.setValuesFrom(other.controlInfo());
 	timeout_ = other.timeout();
 	matchType_ = other.matchType();
 

--- a/source/actions3/actions/AMControlWaitActionInfo.h
+++ b/source/actions3/actions/AMControlWaitActionInfo.h
@@ -61,7 +61,8 @@ public:
 	//////////////////////////
 
 	/// Returns a pointer to our move destination setpoint
-	const AMControlInfo* controlInfo() const { return &controlInfo_; }
+//	const AMControlInfo* controlInfo() const { return &controlInfo_; }
+	AMControlInfo controlInfo() const { return controlInfo_; }
 
 	/// Returns our timeout.
 	double timeout() const;
@@ -78,6 +79,11 @@ public:
 	void setTimeout(double newTimeout);
 	void setMatchType(AMControlWaitActionInfo::MatchType newMatchType);
 
+public slots:
+
+signals:
+
+protected:
 	// Database loading/storing
 	////////////////////////////
 
@@ -86,10 +92,6 @@ public:
 	/// For database loading only. This function will never be called since dbReadControlInfo() always returns a valid setpoint, but it needs to be here.
 	void dbLoadControlInfo(AMDbObject* newLoadedObject) { newLoadedObject->deleteLater(); }
 
-signals:
-
-public slots:
-protected:
 	int matchTypeAsInt() const;
 	void setMatchTypeAsInt(int newMatchType);
 

--- a/source/actions3/actions/AMControlWaitActionInfo.h
+++ b/source/actions3/actions/AMControlWaitActionInfo.h
@@ -61,7 +61,6 @@ public:
 	//////////////////////////
 
 	/// Returns a pointer to our move destination setpoint
-//	const AMControlInfo* controlInfo() const { return &controlInfo_; }
 	AMControlInfo controlInfo() const { return controlInfo_; }
 
 	/// Returns our timeout.

--- a/source/actions3/actions/AMControlWaitActionInfo.h
+++ b/source/actions3/actions/AMControlWaitActionInfo.h
@@ -61,7 +61,7 @@ public:
 	//////////////////////////
 
 	/// Returns a pointer to our move destination setpoint
-	AMControlInfo controlInfo() const { return controlInfo_; }
+	const AMControlInfo& controlInfo() const { return controlInfo_; }
 
 	/// Returns our timeout.
 	double timeout() const;

--- a/source/actions3/actions/AMSampleMoveAction.cpp
+++ b/source/actions3/actions/AMSampleMoveAction.cpp
@@ -129,14 +129,14 @@ void AMSampleMoveAction::startImplementation(){
 	if(asListAction){
 		for(int x = 0, size = asListAction->subActionCount(); x < size; x++){
 			AMControlMoveAction3 *subAsControlMoveAction = qobject_cast<AMControlMoveAction3*>(asListAction->subActionAt(x));
-			if(subAsControlMoveAction && subAsControlMoveAction->controlMoveInfo()->controlInfo()->value() > subAsControlMoveAction->controlMoveInfo()->controlInfo()->maximum()){
-				AMControlInfo newValueInfo(*(subAsControlMoveAction->controlMoveInfo()->controlInfo()));
-				newValueInfo.setValue(subAsControlMoveAction->controlMoveInfo()->controlInfo()->maximum());
+			if(subAsControlMoveAction && subAsControlMoveAction->controlMoveInfo()->controlInfo().value() > subAsControlMoveAction->controlMoveInfo()->controlInfo().maximum()){
+				AMControlInfo newValueInfo(subAsControlMoveAction->controlMoveInfo()->controlInfo());
+				newValueInfo.setValue(subAsControlMoveAction->controlMoveInfo()->controlInfo().maximum());
 				subAsControlMoveAction->controlMoveInfo()->setControlInfo(newValueInfo);
 			}
-			else if(subAsControlMoveAction && subAsControlMoveAction->controlMoveInfo()->controlInfo()->value() < subAsControlMoveAction->controlMoveInfo()->controlInfo()->minimum()){
-				AMControlInfo newValueInfo(*(subAsControlMoveAction->controlMoveInfo()->controlInfo()));
-				newValueInfo.setValue(subAsControlMoveAction->controlMoveInfo()->controlInfo()->minimum());
+			else if(subAsControlMoveAction && subAsControlMoveAction->controlMoveInfo()->controlInfo().value() < subAsControlMoveAction->controlMoveInfo()->controlInfo().minimum()){
+				AMControlInfo newValueInfo(subAsControlMoveAction->controlMoveInfo()->controlInfo());
+				newValueInfo.setValue(subAsControlMoveAction->controlMoveInfo()->controlInfo().minimum());
 				subAsControlMoveAction->controlMoveInfo()->setControlInfo(newValueInfo);
 			}
 		}

--- a/source/actions3/editors/AMControlMoveActionEditor3.cpp
+++ b/source/actions3/editors/AMControlMoveActionEditor3.cpp
@@ -129,7 +129,7 @@ void AMControlMoveActionEditor3::populateControls()
 		controlSelectorBox_->addItem(description, control->name());	// store the actual control name in the UserRole.
 
 		// Is this control the info's current control?
-		if(control->name() == info_->controlInfo()->name())
+		if(control->name() == info_->controlInfo().name())
 			currentIndex = i;
 	}
 
@@ -150,9 +150,9 @@ void AMControlMoveActionEditor3::populateControls()
 		if(info_->isRelativeMove())// don't apply the control's min/max limits to a relative move. For ex: control with (min 5 max 200) could do a relative move from 70 of -10.
 			setpointBox_->setRange(-999999, 999999);
 		else
-			setpointBox_->setRange(info_->controlInfo()->minimum(), info_->controlInfo()->maximum());
-		setpointBox_->setValue(info_->controlInfo()->value());
-		unitsLabel_->setText(info_->controlInfo()->units());
+			setpointBox_->setRange(info_->controlInfo().minimum(), info_->controlInfo().maximum());
+		setpointBox_->setValue(info_->controlInfo().value());
+		unitsLabel_->setText(info_->controlInfo().units());
 		relativeCheckBox_->setChecked(info_->isRelativeMove());
 	}
 }

--- a/source/dataman/info/AMControlInfo.cpp
+++ b/source/dataman/info/AMControlInfo.cpp
@@ -20,7 +20,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "AMControlInfo.h"
 
- AMControlInfo::~AMControlInfo(){}
 AMControlInfo::AMControlInfo(const QString& name, double value, double minimum, double maximum, const QString& units, double tolerance, const QString &description, const QString &contextKnownDescription, const QString& enumString, QObject* parent)
 	: AMDbObject(parent)
 {
@@ -34,3 +33,5 @@ AMControlInfo::AMControlInfo(const QString& name, double value, double minimum, 
 	contextKnownDescription_ = contextKnownDescription;
 	enumString_ = enumString;
 }
+
+AMControlInfo::~AMControlInfo(){}

--- a/source/dataman/info/AMControlInfo.h
+++ b/source/dataman/info/AMControlInfo.h
@@ -42,15 +42,23 @@ class AMControlInfo : public AMDbObject {
 
 
 public:
- 	virtual ~AMControlInfo();
+	/// Default constructor
 	Q_INVOKABLE AMControlInfo(const QString& name = "Invalid Control", double value = 0.0, double minimum = 0.0, double maximum = 0.0, const QString& units = "", double tolerance = 0.0, const QString &description = "", const QString &contextKnownDescription = "", const QString& enumString = QString(), QObject* parent = 0);
+	virtual ~AMControlInfo();
 
+	/// Returns the value of the control
 	double value() const { return value_; }
+	/// Returns the minimum value of the control
 	double minimum() const { return minimum_; }
+	/// Returns the maximum value of the control
 	double maximum() const { return maximum_; }
+	/// Returns the units of the control
 	QString units() const { return units_; }
+	/// Returns the tolerance of the control
 	double tolerance() const { return tolerance_; }
+	/// Returns the full description of the control
 	QString description() const { return description_; }
+	/// Returns the contextual description of the control
 	QString contextKnownDescription() const { return contextKnownDescription_; }
 	/// Returns true if this was derived from an "enum" control with discrete states. It means that enumString() contains the state corresponding to value().
 	bool isEnum() const { return !enumString_.isEmpty(); }
@@ -72,23 +80,39 @@ public:
 	}
 
 public slots:
+	/// Sets the value for this control info
 	void setValue(double value) { value_ = value; setModified(true); }
+	/// Sets the minimum possible value for this control info
 	void setMinimum(double minimum) { minimum_ = minimum; setModified(true); }
+	/// Sets the maximum possible value for this control info
 	void setMaximum(double maximum) { maximum_ = maximum; setModified(true); }
+	/// Sets the units for this control info
 	void setUnits(const QString &units) { units_ = units; setModified(true); }
+	/// Sets the tolerance for this control info
 	void setTolerance(double tolerance) { tolerance_ = tolerance; setModified(true); }
+	/// Sets the full description for this control info
 	void setDescription(const QString &description) { description_ = description; setModified(true); }
+	/// Sets the contextual descriptino for thie contorl info
 	void setContextKnownDescription(const QString &contextKnownDescription) { contextKnownDescription_ = contextKnownDescription; setModified(true); }
+	/// Sets the enum string for this control info (if applicable)
 	void setEnumString(const QString& enumString) { enumString_ = enumString; setModified(true); }
 
 protected:
+	/// Position of the control
 	double value_;
+	/// Minimum value of the control
 	double minimum_;
+	/// Maximum value of the control
 	double maximum_;
+	/// Units for this control
 	QString units_;
+	/// Tolerance for this control
 	double tolerance_;
+	/// Full description of this control
 	QString description_;
+	/// Contextual description of this control
 	QString contextKnownDescription_;
+	/// The enum string value of the control (if applicable)
 	QString enumString_;
 };
 


### PR DESCRIPTION
Altered the AMControl[Move/Stop/Wait]ActionInfo classes to return the AMControlInfo by value rather than a const pointer. Tested on VESPERS and doesn't appear to introduce any problems.