### PR TITLE
Pull Request for Issue1151: Initialize the delayMove_ for CLSPseudoMotorControl,

### DIFF
--- a/source/beamline/CLS/CLSPseudoMotorControl.cpp
+++ b/source/beamline/CLS/CLSPseudoMotorControl.cpp
@@ -24,6 +24,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 CLSPseudoMotorControl::CLSPseudoMotorControl(const QString &name, const QString &readPVname, const QString &writePVname, const QString &movingPVname, const QString &stopPVname, QObject *parent, double tolerance, double moveStartTimeoutSeconds, AMAbstractControlStatusChecker *statusChecker, int stopValue, const QString &description)
 	: AMPVwStatusControl(name, readPVname, writePVname, movingPVname, stopPVname, parent, tolerance, moveStartTimeoutSeconds, statusChecker, stopValue, description)
 {
+	delayMove_ = false;
 }
 
 AMControl::FailureExplanation CLSPseudoMotorControl::move(double setpoint)

--- a/source/beamline/CLS/CLSPseudoMotorControl.cpp
+++ b/source/beamline/CLS/CLSPseudoMotorControl.cpp
@@ -25,6 +25,7 @@ CLSPseudoMotorControl::CLSPseudoMotorControl(const QString &name, const QString 
 	: AMPVwStatusControl(name, readPVname, writePVname, movingPVname, stopPVname, parent, tolerance, moveStartTimeoutSeconds, statusChecker, stopValue, description)
 {
 	delayMove_ = false;
+	delayMoveSetpoint_ = 0.0;
 }
 
 AMControl::FailureExplanation CLSPseudoMotorControl::move(double setpoint)


### PR DESCRIPTION

https://github.com/acquaman/acquaman/issues/1151

This might cause the random motor move when receiving status change.

Tested on BioXAS beamline. Didn't find random change.

@davidChevrier @dretrex 

