### PR TITLE
Pull Request for Issue922: memcpy may not be safe to call on objects

### DIFF
--- a/source/dataman/datastore/AMInMemoryDataStore.cpp
+++ b/source/dataman/datastore/AMInMemoryDataStore.cpp
@@ -492,7 +492,8 @@ bool AMInMemoryDataStore::axisValues(int axisId, long axisStartIndex, long axisE
 		return false;
 #endif
 
-	memcpy(outputValues, (axisValues_.at(axisId).constData()+axisStartIndex), (axisEndIndex-axisStartIndex+1)*sizeof(AMNumber));
+	for (int i = 0, size = (axisEndIndex-axisStartIndex+1); i < size; i++)
+		outputValues[i] = axisValues_.at(axisId).at(i+axisStartIndex);
 
 	return true;
 }


### PR DESCRIPTION
Replaced the memcpy of AMNumber with a for loop to prevent any bad copying.  I elected to only fix the problem here rather than doing a wholescale revision of ```axisValues()``` to use ```double *``` since we are likely going to have to revisit this problem in the near future after @davidChevrier releases some of his work on the detector server stuff.