### PR TITLE
Pull Request for Issue1194: Separate enable/disable elements from dead time buttons

### DIFF
--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -82,6 +82,8 @@ public:
 	virtual double deadTime() const;
 	/// Returns a specific dead time as a percentage.
 	virtual double deadTimeAt(int index) const;
+	/// Returns whether the element is enabled or not.  Elements are zero indexed.
+	bool isElementEnabled(int index) const;
 
 	// The dead time data sources.  Dead time corrections are input/output and to get the percentage, 1 - output/input.
 	/// Returns the input count data sources.
@@ -132,6 +134,11 @@ public slots:
 	/// Removes all regions of interest.
 	void removeAllRegionsOfInterest();
 
+	/// Enables the given element.  Elements are zero indexed.
+	void enableElement(int elementId);
+	/// Disables the given element.  Elements are zero indexed.
+	void disableElement(int elementId);
+
 signals:
 	/// Notifier that the elapsed time has updated.
 	void elapsedTimeChanged(double time);
@@ -143,6 +150,10 @@ signals:
 	void regionOfInterestBoundingRangeChanged(AMRegionOfInterest *);
 	/// Notifier that the dead time has updated.
 	void deadTimeChanged();
+	/// Notifier that an element has been enabled.  Passes the element ID.
+	void elementEnabled(int);
+	/// Notifier that an element has been disabled. Passes the element ID.
+	void elementDisabled(int);
 
 protected slots:
 	/// Determines if the detector is connected to ALL controls and process variables.
@@ -169,6 +180,8 @@ protected:
 	virtual void addRegionOfInterestImplementation(AMRegionOfInterest *newRegionOfInterest);
 	/// This function is callled if there is anythign extra you need to do when removing regions of interest.  Default behaviour does nothing extra.
 	virtual void removeRegionOfInterestImplementation(AMRegionOfInterest *regionOfInterest);
+	/// Helper function that updates the primary spectrum source to only use the enabled elements.
+	void updatePrimarySpectrumSources();
 
 	// Controls.  It is up to subclasses to ensure these are properly instantiated.
 	/// Control handling the acquire time.
@@ -200,6 +213,9 @@ protected:
 	QList<AMDataSource *> analyzedSpectraSources_;
 	/// The primary spectrum data source.  This is the data source that will be returned by AMDataSource::dataSource().
 	AMDataSource *primarySpectrumDataSource_;
+
+	/// The list of enabled elements.  Values are 0 indexed.
+	QList<int> enabledElements_;
 
 	// Regions of interest and their data sources.
 	/// List of all the regions of interest.

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -26,6 +26,15 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 AMDeadTimeButton::~AMDeadTimeButton(){}
 
