### PR TITLE
Pull Request for Issue1183: release the AMProcessWatcher objects

### DIFF
--- a/source/application/AMCrashReporter.cpp
+++ b/source/application/AMCrashReporter.cpp
@@ -394,5 +394,5 @@ void AMProcessWatcher::onProcessReadReady(){
 }
 
 void AMProcessWatcher::onProcessFinished(){
-	emit foundWatchPID(foundProcess_, instanceID_);
+	emit foundWatchPID(foundProcess_, instanceID());
 }


### PR DESCRIPTION
https://github.com/acquaman/acquaman/issues/1183

AMCrashMonitor created instances of AMProcessWatcher, but never release them. These instances will stay in memory until AMCrashMonitor is terminated, which will cause memory leak since AMCrashMonitor will only stop if the beamline acquaman is closed.

@dretrex @davidChevrier 