### PR TITLE
Pull Request for Issue1084: Skip doesn't seem to work properly when executed from Paused state

### DIFF
--- a/source/acquaman/AMScanController.cpp
+++ b/source/acquaman/AMScanController.cpp
@@ -312,7 +312,8 @@ bool AMScanController::canChangeStateTo(AMScanController::ScanState newState)
 		break;
 
 	case AMScanController::Stopping :
-		canTransition = true;
+		if (isRunning())
+			canTransition = true;
 		break;
 
 	case AMScanController::Cancelling :

--- a/source/actions3/AMAction3.cpp
+++ b/source/actions3/AMAction3.cpp
@@ -369,7 +369,7 @@ bool AMAction3::canChangeState(State newState) const
 		break;
 
 	case Skipping:
-		if (canSkip() && (state_ == Running || state_ == Paused))
+		if (canSkip() && state_ == Running)
 			canTransition = true;
 		break;
 	}

--- a/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
+++ b/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
@@ -214,6 +214,19 @@ void AMActionRunnerCurrentViewBase::onStateChanged(int state, int previousState)
 
 	skipButton_->setEnabled(state == AMAction3::Running);
 
+	AMAction3 *action = actionRunner_->currentAction();
+
+	if (action){
+
+		if (action->canSkip() && state == AMAction3::Paused)
+			skipButton_->setToolTip("Can not skip while paused");
+
+		else if (action->canSkip() && action->skipOptions().size() == 1)
+			skipButton_->setToolTip(action->skipOptions().first());
+
+		else
+			skipButton_->setToolTip("Finish: Click for options");
+	}
 	// Can pause or resume from only these states:
 	if (actionRunner_->currentAction())
 		pauseButton_->setEnabled(actionRunner_->currentAction()->canPause() && (state == AMAction3::Running || state == AMAction3::Paused));

--- a/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
+++ b/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
@@ -212,6 +212,8 @@ void AMActionRunnerCurrentViewBase::onStateChanged(int state, int previousState)
 		pauseButton_->setToolTip("Pause the current action.");
 	}
 
+	skipButton_->setEnabled(state == AMAction3::Running);
+
 	// Can pause or resume from only these states:
 	if (actionRunner_->currentAction())
 		pauseButton_->setEnabled(actionRunner_->currentAction()->canPause() && (state == AMAction3::Running || state == AMAction3::Paused));


### PR DESCRIPTION
I changed the state machine to only allow actions to go into the skipping state if they are running.  This matches what the concept of skip was meant for.  I also updated the button inside the bottom bar and action runner current view to be disabled while not running.  This should prevent users from getting the state machine into a state that is unrecoverable and prevent weird hang ups.