+AMDeadTimeButton::AMDeadTimeButton(QWidget *parent)
+	: QToolButton(parent)
+{
+	inputCountSource_ = 0;
+	outputCountSource_ = 0;
+	goodReferencePoint_ = 0;
+	badReferencecPoint_ = 0;
+}
+
 AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, QWidget *parent)
 	: QToolButton(parent)
 {
@@ -61,14 +70,20 @@ void AMDeadTimeButton::paintEvent(QPaintEvent *e)
 
 	else if (!isChecked()){
 
-		double newValue = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
+		if (hasDeadTimeSources()){
 
-		if (newValue < goodReferencePoint_)
-			option.palette = QPalette(Qt::black, QColor(20, 220, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::green, QColor(0, 200, 0));
-		else if (newValue >= goodReferencePoint_ && newValue < badReferencecPoint_)
-			option.palette = QPalette(Qt::black, QColor(220, 220, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::yellow, QColor(200, 200, 0));
+			double newValue = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
+
+			if (newValue < goodReferencePoint_)
+				option.palette = QPalette(Qt::black, QColor(20, 220, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::green, QColor(0, 200, 0));
+			else if (newValue >= goodReferencePoint_ && newValue < badReferencecPoint_)
+				option.palette = QPalette(Qt::black, QColor(220, 220, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::yellow, QColor(200, 200, 0));
+			else
+				option.palette = QPalette(Qt::black, QColor(220, 20, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::red, QColor(200, 0, 0));
+		}
+
 		else
-			option.palette = QPalette(Qt::black, QColor(220, 20, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::red, QColor(200, 0, 0));
+			option.palette = QPalette(Qt::black, QColor(20, 220, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::green, QColor(0, 200, 0));
 	}
 
 	else
@@ -97,4 +112,9 @@ void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMData
 	outputCountSource_ = outputCountSource;
 	connect(inputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(update()));
 	connect(outputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(update()));
+}
+
+bool AMDeadTimeButton::hasDeadTimeSources() const
+{
+	return !(outputCountSource_ == 0 || inputCountSource_ == 0);
 }

--- a/source/ui/beamline/AMDeadTimeButton.h
+++ b/source/ui/beamline/AMDeadTimeButton.h
@@ -32,6 +32,8 @@ class AMDeadTimeButton : public QToolButton
 	Q_OBJECT
 
 public:
+	/// Constructor.  Makes a default button with no changing other than looking disabled.
+	AMDeadTimeButton(QWidget *parent = 0);
 	/// Constructor.  Takes two data sources (the data source is assumed to have rank 0), one for the input counts and one for the output counts, the good reference point, and the bad reference point.
 	AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, QWidget *parent = 0);
 	/// Destructor.
@@ -45,7 +47,7 @@ public:
 	double badReferencecPoint() const { return badReferencecPoint_; }
 
 public slots:
-	/// Sets a new data source for the dead time (the data source is assumed to have rank 0).
+	/// Sets a new data source for the dead time (the data source is assumed to have rank 0).  Sources can be 0/null pointers.
 	void setDeadTimeSources(AMDataSource *inputCountSource, AMDataSource *outputCountSource);
 	/// Sets the good reference point.
 	void setGoodReferencePoint(double newReference);
@@ -57,6 +59,8 @@ protected slots:
 	void onDeadTimeUpdated();
 
 protected:
+	/// Helper method that returns whether there are valid data sources or not.
+	bool hasDeadTimeSources() const;
 	/// Re-implemented paint event.
 	void paintEvent(QPaintEvent *e);
 

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -101,13 +101,28 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 	deadTimeButtons_->setExclusive(false);
 	QGridLayout *deadTimeButtonLayout = new QGridLayout;
 
-	for (int i = 0, elements = detector_->elements(); i < elements && deadTimeEnabled; i++){
+	if (deadTimeEnabled){
 
-		AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), detector_->outputCountSourceAt(i), 30.0, 50.0);
-		deadTimeButton->setCheckable(true);
-		deadTimeButton->setFixedSize(20, 20);
-		deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
-		deadTimeButtons_->addButton(deadTimeButton, i);
+		for (int i = 0, elements = detector_->elements(); i < elements; i++){
+
+			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), detector_->outputCountSourceAt(i), 30.0, 50.0);
+			deadTimeButton->setCheckable(true);
+			deadTimeButton->setFixedSize(20, 20);
+			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
+			deadTimeButtons_->addButton(deadTimeButton, i);
+		}
+	}
+
+	else {
+
+		for (int i = 0, elements = detector_->elements(); i < elements; i++){
+
+			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton;
+			deadTimeButton->setCheckable(true);
+			deadTimeButton->setFixedSize(20, 20);
+			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
+			deadTimeButtons_->addButton(deadTimeButton, i);
+		}
 	}
 
 	connect(deadTimeButtons_, SIGNAL(buttonClicked(int)), this, SLOT(onDeadTimeButtonClicked()));

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -125,7 +125,9 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 		}
 	}
 
-	connect(deadTimeButtons_, SIGNAL(buttonClicked(int)), this, SLOT(onDeadTimeButtonClicked()));
+	connect(deadTimeButtons_, SIGNAL(buttonClicked(int)), this, SLOT(onDeadTimeButtonClicked(int)));
+	connect(detector_, SIGNAL(elementEnabled(int)), this, SLOT(onElementEnabledOrDisabled(int)));
+	connect(detector_, SIGNAL(elementDisabled(int)), this, SLOT(onElementEnabledOrDisabled(int)));
 
 	QHBoxLayout *squeezedDeadTimeButtonsLayout = new QHBoxLayout;
 	squeezedDeadTimeButtonsLayout->addStretch();
@@ -812,18 +814,20 @@ void AMXRFDetailedDetectorView::onDeadTimeChanged()
 		deadTimeLabel_->setText(QString("Dead Time:\t%1%").arg(detector_->deadTime()*100, 0, 'f', 0));
 }
 
-void AMXRFDetailedDetectorView::onDeadTimeButtonClicked()
+void AMXRFDetailedDetectorView::onDeadTimeButtonClicked(int deadTimeButtonId)
 {
-	if (detector_->elements() > 1){
+	if (detector_->isElementEnabled(deadTimeButtonId))
+		detector_->disableElement(deadTimeButtonId);
 
-		QList<AMDataSource *> newSum;
+	else
+		detector_->enableElement(deadTimeButtonId);
+}
 
-		for (int i = 0, size = deadTimeButtons_->buttons().size(); i < size; i++)
-			if (!deadTimeButtons_->button(i)->isChecked())
-				newSum << (detector_->hasDeadTimeCorrection() ? detector_->analyzedSpectrumSources().at(i) : detector_->rawSpectrumSources().at(i));
-
-		((AMAnalysisBlock *)detector_->dataSource())->setInputDataSources(newSum);
-	}
+void AMXRFDetailedDetectorView::onElementEnabledOrDisabled(int elementId)
+{
+	deadTimeButtons_->blockSignals(true);
+	deadTimeButtons_->button(elementId)->setChecked(!detector_->isElementEnabled(elementId));
+	deadTimeButtons_->blockSignals(false);
 }
 
 void AMXRFDetailedDetectorView::onRegionOfInterestBoundsChanged(QObject *id)

--- a/source/ui/beamline/AMXRFDetailedDetectorView.h
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.h
@@ -179,7 +179,9 @@ protected slots:
 	/// Handles updating the dead time label.
 	void onDeadTimeChanged();
 	/// Handles changing the data sources used for the corrected sum PV.
-	void onDeadTimeButtonClicked();
+	void onDeadTimeButtonClicked(int deadTimeButtonId);
+	/// Handles updating the look of a button if it is enabled or not.
+	void onElementEnabledOrDisabled(int elementId);
 	/// Handles updating the region of interest markers using the signal mapper.
 	void onRegionOfInterestBoundsChanged(QObject *id);
 	/// Handles changing the scale of the axis to logarithmic or linear.


### PR DESCRIPTION
Moved the enabling and disabling from the dead time buttons to the AMXRFDetector model.  Tested using the BioXAS 32 element detector and the VESPERS vortex detectors.  It appears to work as intended.