### PR TITLE
Pull Request for Issue985: Add a createChangeTolerance action inside of AMControl

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -443,7 +443,9 @@ HEADERS += \
 	source/ui/util/AMEnergyListView.h \
 	source/dataman/export/AMExporterOptionSMAK.h \
 	source/ui/AMScanEditorsCloseView.h \
-	source/ui/util/AMSortFilterScansWidget.h
+	source/ui/util/AMSortFilterScansWidget.h \
+    source/actions3/actions/AMChangeToleranceActionInfo.h \
+    source/actions3/actions/AMChangeToleranceAction.h
 
 FORMS += \
 	source/ui/dataman/AMImportControllerWidget.ui \
@@ -853,7 +855,9 @@ SOURCES += \
 	source/dataman/export/AMExporterOptionSMAK.cpp \
 	source/ui/AMScanEditorsCloseView.cpp \
 	source/ui/util/AMSortFilterScansWidget.cpp \
-	source/ui/dataman/AMImportControllerWidget.cpp
+	source/ui/dataman/AMImportControllerWidget.cpp \
+    source/actions3/actions/AMChangeToleranceActionInfo.cpp \
+    source/actions3/actions/AMChangeToleranceAction.cpp
 
 RESOURCES *= source/icons/icons.qrc \
 		source/configurationFiles/configurationFiles.qrc \
@@ -870,6 +874,10 @@ contains(DEFINES, AM_BUILD_REPORTER_ENABLED){
 
 	SOURCES *= source/util/AMRunTimeBuildInfo.cpp
 }
+
+
+
+
 
 
 

--- a/source/acquaman/VESPERS/VESPERSEnergyScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSEnergyScanActionController.cpp
@@ -24,6 +24,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/VESPERS/VESPERSBeamline.h"
 #include "dataman/AMXASScan.h"
 #include "actions3/AMListAction3.h"
+#include "actions3/AMActionSupport.h"
 
 VESPERSEnergyScanActionController::~VESPERSEnergyScanActionController(){}
 
@@ -92,6 +93,8 @@ AMAction3* VESPERSEnergyScanActionController::createInitializationActions()
 	initializationActions->addSubAction(buildCCDInitializationAction(configuration_->ccdDetector(),
 									 configuration_->ccdFileName(),
 									 scan_->largestNumberInScansWhere(AMDatabase::database("user"), QString(" name = '%1'").arg(scan_->name()))+1));
+
+	initializationActions->addSubAction(AMActionSupport::buildChangeToleranceAction(VESPERSBeamline::vespers()->energy(), double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd())*0.05));
 
 	return initializationActions;
 }

--- a/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
@@ -33,6 +33,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "analysis/AM1DNormalizationAB.h"
 #include "analysis/AM2DAdditionAB.h"
 #include "analysis/AM1DExpressionAB.h"
+#include "actions3/AMActionSupport.h"
 
 VESPERSXASScanActionController::~VESPERSXASScanActionController(){}
 
@@ -200,6 +201,7 @@ void VESPERSXASScanActionController::createScanAssembler()
 AMAction3* VESPERSXASScanActionController::createInitializationActions()
 {
 	AMListAction3 *initializationAction = qobject_cast<AMListAction3 *>(buildBaseInitializationAction(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
+	initializationAction->addSubAction(AMActionSupport::buildChangeToleranceAction(VESPERSBeamline::vespers()->energy(), configuration_->energy()*0.005));
 
 	return initializationAction;
 }

--- a/source/actions3/AMActionSupport.h
+++ b/source/actions3/AMActionSupport.h
@@ -25,6 +25,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/AMAction3.h"
 #include "beamline/AMControl.h"
 #include "actions3/actions/AMControlMoveAction3.h"
+#include "actions3/actions/AMChangeToleranceAction.h"
 
 /// This namespace provides some convenience methods for using AMActions.
 namespace AMActionSupport
@@ -36,6 +37,16 @@ namespace AMActionSupport
 		info.setValue(setpoint);
 		AMControlMoveActionInfo3 *actionInfo = new AMControlMoveActionInfo3(info);
 		AMControlMoveAction3 *action = new AMControlMoveAction3(actionInfo, control);
+		return action;
+	}
+
+	/// Helper method that takes an AMControl and a desired tolerance and returns a valid AMChangeToleranceAction.  Caller is responsible for memory.
+	inline AMAction3 *buildChangeToleranceAction(AMControl *control, double tolerance)
+	{
+		AMControlInfo info = control->toInfo();
+		info.setTolerance(tolerance);
+		AMChangeToleranceActionInfo *actionInfo = new AMChangeToleranceActionInfo(info, tolerance);
+		AMChangeToleranceAction *action = new AMChangeToleranceAction(actionInfo, control);
 		return action;
 	}
 }

