### PR TITLE
Pull request for Issue1160: IDEAS sample stage motor control tweaks

### DIFF
--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -64,7 +64,7 @@ void IDEASBeamline::setupMotorGroup()
 	AMMotorGroupObject *motorObject = 0;
 	motorGroup_ = new AMMotorGroup(this);
 	motorObject = new AMMotorGroupObject("Sample Platform",
-							       QStringList() << "X" << "Y",
+							       QStringList() << "X" << "Z",
 							       QStringList() << "mm" << "mm",
 							       QList<AMControl*>() << samplePlatformHorizontal_ << samplePlatformVertical_,
 							       QList<AMMotorGroupObject::Orientation>() << AMMotorGroupObject::Horizontal << AMMotorGroupObject::Vertical,

--- a/source/ui/IDEAS/IDEASSampleCameraPanel.cpp
+++ b/source/ui/IDEAS/IDEASSampleCameraPanel.cpp
@@ -25,11 +25,20 @@ IDEASSampleCameraPanel::IDEASSampleCameraPanel(QWidget *parent) :
 	sampleMotorGroupView_->setMaximumWidth(250);
 
 	vacuumMotorGroupView_ = new AMMotorGroupObjectView(IDEASBeamline::ideas()->vacuumStageMotorGroupObject());
+	vacuumMotorGroupView_->jogSpinBox()->setMaximum(25);
+	vacuumMotorGroupView_->jogSpinBox()->setMinimum(0);
 	vacuumMotorGroupView_->jogSpinBox()->setValue(1);
 	vacuumMotorGroupView_->jogSpinBox()->setSingleStep(0.5);
 	vacuumMotorGroupView_->jogSpinBox()->setDecimals(1);
+
+
 	foreach(QDoubleSpinBox *cSP, vacuumMotorGroupView_->controlSetpointsSpinBoxes())
+	{
 		cSP->setDecimals(1);
+		cSP->setMaximum(150);
+		cSP->setMinimum(-10);
+	}
+
 	vacuumMotorGroupView_->setMaximumWidth(250);
 
 


### PR DESCRIPTION
Issue #1160
Changed sample stage vertical to 'z' instead of 'y'
Changed limits on spin box value for vacuum sample motor stage