### PR TITLE
Pull Request for Issue1149: remove the --enableCrashMonitor option from the runAcquaman.sh script.

### DIFF
--- a/runAcquaman.sh
+++ b/runAcquaman.sh
@@ -4,4 +4,4 @@ source /home/beamline/tools/qt/startup/startup.qt-4.7.3.sh
 export PATH=/home/beamline/tools/gstreamer-0.10.35/gstreamer-install/bin:/home/beamline/tools/gstreamer-0.10.35/deps/bin:$PATH
 export LD_LIBRARY_PATH=/home/beamline/tools/gstreamer-0.10.35/gstreamer-install/lib:/home/beamline/tools/gstreamer-0.10.35/deps/lib:$LD_LIBRARY_PATH
 
-$1 --enableCrashMonitor -graphicssystem raster "${@:2}"
+$1 -graphicssystem raster "${@:2}"


### PR DESCRIPTION
- removed the `--enableCrashMonitor` from the runAcquaman.sh script
- after this is merged in, each beamline should modify its own run script to pass the option to the runAcquaman.sh

https://github.com/acquaman/acquaman/issues/1149

@davidChevrier @dretrex 