--- a/source/actions3/actions/AMChangeToleranceAction.cpp
+++ b/source/actions3/actions/AMChangeToleranceAction.cpp
@@ -1,0 +1,71 @@
+#include "AMChangeToleranceAction.h"
+
+#include "beamline/AMControl.h"
+#include "beamline/AMBeamline.h"
+#include "util/AMErrorMonitor.h"
+
+AMChangeToleranceAction::AMChangeToleranceAction(AMChangeToleranceActionInfo *info, AMControl *control, QObject *parent)
+	: AMAction3(info, parent)
+{
+	if (control)
+	    control_ = control;
+	else
+	    control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
+
+	info->setShortDescription(QString("Change Tolerance for Control: %1").arg(control_->name()));
+}
+
+AMChangeToleranceAction::AMChangeToleranceAction(const AMChangeToleranceAction &other)
+	: AMAction3(other)
+{
+	const AMChangeToleranceActionInfo *info = qobject_cast<const AMChangeToleranceActionInfo *>(other.info());
+
+	if (info)
+	    control_ = AMBeamline::bl()->exposedControlByInfo(info->controlInfo());
+	else
+	    control_ = 0;
+}
+
+AMChangeToleranceAction::~AMChangeToleranceAction()
+{
+
+}
+
+AMAction3 *AMChangeToleranceAction::createCopy() const
+{
+	return new AMChangeToleranceAction(*this);
+}
+
+void AMChangeToleranceAction::startImplementation()
+{
+	const AMControlInfo &controlInfo = changeToleranceControlInfo()->controlInfo();
+
+	// If you still don't have a control, check the exposed controls one last time.
+	if (!control_)
+	    control_ = AMBeamline::bl()->exposedControlByInfo(controlInfo);
+
+	// Must have a control, and it must be able to move.
+	if(!control_) {
+	    AMErrorMon::alert(this,
+			      AMCHANGETOLERANCEACTION_INVALID_CONTROL,
+			      QString("There was an error setting the tolerance for the control '%1' into position, because the control was not found. Please report this problem to the Acquaman developers.").arg(controlInfo.name()));
+	    setFailed();
+	    return;
+	}
+
+	if (controlInfo.tolerance() <= 0.0){
+
+		AMErrorMon::alert(this,
+				  AMCHANGETOLERANCEACTION_INVALID_NEW_TOLERANCE,
+				  QString("There was an error setting the tolerance for control '%1' because the new tolerance was negative (%2).  Please contact Acquaman developpers.")
+				  .arg(controlInfo.name())
+				  .arg(controlInfo.tolerance(), 0, 'g' , 3));
+
+		setFailed();
+		return;
+	}
+
+	setStarted();
+	control_->setTolerance(changeToleranceControlInfo()->tolerance());
+	setSucceeded();
+}

