### PR TITLE
Pull request for Issue1187: Update sort filter widget when proxy model is updated programatically

### DIFF
--- a/source/ui/dataman/AMBrowseScansView.cpp
+++ b/source/ui/dataman/AMBrowseScansView.cpp
@@ -185,9 +185,11 @@ QAbstractItemView *AMBrowseScansView::currentView()
 void AMBrowseScansView::setFilterRegExp(const QString &pattern)
 {
 	proxyModel_->setFilterRegExp(pattern);
+	sortFilterWidget_->setFilterRegExp(pattern);
 }
 
 void AMBrowseScansView::setFilterKeyColumn(int column)
 {
 	proxyModel_->setFilterKeyColumn(column);
+	sortFilterWidget_->setFilterKeyColumn(column);
 }

--- a/source/ui/dataman/AMBrowseScansView.cpp
+++ b/source/ui/dataman/AMBrowseScansView.cpp
@@ -75,6 +75,7 @@ int AMBrowseScansView::numberOfSelectedItems()
 void AMBrowseScansView::setRunId(int runId)
 {
 	proxyModel_->setRunId(runId);
+	sortFilterWidget_->setRunId(runId);
 }
 
 void AMBrowseScansView::setExperimentId(int experimentId)

--- a/source/ui/util/AMSortFilterScansWidget.cpp
+++ b/source/ui/util/AMSortFilterScansWidget.cpp
@@ -30,6 +30,14 @@ AMSortFilterScansWidget::AMSortFilterScansWidget(AMLightweightScanInfoFilterProx
 	filterBuilder_->formLayout()->addRow("Run: ", runComboBox_);
 }
 
+void AMSortFilterScansWidget::setRunId(int runId)
+{
+	if(runId == -1)
+		runComboBox_->setCurrentIndex(0);
+	else
+		runComboBox_->setCurrentIndex(runId);
+}
+
 void AMSortFilterScansWidget::onRunSelected(int index)
 {
 	AMLightweightScanInfoFilterProxyModel * scanModel =

--- a/source/ui/util/AMSortFilterScansWidget.h
+++ b/source/ui/util/AMSortFilterScansWidget.h
@@ -12,6 +12,7 @@ class AMSortFilterScansWidget : public AMSortFilterWidget
 public:
 	explicit AMSortFilterScansWidget(AMLightweightScanInfoFilterProxyModel *model, QWidget *parent = 0);
 	
+	void setRunId(int runId);
 signals:
 	
 public slots:

--- a/source/ui/util/AMSortFilterWidget.cpp
+++ b/source/ui/util/AMSortFilterWidget.cpp
@@ -62,6 +62,16 @@ QFormLayout* AMSortFilterBuilder::formLayout()
 	return layout_;
 }
 
+void AMSortFilterBuilder::setFilterRegExp(const QString &pattern)
+{
+	criteriaLineEdit_->setText(pattern);
+}
+
+void AMSortFilterBuilder::setFilterKeyColumn(int columnIndex)
+{
+	fieldComboBox_->setCurrentIndex(columnIndex);
+}
+
 void AMSortFilterBuilder::clear()
 {
 	criteriaLineEdit_->setText("");
@@ -112,6 +122,19 @@ bool AMSortFilterWidget::isCurrentlyFiltered()
 void AMSortFilterWidget::addManualColumn(const QString &header)
 {
 	filterBuilder_->addField(header);
+}
+
+void AMSortFilterWidget::setFilterRegExp(const QString &pattern)
+{
+	filterBuilder_->setFilterRegExp(pattern);
+
+	setCurrentlyFiltered(!pattern.isEmpty());
+
+}
+
+void AMSortFilterWidget::setFilterKeyColumn(int columnIndex)
+{
+	filterBuilder_->setFilterKeyColumn(columnIndex);
 }
 
 QSortFilterProxyModel *AMSortFilterWidget::proxyModel()

--- a/source/ui/util/AMSortFilterWidget.h
+++ b/source/ui/util/AMSortFilterWidget.h
@@ -36,6 +36,13 @@ public:
 	void clearFields();
 	/// Returns the form layout used to hold the FilterBuilder's Widgets
 	QFormLayout* formLayout();
+	/// Sets the text to display as the filter pattern. Used when a pattern is
+	/// set programatically as there is no signal from a proxy model to indicate
+	/// that a change has been made to its filter criteria.
+	void setFilterRegExp(const QString& pattern);
+	/// Sets the selected column of the field combo box to the provided index.
+	/// Used when a FilterKeyColumn is specified programatically.
+	void setFilterKeyColumn(int columnIndex);
 public slots:
 	/// Clears the search criteria
 	void clear();
@@ -65,6 +72,13 @@ public:
 	/// aren't in the top level, and so aren't automatically added to the widget. Caution, this may require
 	/// the proxy model to be customized in a way to accept such criteria.
 	void addManualColumn(const QString& header);
+	/// Sets the text to display as the filter pattern. Used when a pattern is
+	/// set programatically as there is no signal from a proxy model to indicate
+	/// that a change has been made to its filter criteria.
+	void setFilterRegExp(const QString& pattern);
+	/// Sets the selected column of the field combo box to the provided index.
+	/// Used when a FilterKeyColumn is specified programatically.
+	void setFilterKeyColumn(int columnIndex);
 signals:
 	/// Emitted whenever the filter the Widget is applying is altered
 	void filterChanged(bool);


### PR DESCRIPTION
Not really an ideal solution, as I'm just exposing elements of the filter widget to allow for manually matching its fields with those of the proxy model when changing the filter programatically. Unfortunately there isn't a signal in the proxy model for 'Filter Criteria Changed', not are any of the proxymodels 'setFilterxxx()' functions virtual - but this does do the job.

Also fixed the fact that the selected run in the filter widget wasn't matching the one selected in the left hand tree of runs.