### PR TITLE
Pull Request for Issue1175: ROI markers have some weird visualization behaviour

### DIFF
--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -58,7 +58,7 @@ AMXRFDetailedDetectorView::AMXRFDetailedDetectorView(AMXRFDetector *detector, QW
 	combinationElement_ = periodicTable_->elementBySymbol("Ca");
 
 	regionOfInterestMapper_ = new QSignalMapper(this);
-	connect(regionOfInterestMapper_, SIGNAL(mapped(int)), this, SLOT(onRegionOfInterestBoundsChanged(int)));
+	connect(regionOfInterestMapper_, SIGNAL(mapped(QObject*)), this, SLOT(onRegionOfInterestBoundsChanged(QObject*)));
 
 	deadTimeViewFactor_ = int(sqrt(double(detector->elements())));
 }
@@ -467,33 +467,22 @@ void AMXRFDetailedDetectorView::onEmissionLineSelected(const AMEmissionLine &emi
 		detector_->addRegionOfInterest(emissionLine);
 
 	AMRegionOfInterest *newRegion = detector_->regionOfInterest(emissionLine);
-	regionOfInterestMapper_->setMapping(newRegion, regionOfInterestMarkers_.size());
+	regionOfInterestMapper_->setMapping(newRegion, newRegion);
 	connect(newRegion, SIGNAL(boundingRangeChanged(AMRange)), regionOfInterestMapper_, SLOT(map()));
 
 	MPlotMarkerTransparentVerticalRectangle *newMarker = new MPlotMarkerTransparentVerticalRectangle(newRegion->name(), newRegion->energy(), newRegion->lowerBound(), newRegion->upperBound());
 	plot_->insertItem(newMarker);
 	newMarker->setYAxisTarget(plot_->axisScale(MPlot::VerticalRelative));
-	regionOfInterestMarkers_.insert(emissionLine, newMarker);
+	regionOfInterestMarkers_.insert(newRegion, newMarker);
 
-	updatePeriodicTableButtonColors(emissionLine);
+	updatePeriodicTableButtonColors(emissionLine.elementSymbol());
 	editRegionsOfInterestButton_->setEnabled(detector_->regionsOfInterestCount() > 0);
 }
 
 void AMXRFDetailedDetectorView::onEmissionLineDeselected(const AMEmissionLine &emissionLine)
 {
-	MPlotItem *itemToBeRemoved = regionOfInterestMarkers_.value(emissionLine);
-
-	if (itemToBeRemoved){
-
-			regionOfInterestMapper_->removeMappings(detector_->regionOfInterest(emissionLine));
-			detector_->removeRegionOfInterest(emissionLine);
-			plot_->removeItem(itemToBeRemoved);
-			regionOfInterestMarkers_.remove(emissionLine);
-			delete itemToBeRemoved;
-
-			updatePeriodicTableButtonColors(emissionLine);
-			editRegionsOfInterestButton_->setEnabled(detector_->regionsOfInterestCount() > 0);
-	}
+	AMRegionOfInterest *region = detector_->regionOfInterest(emissionLine);
+	removeRegionOfInterestItems(region);
 }
 
 void AMXRFDetailedDetectorView::onRegionOfInterestAdded(AMRegionOfInterest *newRegion)
@@ -542,19 +531,15 @@ void AMXRFDetailedDetectorView::removeAllEmissionLineMarkers()
 
 void AMXRFDetailedDetectorView::removeAllRegionsOfInterest()
 {
-	foreach (MPlotMarkerTransparentVerticalRectangle *item, regionOfInterestMarkers_){
-
-		AMEmissionLine line = regionOfInterestMarkers_.key(item);
-		AMSelectableElement *element = qobject_cast<AMSelectableElement *>(periodicTable_->elementBySymbol(line.elementSymbol()));
-		element->deselectEmissionLine(line);
-	}
+	foreach (AMRegionOfInterest *region, detector_->regionsOfInterest())
+		removeRegionOfInterestItems(region);
 
 	elementView_->setElement(elementView_->element());
 }
 
-void AMXRFDetailedDetectorView::updatePeriodicTableButtonColors(const AMEmissionLine &line)
+void AMXRFDetailedDetectorView::updatePeriodicTableButtonColors(const QString &symbol)
 {
-	AMSelectableElement *element = qobject_cast<AMSelectableElement *>(periodicTable_->elementBySymbol(line.elementSymbol()));
+	AMSelectableElement *element = qobject_cast<AMSelectableElement *>(periodicTable_->elementBySymbol(symbol));
 
 	if (element){
 
@@ -566,12 +551,12 @@ void AMXRFDetailedDetectorView::updatePeriodicTableButtonColors(const AMEmission
 				keyString << line.lineName().left(1);
 
 			keyString.removeDuplicates();
-			periodicTableView_->button(periodicTable_->elementBySymbol(line.elementSymbol()))->setStyleSheet(buildStyleSheet(keyString.join("")));
+			periodicTableView_->button(periodicTable_->elementBySymbol(symbol))->setStyleSheet(buildStyleSheet(keyString.join("")));
 		}
 
 		else{
 
-			periodicTableView_->button(periodicTable_->elementBySymbol(line.elementSymbol()))->setStyleSheet(buildStyleSheet("Default"));
+			periodicTableView_->button(periodicTable_->elementBySymbol(symbol))->setStyleSheet(buildStyleSheet("Default"));
 		}
 	}
 }
