### PR TITLE
Pull Request for Issue1209 - IDEAS sidebar too large

### DIFF
--- a/source/ui/IDEAS/IDEASPersistentView.cpp
+++ b/source/ui/IDEAS/IDEASPersistentView.cpp
@@ -242,7 +242,6 @@ IDEASPersistentView::IDEASPersistentView(QWidget *parent) :
 	mainPanelLayout->addLayout(monoEnergyLayout);
 	mainPanelLayout->addWidget(monoCrystal_);
 	mainPanelLayout->addWidget(monoEnergyRange_);
-	//mainPanelLayout->addStretch();
 	mainPanelLayout->addWidget(stripTool_);
 
 	QVBoxLayout *scalerPanelLayout = new QVBoxLayout;

--- a/source/ui/IDEAS/IDEASPersistentView.cpp
+++ b/source/ui/IDEAS/IDEASPersistentView.cpp
@@ -231,15 +231,18 @@ IDEASPersistentView::IDEASPersistentView(QWidget *parent) :
 	beamChangeLayout->addWidget(beamOnButton_);
 	beamChangeLayout->addWidget(beamOffButton_);
 
+	QHBoxLayout *monoEnergyLayout = new QHBoxLayout;
+	monoEnergyLayout->addWidget(energyControlEditor_);
+	monoEnergyLayout->addWidget(calibrateButton_);
+
 	QVBoxLayout *mainPanelLayout = new QVBoxLayout;
 	mainPanelLayout->addWidget(ringCurrent_);
 	mainPanelLayout->addLayout(beamChangeLayout);
 	mainPanelLayout->addWidget(beamStatusLabel_, 0, Qt::AlignCenter);
-	mainPanelLayout->addWidget(energyControlEditor_);
-	mainPanelLayout->addWidget(calibrateButton_);
+	mainPanelLayout->addLayout(monoEnergyLayout);
 	mainPanelLayout->addWidget(monoCrystal_);
 	mainPanelLayout->addWidget(monoEnergyRange_);
-	mainPanelLayout->addStretch();
+	//mainPanelLayout->addStretch();
 	mainPanelLayout->addWidget(stripTool_);
 
 	QVBoxLayout *scalerPanelLayout = new QVBoxLayout;
@@ -258,10 +261,16 @@ IDEASPersistentView::IDEASPersistentView(QWidget *parent) :
 	layout->addWidget(jjSlitGroupBox_);
 	layout->addWidget(scalerPanel);
 
-	setLayout(layout);
-
+	setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+	setMaximumHeight(1000);
+	setMinimumHeight(800);
 	setMaximumWidth(400);
 	setMinimumWidth(400);
+
+	setLayout(layout);
+
+
+
 }
 
 void IDEASPersistentView::onBeamOnClicked()

--- a/source/ui/IDEAS/IDEASScalerView.cpp
+++ b/source/ui/IDEAS/IDEASScalerView.cpp
@@ -40,7 +40,7 @@ IDEASScalerView::IDEASScalerView(QWidget *parent)
 		view->setAmplifierViewFormat('g');
 		view->setAmplifierViewPrecision(3);
 		singleViews_ << view;
-		view->setFixedHeight(55);
+		view->setFixedHeight(40);
 		connect(view, SIGNAL(amplifierViewModeChanged(AMCurrentAmplifierView::ViewMode)), this, SLOT(onSR570ViewChanged(AMCurrentAmplifierView::ViewMode)) );
 		connect(view, SIGNAL(outputViewModeChanged(CLSSIS3820ScalerChannelView::OutputViewMode)), this, SLOT(onOutputViewModeChanged(CLSSIS3820ScalerChannelView::OutputViewMode)));
 		layout->addWidget(view);

--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorViewWithSave.cpp
@@ -31,6 +31,8 @@ IDEASXRFDetailedDetectorViewWithSave::IDEASXRFDetailedDetectorViewWithSave(AMXRF
 {
 	config_ = new IDEASXRFScanConfiguration;
 
+	setMaximumHeight(885);
+
 	if (detector_->name() == "KETEK")
 		config_->setFluorescenceDetector(IDEASXRFScanConfiguration::Ketek);
 


### PR DESCRIPTION
Rearranged sidebar to save space only to find that it wasn't the problem.  Left changes, as they're more efficient.

Set a maximum size for the IDEASXRFDetailedDetectorViewWithSave so that it doesn't drive the AM App window too large for the screen.
 