--- a/source/actions3/actions/AMChangeToleranceAction.h
+++ b/source/actions3/actions/AMChangeToleranceAction.h
@@ -1,0 +1,78 @@
+#ifndef AMCHANGETOLERANCEACTION_H
+#define AMCHANGETOLERANCEACTION_H
+
+#include "actions3/AMAction3.h"
+#include "actions3/actions/AMChangeToleranceActionInfo.h"
+
+class AMControl;
+
+#define AMCHANGETOLERANCEACTION_INVALID_CONTROL 570001
+#define AMCHANGETOLERANCEACTION_INVALID_NEW_TOLERANCE 570002
+
+/// This class changes the tolerance of the given control.
+class AMChangeToleranceAction : public AMAction3
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.  Requires and takes ownership of an existing AMChangeToleranceActionInfo.
+	Q_INVOKABLE AMChangeToleranceAction(AMChangeToleranceActionInfo *info, AMControl *control = 0, QObject *parent = 0);
+	/// Copy constructor.
+	AMChangeToleranceAction(const AMChangeToleranceAction &other);
+	/// Destructor.
+	~AMChangeToleranceAction();
+
+	/// Virtual copy constructor.
+	virtual AMAction3 *createCopy() const;
+
+	/// Returns the control that this action will watch.
+	AMControl *control() const { return control_; }
+	/// Sets the control used by this action.  This will generally not be used because the control will be provided by the constructor.
+	void setControl(AMControl *control) { control_ = control; }
+
+	// Re-implemented public functions
+	///////////////////////////////
+
+	/// Specify that we cannot pause (since AMControl cannot pause).  If we wanted to get fancy, we might check if the control could stop, (and stop it for pause, and then start it again to resume). But this is much simpler for now.
+	virtual bool canPause() const { return false; }
+	/// This action cannot skip.
+	virtual bool canSkip() const { return false; }
+
+	/// Virtual function that denotes that this action has children underneath it or not.
+	virtual bool hasChildren() const { return false; }
+	/// Virtual function that returns the number of children for this action.
+	virtual int numberOfChildren() const { return 0; }
+
+protected:
+
+	// The following functions are used to define the unique behaviour of the action.  We set them up in this way so that subclasses don't need to worry about (and cannot) break the state machine logic, they only need to fill in their pieces.
+
+	// These virtual functions allow us to implement our unique action behaviour.  They are called at the appropriate time by the base class, when base-class-initiated state changes happen: ->Starting, ->Cancelling, ->Pausing, ->Resuming
+	/////////////////////////
+	/// This function is called from the Starting state when the implementation should initiate the action. Once the action is started, you should call notifyStarted().
+	virtual void startImplementation();
+
+	/// For actions which support pausing, this function is called from the Pausing state when the implementation should pause the action. Once the action is paused, you should call notifyPaused().  The base class implementation does nothing and must be re-implemented.
+	virtual void pauseImplementation() { setPaused(); }
+
+	/// For actions that support resuming, this function is called from the Paused state when the implementation should resume the action. Once the action is running again, you should call notifyResumed().
+	virtual void resumeImplementation() { setResumed(); }
+
+	/// All implementations must support cancelling. This function will be called from the Cancelling state. Implementations will probably want to examine the previousState(), which could be any of Starting, Running, Pausing, Paused, or Resuming. Once the action is cancelled and can be deleted, you should call notifyCancelled().
+	/*! \note If startImplementation() was never called, you won't receive this when a user tries to cancel(); the base class will handle it for you. */
+	virtual void cancelImplementation() { setCancelled(); }
+
+	/// Since this action does not support skipping, the method is empty.
+	virtual void skipImplementation(const QString &command) { Q_UNUSED(command); }
+
+	/// We can always access our info object via info_ or info(), but it will come back as a AMActionInfo* pointer that we would need to cast to AMControlMoveActionInfo. This makes it easier to access.
+	const AMChangeToleranceActionInfo* changeToleranceControlInfo() const { return qobject_cast<const AMChangeToleranceActionInfo *>(info()); }
+	/// We can always access our info object via info_ or info(), but it will come back as a AMActionInfo* pointer that we would need to cast to AMControlMoveActionInfo. This makes it easier to access.
+	AMChangeToleranceActionInfo *changeToleranceControlInfo() { return qobject_cast<AMChangeToleranceActionInfo *>(info()); }
+
+
+	/// A pointer to the AMControl we use to implement the action
+	AMControl* control_;
+};
+
+#endif // AMCHANGETOLERANCEACTION_H

