### PR TITLE
Pull Request for Issue1142: Add Internal Retry to AMControlMoveAction

### DIFF
--- a/source/actions3/actions/AMControlMoveAction3.cpp
+++ b/source/actions3/actions/AMControlMoveAction3.cpp
@@ -48,7 +48,7 @@ AMControlMoveAction3::AMControlMoveAction3(const AMControlMoveAction3 &other)
 	else
 		control_ = 0;
 
-	retries_ = 1;
+	retries_ = other.retries();
 	attempts_ = 0;
 	destination_ = 0;
 }
@@ -119,13 +119,10 @@ void AMControlMoveAction3::startImplementation()
 	// determine the absolute destination
 	if(controlMoveInfo()->isRelativeMove() && controlMoveInfo()->isRelativeFromSetpoint())
 		destination_ = control_->setpoint() + setpoint.value();
-		//failureExplanation = control_->moveRelative(setpoint.value(), AMControl::RelativeMoveFromSetpoint);
 	else if(controlMoveInfo()->isRelativeMove())
 		destination_ = control_->value() + setpoint.value();
-		//failureExplanation = control_->moveRelative(setpoint.value(), AMControl::RelativeMoveFromValue);
 	else
 		destination_ = setpoint.value();
-		//failureExplanation = control_->move(setpoint.value());
 
 	// start the move:
 	int failureExplanation = control_->move(destination_);
@@ -202,7 +199,6 @@ void AMControlMoveAction3::onMoveFailed(int reason)
 		attempts_++;
 
 		// retry move
-		qDebug() << "Retrying move to " << destination_;
 		int failureExplanation = control_->move(destination_);
 		if(failureExplanation != AMControl::NoFailure)
 			onMoveFailed(failureExplanation);

--- a/source/actions3/actions/AMControlMoveAction3.h
+++ b/source/actions3/actions/AMControlMoveAction3.h
@@ -54,11 +54,18 @@ public:
 	/// Virtual copy constructor
 	virtual AMAction3* createCopy() const { return new AMControlMoveAction3(*this); }
 
-
 	/// Returns the control that this action will move.
 	AMControl *control() const { return control_; }
 	/// Sets the control used by this action.  This will generally not be used because the control will be provided by the constructor.
 	void setControl(AMControl *control) { control_ = control; }
+
+	/// Returns the destination of this move in absolute position
+	double destination() const;
+
+	/// Returns the maximum number of times we'll retry this action if it fails
+	int retries() const;
+	/// Retruns the number of times we've attempted the action thus far
+	int attempts() const;
 
 	// Re-implemented public functions
 	///////////////////////////////
@@ -81,6 +88,8 @@ public:
 signals:
 
 public slots:
+	/// Sets the maximum number of times we'll retry this action if it fails
+	void setRetries(int retries);
 
 protected:
 
@@ -124,6 +133,13 @@ protected:
 	AMControl* control_;
 	/// Stores the start position, which we use for calculating progress
 	AMControlInfo startPosition_;
+	/// Stores the actual destination of this move in absolute position (for retries in particular)
+	double destination_;
+
+	/// Stores the number of times we're willing to retry on failure
+	int retries_;
+	/// Stores the number of attempts to this point, to compare with the retries_ value
+	int attempts_;
 };
 
 #endif // AMCONTROLMOVEACTION3_H


### PR DESCRIPTION
Added and tested on VESPERS. Appears to work well. Default retries is set to 1.