### PR TITLE
Pull Request for Issue1173: Export controller in AMScanAction used for auto-export is never deleted.

### DIFF
--- a/source/actions3/actions/AMScanAction.cpp
+++ b/source/actions3/actions/AMScanAction.cpp
@@ -371,7 +371,7 @@ void AMScanAction::autoExportScan()
 
 			if (config->autoExportEnabled()){
 
-				AMExportController *exportController = new AMExportController(QList<AMScan *>() << controller_->scan());
+				AMExportController *exportController = new AMExportController(QList<AMScan *>() << controller_->scan(), this);
 
 				// This needs to be generalized so the user can set it (on beamlines where this is acceptable)
 				//QDir exportDir(AMUserSettings::userDataFolder);

--- a/source/dataman/export/AMExportController.cpp
+++ b/source/dataman/export/AMExportController.cpp
@@ -40,8 +40,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 QHash<QString, AMExporterInfo> AMExportController::registeredExporters_;
 
-AMExportController::AMExportController(const QList<QUrl>& scansToExport) :
-	QObject()
+AMExportController::AMExportController(const QList<QUrl> &scansToExport, QObject *parent)
+	: QObject(parent)
 {
 	usingScanURLs_ = true;
 	usingScanObjects_ = false;
@@ -67,8 +67,8 @@ AMExportController::AMExportController(const QList<QUrl>& scansToExport) :
 		destinationFolderPath_ = QDir::toNativeSeparators(QDir::homePath());
 }
 
-AMExportController::AMExportController(const QList<AMScan*>& scansToExport) :
-	QObject()
+AMExportController::AMExportController(const QList<AMScan*>& scansToExport, QObject *parent)
+	: QObject(parent)
 {
 	usingScanObjects_ = true;
 	usingScanURLs_ = false;
@@ -351,9 +351,12 @@ void AMExportController::continueScanExport()
 
 }
 
-void AMExportController::setOption(AMExporterOption *option) {
+void AMExportController::setOption(AMExporterOption *option)
+{
 	option_->deleteLater();
 	option_ = option;
+	option_->setParent(this);
+
 	if(option_)
 		option_->setAvailableDataSourcesModel(availableDataSourcesModel());
 }

--- a/source/dataman/export/AMExportController.h
+++ b/source/dataman/export/AMExportController.h
@@ -34,7 +34,7 @@ class QStandardItemModel;
 class AMExporterInfo {
 public:
 	/// Constructor (Default values make an invalid AMExporterInfo)
- 	virtual ~AMExporterInfo();
+	virtual ~AMExporterInfo();
 	AMExporterInfo(const QMetaObject* exporterMetaObject = 0, QString exporterDescription = QString(), QString exporterOptionClassName = QString(), QString exporterLongDescription = QString() )
 		: description(exporterDescription),
 		  optionClassName(exporterOptionClassName),
@@ -92,9 +92,9 @@ public:
 	};
 
 	/// Construct an AMExportController with a list of Urls to the scan items you wish to export.  The URLs should be in the amd://databaseConnectionName/tableName/objectId format.  The controller will supervise the rest of the process, and delete itself when finished (or cancelled).
-	explicit AMExportController(const QList<QUrl>& scansToExport);
+	explicit AMExportController(const QList<QUrl>& scansToExport, QObject *parent = 0);
 
-	explicit AMExportController(const QList<AMScan*>& scansToExport);
+	explicit AMExportController(const QList<AMScan*>& scansToExport, QObject *parent = 0);
 
 	virtual ~AMExportController();
 


### PR DESCRIPTION
Added:
- Proper parenting to the AMExportController.
- Setting the parent of the AMExporterOption to the AMExportController
so it cleans up its memory when it's done.

Altered:
- The constructor of the export controller in AMScanAction to have the
export controller be a child object of it.  That way it gets cleaned up
properly.