### PR TITLE
Pull Request for Issue1059: AMExportWizard seems to double populate the available exporters

### DIFF
--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -229,6 +229,9 @@ void VESPERSAppController::registerClasses()
 	AMOldDetectorViewSupport::registerClass<VESPERSCCDDetectorView, VESPERSMarCCDDetector>();
 	AMOldDetectorViewSupport::registerClass<VESPERSPilatusCCDDetectorView, VESPERSPilatusCCDDetector>();
 
+	AMExportController::unregisterExporter<AMSMAKExporter>();
+	AMExportController::unregisterExporter<AMExporter2DAscii>();
+
 	AMExportController::registerExporter<VESPERSExporter3DAscii>();
 	AMExportController::registerExporter<VESPERSExporter2DAscii>();
 	AMExportController::registerExporter<VESPERSExporterSMAK>();

--- a/source/dataman/export/AMExportController.h
+++ b/source/dataman/export/AMExportController.h
@@ -133,6 +133,23 @@ public:
 		return true;
 	}
 
+	template <class T>
+	static bool unregisterExporter()
+	{
+		const QMetaObject* mo = &(T::staticMetaObject);
+
+		QString className(mo->className());
+
+		if(!registeredExporters_.contains(className)) {
+
+			AMErrorMon::debug(0, 0, QString("Export Support: The class '%1' was not registered as an Exporter. Skipping unregistration.").arg(className));
+			return false;
+		}
+
+		registeredExporters_.remove(className);
+
+		return true;
+	}
 
 	/// Access the set of currently-registered exporters
 	static const QHash<QString, AMExporterInfo>& registeredExporters() { return registeredExporters_; }

--- a/source/dataman/export/VESPERS/VESPERSExporter2DAscii.h
+++ b/source/dataman/export/VESPERS/VESPERSExporter2DAscii.h
@@ -44,6 +44,9 @@ public:
 	/// Destructor.
 	virtual ~VESPERSExporter2DAscii();
 
+	/// Description of the exporter.
+	virtual QString description() const { return "VESPERS 2D Map Style (plain text file)"; }
+
 protected:
 	/// Method that writes the data in the main table, including the function names.
 	virtual void writeMainTable();

--- a/source/dataman/export/VESPERS/VESPERSExporter3DAscii.h
+++ b/source/dataman/export/VESPERS/VESPERSExporter3DAscii.h
@@ -45,7 +45,7 @@ public:
 	Q_INVOKABLE explicit VESPERSExporter3DAscii(QObject *parent = 0);
 
 	/// Description of the exporter.
-	virtual QString description() const { return "3D Map Style (plain text file)"; }
+	virtual QString description() const { return "VESPERS 3D Map Style (plain text file)"; }
 	/// More verbose description of the exporter.
 	virtual QString longDescription() const
 	{

--- a/source/dataman/export/VESPERS/VESPERSExporterLineScanAscii.h
+++ b/source/dataman/export/VESPERS/VESPERSExporterLineScanAscii.h
@@ -40,11 +40,11 @@ class VESPERSExporterLineScanAscii : public AMExporterGeneralAscii
 
 public:
 	/// Constructor.
- 	virtual ~VESPERSExporterLineScanAscii();
+	virtual ~VESPERSExporterLineScanAscii();
 	Q_INVOKABLE explicit VESPERSExporterLineScanAscii(QObject *parent = 0);
 
 	/// Description of the exporter.
-	virtual QString description() const { return "Line Scan Style (plain text file)"; }
+	virtual QString description() const { return "VESPERS Line Scan Style (plain text file)"; }
 	/// More verbose description of the exporter.
 	virtual QString longDescription() const {
 		return "The Line Scan Style file format creates one table of data in a plain text file where each data source is in a single column.  You can choose which data sources to include.";

--- a/source/dataman/export/VESPERS/VESPERSExporterSMAK.h
+++ b/source/dataman/export/VESPERS/VESPERSExporterSMAK.h
@@ -40,6 +40,9 @@ public:
 	/// Constructor.
 	virtual ~VESPERSExporterSMAK();
 
+	/// Description of the exporter.
+	virtual QString description() const { return "VESPERS SMAK 2D Map (plain text file)"; }
+
 protected:
 	/// Method that writes the data in the main table, including the function names.
 	virtual void writeMainTable();


### PR DESCRIPTION
I added another method to AMExportController which allows you to unregister an exporter.  This seemed like the most straight forward way of getting out the duplicates without having to do unnecessarily complex logic.  I could also imagine cases where you may want various subclasses as options.