### PR TITLE
Pull Request for Issue1233: Do NOT allow click event when it is a single element detector

### DIFF
--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -125,7 +125,11 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 		}
 	}
 
-	connect(deadTimeButtons_, SIGNAL(buttonClicked(int)), this, SLOT(onDeadTimeButtonClicked(int)));
+	if (deadTimeButtons_->buttons().size() > 1) {
+		connect(deadTimeButtons_, SIGNAL(buttonClicked(int)), this, SLOT(onDeadTimeButtonClicked(int)));
+	} else{
+		deadTimeButtons_->button(0)->setCheckable(false);
+	}
 	connect(detector_, SIGNAL(elementEnabled(int)), this, SLOT(onElementEnabledOrDisabled(int)));
 	connect(detector_, SIGNAL(elementDisabled(int)), this, SLOT(onElementEnabledOrDisabled(int)));
 


### PR DESCRIPTION
https://github.com/acquaman/acquaman/issues/1233

When the bruker detector is a single element detector, the deadtime button group will contain only one button. We should NOT allow user to disable the element at this scenario.

@davidChevrier @dretrex 