--- a/source/actions3/actions/AMChangeToleranceActionInfo.cpp
+++ b/source/actions3/actions/AMChangeToleranceActionInfo.cpp
@@ -1,0 +1,45 @@
+#include "AMChangeToleranceActionInfo.h"
+
+AMChangeToleranceActionInfo::AMChangeToleranceActionInfo(const AMControlInfo &control, double newTolerance, QObject *parent)
+	: AMActionInfo3("Change Tolerance", "Change Tolerance", QString(), parent)
+{
+	controlInfo_ = control;
+	tolerance_ = newTolerance;
+}
+
+AMChangeToleranceActionInfo::AMChangeToleranceActionInfo(const AMChangeToleranceActionInfo &other)
+	: AMActionInfo3(other)
+{
+	controlInfo_.setValuesFrom(other.controlInfo());
+	tolerance_ = other.tolerance();
+}
+
+AMChangeToleranceActionInfo::~AMChangeToleranceActionInfo()
+{
+
+}
+
+AMActionInfo3 *AMChangeToleranceActionInfo::createCopy() const
+{
+	AMActionInfo3 *info = new AMChangeToleranceActionInfo(*this);
+	info->dissociateFromDb(true);
+	return info;
+}
+
+void AMChangeToleranceActionInfo::setControlInfo(const AMControlInfo &controlInfo)
+{
+	controlInfo_.setValuesFrom(controlInfo);
+	setModified(true);
+}
+
+void AMChangeToleranceActionInfo::setTolerance(double newTolerance)
+{
+	if (newTolerance <= 0)
+		return;
+
+	if (newTolerance == tolerance_){
+
+		tolerance_ = newTolerance;
+		setModified(true);
+	}
+}

--- a/source/actions3/actions/AMChangeToleranceActionInfo.h
+++ b/source/actions3/actions/AMChangeToleranceActionInfo.h
@@ -1,0 +1,63 @@
+#ifndef AMCHANGETOLERANCEACTIONINFO_H
+#define AMCHANGETOLERANCEACTIONINFO_H
+
+#include "actions3/AMActionInfo3.h"
+#include "dataman/info/AMControlInfo.h"
+
+/// This class changes the tolerance of the control associated with the given control info to a new value.
+class AMChangeToleranceActionInfo : public AMActionInfo3
+{
+	Q_OBJECT
+
+	Q_PROPERTY(AMDbObject* controlInfo READ dbReadControlInfo WRITE dbLoadControlInfo)
+	Q_PROPERTY(double tolerance READ tolerance WRITE setTolerance)
+
+public:
+
+	/// Constructor.
+	Q_INVOKABLE AMChangeToleranceActionInfo(const AMControlInfo &control = AMControlInfo(), double newTolerance = 0.0, QObject *parent = 0);
+	/// Copy constructor.
+	AMChangeToleranceActionInfo(const AMChangeToleranceActionInfo &other);
+	/// Destructor.
+	~AMChangeToleranceActionInfo();
+
+	/// This function is used as a virtual copy constructor.
+	virtual AMActionInfo3 *createCopy() const;
+
+	// Re-implemented public functions
+	/////////////////////////////////
+
+	/// This should describe the type of the action
+	virtual QString typeDescription() const { return "Control Wait"; }
+
+	// New public functions
+	//////////////////////////
+
+	/// Returns a pointer to our move destination setpoint
+	const AMControlInfo& controlInfo() const { return controlInfo_; }
+
+	/// Returns our timeout.
+	double tolerance() const { return tolerance_; }
+
+	/// Set the move destination setpoint, including the control name, value, and description.
+	/*! \note We make a copy of \c controlInfo's values, and do not retain any reference to it afterward. */
+	void setControlInfo(const AMControlInfo& controlInfo);
+	/// Set new tolerance value (value only).
+	void setTolerance(double newTolerance);
+
+protected:
+	// Database loading/storing
+	////////////////////////////
+
+	/// For database storing only.
+	AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
+	/// For database loading only. This function will never be called since dbReadControlInfo() always returns a valid setpoint, but it needs to be here.
+	void dbLoadControlInfo(AMDbObject* newLoadedObject) { newLoadedObject->deleteLater(); }
+
+	/// The AMControlInfo that specifies where to move to
+	AMControlInfo controlInfo_;
+	/// The max time to wait for the control to reach a setpoint. (seconds)
+	double tolerance_;
+};
+
+#endif // AMCHANGETOLERANCEACTIONINFO_H

