### PR TITLE
Pull Request for Issue1164: I0 not selectable in Line scans

### DIFF
--- a/source/ui/VESPERS/VESPERSSpatialLineScanConfigurationView.cpp
+++ b/source/ui/VESPERS/VESPERSSpatialLineScanConfigurationView.cpp
@@ -431,7 +431,7 @@ void VESPERSSpatialLineScanConfigurationView::onItClicked(int index)
 	QStandardItemModel *model = qobject_cast<QStandardItemModel *>(i0ComboBox_->model());
 
 	for (int i = 0; i < i0ComboBox_->count(); i++)
-		model->item(i)->setFlags(i < index ? Qt::ItemIsEnabled : Qt::NoItemFlags);
+		model->item(i)->setFlags(i < index ? (Qt::ItemIsEnabled | Qt::ItemIsSelectable) : Qt::NoItemFlags);
 
 	configuration_->setTransmissionChoice(index);
 }


### PR DESCRIPTION
Added the selectable flag to the I0 spin box in VESPERS line scans because I forgot to make them selectable after disabling them through actions of the It spin box.