@@ -826,11 +811,11 @@ void AMXRFDetailedDetectorView::onDeadTimeButtonClicked()
 	}
 }
 
-void AMXRFDetailedDetectorView::onRegionOfInterestBoundsChanged(int id)
+void AMXRFDetailedDetectorView::onRegionOfInterestBoundsChanged(QObject *id)
 {
-	AMRegionOfInterest *region = qobject_cast<AMRegionOfInterest *>(regionOfInterestMapper_->mapping(id));
-	regionOfInterestMarkers_.values().at(id)->setLowEnd(region->lowerBound());
-	regionOfInterestMarkers_.values().at(id)->setHighEnd(region->upperBound());
+	AMRegionOfInterest *region = qobject_cast<AMRegionOfInterest *>(id);
+	regionOfInterestMarkers_.value(region)->setLowEnd(region->lowerBound());
+	regionOfInterestMarkers_.value(region)->setHighEnd(region->upperBound());
 }
 
 void AMXRFDetailedDetectorView::onLogScaleClicked(bool logScale)
@@ -872,5 +857,23 @@ void AMXRFDetailedDetectorView::hidePeriodicTableViews(bool setHidden){
 	else if(!setHidden && bottomLayoutWidget_->isHidden()){
 		periodicTableHeaderButton_->setArrowType(Qt::DownArrow);
 		bottomLayoutWidget_->show();
+	}
+}
+
+void AMXRFDetailedDetectorView::removeRegionOfInterestItems(AMRegionOfInterest *region)
+{
+	MPlotItem *itemToBeRemoved = regionOfInterestMarkers_.value(region);
+
+	if (itemToBeRemoved){
+
+		QString regionName = region->name();
+		regionOfInterestMapper_->removeMappings(region);
+		plot_->removeItem(itemToBeRemoved);
+		regionOfInterestMarkers_.remove(region);
+		delete itemToBeRemoved;
+		detector_->removeRegionOfInterest(region);
+
+		updatePeriodicTableButtonColors(regionName.split(" ").first());
+		editRegionsOfInterestButton_->setEnabled(detector_->regionsOfInterestCount() > 0);
 	}
 }

--- a/source/ui/beamline/AMXRFDetailedDetectorView.h
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.h
@@ -181,7 +181,7 @@ protected slots:
 	/// Handles changing the data sources used for the corrected sum PV.
 	void onDeadTimeButtonClicked();
 	/// Handles updating the region of interest markers using the signal mapper.
-	void onRegionOfInterestBoundsChanged(int id);
+	void onRegionOfInterestBoundsChanged(QObject *id);
 	/// Handles changing the scale of the axis to logarithmic or linear.
 	void onLogScaleClicked(bool logScale);
 	/// Handles setting the minimum energy after a new input from the spin box.
@@ -197,8 +197,8 @@ protected slots:
 protected:
 	/// Method that highlights the region of interest of the current element (if it has been selected).
 	void highlightCurrentElementRegionOfInterest();
-	/// Updates the buttons in the periodic table view based on the selected emission lines.  Uses the emission line for appropriate lookups.
-	void updatePeriodicTableButtonColors(const AMEmissionLine &line);
+	/// Updates the buttons in the periodic table view based on the selected emission lines.  Uses the element symbol for appropriate lookups.
+	void updatePeriodicTableButtonColors(const QString &symbol);
 	/// Method that builds the style sheet for the regions of interest color.  The key is a string that can have any of the keys mashed together (eg: "KL").  If multiple lines exist then it will make a linear gradient of multiple colors.  Subclasses can re-implement for different stylesheets.
 	virtual const QString buildStyleSheet(const QString &colorMapKey) const;
 	/// Method that builds the periodic table view and element view and adds it to the detector layout.
@@ -217,6 +217,8 @@ protected:
 	void removeAllPlotItems(QList<MPlotItem *> &items);
 	/// Method that takes two AMEmissionLines and adds them to the plot as a pile up peak if it would fit.
 	void addPileUpMarker(const AMEmissionLine &firstLine, const AMEmissionLine &secondLine);
+	/// Removes all the region of interest pieces from the view.
+	void removeRegionOfInterestItems(AMRegionOfInterest *region);
 
 	/// Helper method to show or hide the periodic table related views and fix the header button
 	void hidePeriodicTableViews(bool setHidden);
@@ -246,7 +248,7 @@ protected:
 	/// The list of emission line markers.
 	QList<MPlotItem *> emissionLineMarkers_;
 	/// A mapping of emission lines to region of interest markers.
-	QMap<AMEmissionLine, MPlotMarkerTransparentVerticalRectangle *> regionOfInterestMarkers_;
+	QMap<AMRegionOfInterest *, MPlotMarkerTransparentVerticalRectangle *> regionOfInterestMarkers_;
 	/// A signal mapper that maps the MPlotItems to the regions they represent.  Allows easy manipulation of the item's shape.
 	QSignalMapper *regionOfInterestMapper_;
 	/// A simple map for the line colors.


### PR DESCRIPTION
Turns out it was actually just a bad mapping on my part.  Thankfully, the bug was only in the markers and not the ROIs themselves.  Markers are now properly mapped to the regions of interest they represent.