### PR TITLE
Pull Request for Issue1167: Make the report file date in front of time

### DIFF
--- a/source/application/AMCrashReporter.cpp
+++ b/source/application/AMCrashReporter.cpp
@@ -287,7 +287,7 @@ void AMCrashReporter::onOneSymbolProcessed(){
 }
 
 void AMCrashReporter::onAllSymbolsProcessed(){
-	QFile reportFile(QString("%1/report_%2_%3_%4_%5.txt").arg(errorFilePath_).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("ddMMyyyy_hhmmss")).arg(watchingPID_));
+	QFile reportFile(QString("%1/%2/report_%3_%4_%5_%6.txt").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy")).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("ddMMyyyy_hhmmss")).arg(watchingPID_));
 	if(reportFile.open(QIODevice::WriteOnly | QIODevice::Text)){
 		QTextStream reportStream(&reportFile);
 		for(int x = 0; x < allProcessedLines_.count(); x++){

--- a/source/application/AMCrashReporter.cpp
+++ b/source/application/AMCrashReporter.cpp
@@ -118,12 +118,6 @@ AMCrashMonitor::AMCrashMonitor(const QString &executableFullPath, const QString 
 	errorFilePath_ = errorFilePath;
 	watchingPID_ = watchingPID;
 
-	//check the current year directory exist or not, if not create one.
-	QString targetPath = QString("%1/%2").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy"));
-	if (!QDir(targetPath).exists()) {
-		QDir().mkdir(targetPath);
-	}
-
 	unixSignalHandler_ = new AMCrashReporterUnixSignalHandler();
 	connect(unixSignalHandler_, SIGNAL(sigusr1Detected()), this, SLOT(onSiguser1Detected()));
 	connect(unixSignalHandler_, SIGNAL(sigusr2Detected()), this, SLOT(onSiguser2Detected()));
@@ -293,7 +287,14 @@ void AMCrashReporter::onOneSymbolProcessed(){
 }
 
 void AMCrashReporter::onAllSymbolsProcessed(){
-	QFile reportFile(QString("%1/%2/report_%3_%4_%5_%6.txt").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy")).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("MMddyyyy_hhmmss")).arg(watchingPID_));
+	//check the current year directory exist or not, if not create one.
+	QString targetPath = QString("%1/%2").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy"));
+	if (!QDir(targetPath).exists()) {
+		if (!QDir().mkdir(targetPath))
+			targetPath = errorFilePath_;
+	}
+
+	QFile reportFile(QString("%1/report_%2_%3_%4_%5.txt").arg(targetPath).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("MMddyyyy_hhmmss")).arg(watchingPID_));
 	if(reportFile.open(QIODevice::WriteOnly | QIODevice::Text)){
 		QTextStream reportStream(&reportFile);
 		for(int x = 0; x < allProcessedLines_.count(); x++){

--- a/source/application/AMCrashReporter.cpp
+++ b/source/application/AMCrashReporter.cpp
@@ -287,7 +287,7 @@ void AMCrashReporter::onOneSymbolProcessed(){
 }
 
 void AMCrashReporter::onAllSymbolsProcessed(){
-	QFile reportFile(QString("%1/report_%2_%3_%4_%5.txt").arg(errorFilePath_).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("hhmmss_ddMMyyyy")).arg(watchingPID_));
+	QFile reportFile(QString("%1/report_%2_%3_%4_%5.txt").arg(errorFilePath_).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("ddMMyyyy_hhmmss")).arg(watchingPID_));
 	if(reportFile.open(QIODevice::WriteOnly | QIODevice::Text)){
 		QTextStream reportStream(&reportFile);
 		for(int x = 0; x < allProcessedLines_.count(); x++){

--- a/source/application/AMCrashReporter.cpp
+++ b/source/application/AMCrashReporter.cpp
@@ -287,7 +287,7 @@ void AMCrashReporter::onOneSymbolProcessed(){
 }
 
 void AMCrashReporter::onAllSymbolsProcessed(){
-	QFile reportFile(QString("%1/%2/report_%3_%4_%5_%6.txt").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy")).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("ddMMyyyy_hhmmss")).arg(watchingPID_));
+	QFile reportFile(QString("%1/%2/report_%3_%4_%5_%6.txt").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy")).arg(executableFullPath_.section('/', -1)).arg(QHostInfo::localHostName()).arg(QDateTime::currentDateTime().toString("MMddyyyy_hhmmss")).arg(watchingPID_));
 	if(reportFile.open(QIODevice::WriteOnly | QIODevice::Text)){
 		QTextStream reportStream(&reportFile);
 		for(int x = 0; x < allProcessedLines_.count(); x++){

--- a/source/application/AMCrashReporter.cpp
+++ b/source/application/AMCrashReporter.cpp
@@ -118,6 +118,12 @@ AMCrashMonitor::AMCrashMonitor(const QString &executableFullPath, const QString 
 	errorFilePath_ = errorFilePath;
 	watchingPID_ = watchingPID;
 
+	//check the current year directory exist or not, if not create one.
+	QString targetPath = QString("%1/%2").arg(errorFilePath_).arg(QDateTime::currentDateTime().toString("yyyy"));
+	if (!QDir(targetPath).exists()) {
+		QDir().mkdir(targetPath);
+	}
+
 	unixSignalHandler_ = new AMCrashReporterUnixSignalHandler();
 	connect(unixSignalHandler_, SIGNAL(sigusr1Detected()), this, SLOT(onSiguser1Detected()));
 	connect(unixSignalHandler_, SIGNAL(sigusr2Detected()), this, SLOT(onSiguser2Detected()));


### PR DESCRIPTION
https://github.com/acquaman/acquaman/issues/1167

1) the reports can be easier to be found since they are ordered by date and then time.
2) add year to the subfolder of the beamline folder, so that the history reports will be organized nicely

@dretrex @davidChevrier 