### PR TITLE
Pull Request for Issue1220: Connect signals should be disconnect inside AMListAction disconnect action

### DIFF
--- a/source/actions3/AMListAction3.cpp
+++ b/source/actions3/AMListAction3.cpp
@@ -673,9 +673,9 @@ void AMListAction3::internalDisconnectAction(AMAction3 *action)
 	AMListAction3 *listAction = qobject_cast<AMListAction3 *>(action);
 	if (listAction){
 
-		connect(listAction, SIGNAL(scanActionCreated(AMScanAction*)), this, SIGNAL(scanActionCreated(AMScanAction*)));
-		connect(listAction, SIGNAL(scanActionStarted(AMScanAction*)), this, SIGNAL(scanActionStarted(AMScanAction*)));
-		connect(listAction, SIGNAL(scanActionFinished(AMScanAction*)), this, SIGNAL(scanActionFinished(AMScanAction*)));
+		disconnect(listAction, SIGNAL(scanActionCreated(AMScanAction*)), this, SIGNAL(scanActionCreated(AMScanAction*)));
+		disconnect(listAction, SIGNAL(scanActionStarted(AMScanAction*)), this, SIGNAL(scanActionStarted(AMScanAction*)));
+		disconnect(listAction, SIGNAL(scanActionFinished(AMScanAction*)), this, SIGNAL(scanActionFinished(AMScanAction*)));
 	}
 }
 


### PR DESCRIPTION
Changed some bad connect statements to disconnect, since that is what they were supposed to be.