### PR TITLE
Pull Requet for Issue1236: AMXRFDetailedDetectorView does not remove ROI markers

### DIFF
--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -532,6 +532,7 @@ void AMXRFDetailedDetectorView::onRegionOfInterestRemoved(AMRegionOfInterest *re
 	if (!emissionLine.isNull()){
 
 		element->deselectEmissionLine(emissionLine);
+		removeRegionOfInterestItems(region);
 		elementView_->updateEmissionLineViewList();
 	}
 }


### PR DESCRIPTION
Added an explicit call to remove the region of interest items associated with a removed AMRegionOfInterest.