--- a/source/application/AMAppController.cpp
+++ b/source/application/AMAppController.cpp
@@ -54,6 +54,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/actions/AMControlWaitActionInfo.h"
 #include "actions3/actions/AMWaitAction.h"
 #include "actions3/editors/AMWaitActionEditor.h"
+#include "actions3/actions/AMChangeToleranceAction.h"
 
 #include "application/AMAppControllerSupport.h"
 #include "acquaman/AMDetectorTriggerSourceScanOptimizer.h"
@@ -97,7 +98,7 @@ bool AMAppController::startup(){
 		success &= AMActionRegistry3::s()->registerInfoAndEditor<AMWaitActionInfo, AMWaitActionEditor>();
 
 		success &= AMActionRegistry3::s()->registerInfoAndAction<AMControlWaitActionInfo, AMControlWaitAction>("Wait for Control", "Wait for Control", ":system-run.png", false);
-
+		success &= AMActionRegistry3::s()->registerInfoAndAction<AMChangeToleranceActionInfo, AMChangeToleranceAction>("Change Tolerance Action", "Changes the tolerance of a specific control.", ":/user-away.png", false);
 		AMAgnosticDataMessageQEventHandler *scanActionMessager = new AMAgnosticDataMessageQEventHandler();
 		AMAgnosticDataAPISupport::registerHandler("ScanActions", scanActionMessager);
 

--- a/source/application/AMDatamanAppControllerForActions3.cpp
+++ b/source/application/AMDatamanAppControllerForActions3.cpp
@@ -49,6 +49,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/actions/AMDoDarkCurrentCorrectionActionInfo.h"
 #include "actions3/actions/AMDoingDarkCurrentCorrectionActionInfo.h"
 #include "actions3/actions/AMWaitActionInfo.h"
+#include "actions3/actions/AMChangeToleranceActionInfo.h"
 
 #include "util/AMErrorMonitor.h"
 
@@ -173,9 +174,8 @@ bool AMDatamanAppControllerForActions3::startupRegisterDatabases()
 	AMDbObjectSupport::s()->registerClass<AMAxisFinishedActionInfo>();
 	AMDbObjectSupport::s()->registerClass<AMAxisValueFinishedActionInfo>();
 	AMDbObjectSupport::s()->registerClass<AMWaitActionInfo>();
-
+	AMDbObjectSupport::s()->registerClass<AMChangeToleranceActionInfo>();
 	AMDbObjectSupport::s()->registerClass<AMControlWaitActionInfo>();
-
 	AMDbObjectSupport::s()->registerClass<AMDoDarkCurrentCorrectionActionInfo>();
 	AMDbObjectSupport::s()->registerClass<AMDoingDarkCurrentCorrectionActionInfo>();
 


### PR DESCRIPTION
Made an action for changing the tolerance of an AMControl.  I did not add it inside of AMControl, but I did make a convenience creation method inside of AMActionSupport.  Tested it out on VESPERSXASScanController and it appeared to work just fine.