### PR TITLE
Pull Request for Issue1154: Plot scaling issues?

### DIFF
--- a/source/dataman/datasource/AMDataSourceImageData.cpp
+++ b/source/dataman/datasource/AMDataSourceImageData.cpp
@@ -311,7 +311,7 @@ void AMDataSourceImageData::updateCachedValues() const
 		}
 
 		// The default range is invalid.
-		if (range_.isNull())
+		if (range_.isNull() || dirtyRectBottomLeft_.totalPointsTo(dirtyRectTopRight_) == xSize_*ySize_)
 			range_ = MPlotRange(rangeMinimum, rangeMaximum);
 
 		else {

--- a/source/dataman/datasource/AMDataSourceSeriesData.cpp
+++ b/source/dataman/datasource/AMDataSourceSeriesData.cpp
@@ -189,7 +189,7 @@ void AMDataSourceSeriesData::updateCachedValues() const
 		double rangeMinimum = newData.first();
 		double rangeMaximum = newData.first();
 
-		for (int i = 0, iSize = axisSize_; i < iSize; i++){
+		for (int i = 0; i < size; i++){
 
 			double newValue = newData.at(i);
 
@@ -203,7 +203,7 @@ void AMDataSourceSeriesData::updateCachedValues() const
 		}
 
 		// The default range is invalid.
-		if (!dataRange_.isValid())
+		if (!dataRange_.isValid() || size == axisSize_)
 			dataRange_ = AMRange(rangeMinimum, rangeMaximum);
 
 		else {


### PR DESCRIPTION
Added an extra condition on setting the range where if the entire data was searched that it would set the range regardless.  Added it to both AMDataSourceSeriesData and AMDataSourceImageData.  Found a potential crash bug that makes me sad.  In AMDataSourceSeriesData, it was always going through all of the data but offsetting the input data by the minimum of the dirty range.  This never caused a crash because we always have gone through ever piece of data.  That is a little disappointing.  Looks like data handling will need another revisiting sometime because I really want data handling to be efficient.

@epengr, after this is merged in, could you redo the tests that caused you to create #1154?  If they still persist, just make another issue.