### PR TITLE
Pull Request for Issue1165: Using default tolerance in AMWaitAction for initializations causing scans to fail

### DIFF
--- a/source/acquaman/BioXASSide/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXASSide/BioXASSideXASScanActionController.cpp
@@ -64,6 +64,7 @@ AMAction3* BioXASSideXASScanActionController::createInitializationActions()
 {
 	AMSequentialListAction3 *initializationAction = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Side Scan Initialization Actions", "BioXAS Side Scan Initialization Actions"));
 	CLSSIS3820Scaler *scaler = BioXASSideBeamline::bioXAS()->scaler();
+	double regionTime = double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime());
 
 	AMListAction3 *stage1 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 1", "BioXAS Side Initialization Stage 1"), AMListAction3::Parallel);
 	stage1->addSubAction(scaler->createContinuousEnableAction3(false));
@@ -77,15 +78,15 @@ AMAction3* BioXASSideXASScanActionController::createInitializationActions()
 
 	AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 3", "BioXAS Side Initialization Stage 3"), AMListAction3::Parallel);
 	stage3->addSubAction(scaler->createStartAction3(true));
-	stage3->addSubAction(scaler->createWaitForDwellFinishedAction());
+	stage3->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 
 	AMListAction3 *stage4 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 4", "BioXAS Side Initialization Stage 4"), AMListAction3::Parallel);
 	stage4->addSubAction(scaler->createStartAction3(true));
-	stage4->addSubAction(scaler->createWaitForDwellFinishedAction());
+	stage4->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 
 	initializationAction->addSubAction(stage1);
 	initializationAction->addSubAction(stage2);
-	initializationAction->addSubAction(scaler->createDwellTimeAction3(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
+	initializationAction->addSubAction(scaler->createDwellTimeAction3());
 	initializationAction->addSubAction(stage3);
 	initializationAction->addSubAction(stage4);
 

--- a/source/acquaman/VESPERS/VESPERSScanController.cpp
+++ b/source/acquaman/VESPERS/VESPERSScanController.cpp
@@ -55,19 +55,19 @@ AMAction3 *VESPERSScanController::buildBaseInitializationAction(double firstRegi
 	stage2->addSubAction(scaler->createScansPerBufferAction3(1));
 	stage2->addSubAction(scaler->createTotalScansAction3(1));
 
-	AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("VESPERS Initialization Stage 3", "VESPERS Initialization Stage 3"), AMListAction3::Parallel);
+	AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("VESPERS Initialization Stage 3", "VESPERS Initialization Stage 3"), AMListAction3::Sequential);
 	stage3->addSubAction(scaler->createStartAction3(true));
-	stage3->addSubAction(scaler->createWaitForDwellFinishedAction());
+	stage3->addSubAction(scaler->createWaitForDwellFinishedAction(firstRegionTime + 5.0));
 
-	AMListAction3 *stage4 = new AMListAction3(new AMListActionInfo3("VESPERS Initialization Stage 4", "VESPERS Initialization Stage 4"), AMListAction3::Parallel);
-	stage4->addSubAction(scaler->createStartAction3(true));
-	stage4->addSubAction(scaler->createWaitForDwellFinishedAction());
+//	AMListAction3 *stage4 = new AMListAction3(new AMListActionInfo3("VESPERS Initialization Stage 4", "VESPERS Initialization Stage 4"), AMListAction3::Parallel);
+//	stage4->addSubAction(scaler->createStartAction3(true));
+//	stage4->addSubAction(scaler->createWaitForDwellFinishedAction());
 
 	initializationAction->addSubAction(stage1);
 	initializationAction->addSubAction(stage2);
 	initializationAction->addSubAction(scaler->createDwellTimeAction3(firstRegionTime));
 	initializationAction->addSubAction(stage3);
-	initializationAction->addSubAction(stage4);
+//	initializationAction->addSubAction(stage4);
 
 	return initializationAction;
 }

--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -263,13 +263,14 @@ AMAction3* CLSSIS3820Scaler::createTotalScansAction3(int totalScans) {
 }
 
 
-AMAction3* CLSSIS3820Scaler::createWaitForDwellFinishedAction() {
+AMAction3* CLSSIS3820Scaler::createWaitForDwellFinishedAction(double timeoutTime)
+{
 	if(!isConnected())
 		return 0; //NULL
 
 	AMControlInfo setpoint = startToggle_->toInfo();
 	setpoint.setValue(0);
-	AMControlWaitActionInfo *actionInfo = new AMControlWaitActionInfo(setpoint, 11.0 , AMControlWaitActionInfo::MatchEqual);
+	AMControlWaitActionInfo *actionInfo = new AMControlWaitActionInfo(setpoint, timeoutTime , AMControlWaitActionInfo::MatchEqual);
 	AMControlWaitAction *action = new AMControlWaitAction(actionInfo, startToggle_);
 
 	if(!action)

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -104,8 +104,8 @@ public:
 	AMAction3* createScansPerBufferAction3(int scansPerBuffer);
 	/// Creates an action that sets the total number of scans to \param totalScans.
 	AMAction3* createTotalScansAction3(int totalScans);
-
-	AMAction3* createWaitForDwellFinishedAction();
+	/// Creates an action that waits for the acquisition to finish.  Provide an acceptable time wait so that you don't hang up indefinitely.
+	AMAction3* createWaitForDwellFinishedAction(double timeoutTime = 10.0);
 
 	AMAction3* createDoingDarkCurrentCorrectionAction(int dwellTime);
 


### PR DESCRIPTION
Added a default timeout time to the createWaitAction in the scaler.  The default will cause a failure for any acquisition longer than 11.0 seconds.  I then used the new method in the two instances where it appears to be used.