### PR TITLE
PullRequest for issue1295: the :unit:setPosn pv for the CLSMAXvMotor can be used for calibration

### DIFF
--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -36,11 +36,7 @@ AMAction3* BioXASSSRLMonochromator::createCalibrateBraggPositionAction(double ne
 	AMAction3 *action = 0;
 
 	if (braggMotor()->isConnected()) {
-		// calculate the needed offset.
-		double newOffset = calculateBraggEncoderOffset(braggMotor()->value(), braggMotor()->encoderCalibrationAbsoluteOffset(), newPosition, braggMotor()->encoderCalibrationSlope());
-
-		// set the new offset.
-		action = braggMotor()->createEncoderCalibrationAbsoluteOffsetAction(newOffset);
+		action = braggMotor()->createEGUSetPositionAction(newPosition);
 	}
 
 	return action;
@@ -61,18 +57,6 @@ void BioXASSSRLMonochromator::setRegion(double newRegion)
 void BioXASSSRLMonochromator::calibrateBraggPosition(double newBraggPosition)
 {
 	if (braggMotor()->isConnected()) {
-		// calculate the needed encoder calibration offset.
-		double newEncoderOffset = calculateBraggEncoderOffset(braggMotor()->value(), braggMotor()->encoderCalibrationAbsoluteOffset(), newBraggPosition, braggMotor()->encoderCalibrationSlope());
-
-		// apply the new encoder offset.
-		braggMotor()->setEncoderCalibrationAbsoluteOffset(newEncoderOffset);
+		braggMotor()->setEGUSetPosition(newBraggPosition);
 	}
-}
-
-double BioXASSSRLMonochromator:: calculateBraggEncoderOffset(double oldPosition, double oldEncoderOffset, double newPosition, double encoderSlope)
-{
-	// Calculate the new offset.
-	double newEncoderOffset = oldEncoderOffset + (oldPosition - newPosition) / encoderSlope;
-
-	return newEncoderOffset;
 }

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.h
@@ -103,10 +103,6 @@ public slots:
 
 	/// Sets the calibrated bragg position.
 	void calibrateBraggPosition(double newPosition);
-
-private:
-	/// Returns the encoder calibration offset that would be needed to change the current bragg motor position to the newPosition.
-	static double calculateBraggEncoderOffset(double oldPosition, double oldEncoderOffset, double newPosition, double encoderSlope);
 };
 
 #endif // BIOXASSSRLMONOCHROMATOR_H

--- a/source/beamline/CLS/CLSMAXvMotor.cpp
+++ b/source/beamline/CLS/CLSMAXvMotor.cpp
@@ -42,6 +42,7 @@ CLSMAXvMotor::CLSMAXvMotor(const QString &name, const QString &baseName, const Q
 	EGUBaseVelocity_ = new AMPVControl(name+"EGUBaseVelocity", baseName+":vBase"+pvUnitFieldName+"ps:sp", baseName+":vBase"+pvUnitFieldName+"ps", QString(), this, 0.05);
 	EGUAcceleration_ = new AMPVControl(name+"EGUAcceleration", baseName+":acc"+pvUnitFieldName+"pss:sp", baseName+":accel"+pvUnitFieldName+"pss", QString(), this, 2);
 	EGUCurrentVelocity_ = new AMReadOnlyPVControl(name+"EGUCurrentVelocity", baseName+":vel"+pvUnitFieldName+"ps:fbk", this);
+	EGUSetPosition_ = new AMPVControl(name+"EGUSetPostion", baseName+pvUnitFieldName+":setPosn", baseName+pvUnitFieldName+":setPosn", QString(), this, 0.005);
 	EGUOffset_ = new AMPVControl(name+"EGUOffset", baseName+pvUnitFieldName+":offset", baseName+pvUnitFieldName+":offset", QString(), this, 0.005);
 
 	step_ = new AMPVControl(name+"Step", baseName+":step:sp", baseName+":step", QString(), this, 20);
@@ -91,6 +92,8 @@ CLSMAXvMotor::CLSMAXvMotor(const QString &name, const QString &baseName, const Q
 	connect(EGUAcceleration_, SIGNAL(valueChanged(double)), this, SIGNAL(EGUAccelerationChanged(double)));
 	connect(EGUCurrentVelocity_, SIGNAL(connected(bool)), this, SLOT(onPVConnected(bool)));
 	connect(EGUCurrentVelocity_, SIGNAL(valueChanged(double)), this, SIGNAL(EGUCurrentVelocityChanged(double)));
+	connect(EGUSetPosition_, SIGNAL(connected(bool)), this, SLOT(onPVConnected(bool)));
+	connect(EGUSetPosition_, SIGNAL(valueChanged(double)), this, SIGNAL(EGUSetPoistionChanged(double)));
 	connect(EGUOffset_, SIGNAL(connected(bool)), this, SLOT(onPVConnected(bool)));
 	connect(EGUOffset_, SIGNAL(valueChanged(double)), this, SIGNAL(EGUOffsetChanged(double)));
 
@@ -163,6 +166,7 @@ bool CLSMAXvMotor::isConnected() const{
 			&& EGUBaseVelocity_->isConnected()
 			&& EGUAcceleration_->isConnected()
 			&& EGUCurrentVelocity_->isConnected()
+			&& EGUSetPosition_->isConnected()
 			&& EGUOffset_->isConnected()
 			&& step_->isConnected()
 			&& stepVelocity_->isConnected()
@@ -243,6 +247,12 @@ double CLSMAXvMotor::EGUCurrentVelocity() const{
 	if(isConnected())
 		return EGUCurrentVelocity_->value();
 
+	return 0.0;
+}
+
+double CLSMAXvMotor::EGUSetPosition() const{
+	if(isConnected())
+		return EGUSetPosition_->value();
 	return 0.0;
 }
 
@@ -536,6 +546,14 @@ AMAction3 *CLSMAXvMotor::createEGUAccelerationAction(double EGUAcceleration)
 	return AMActionSupport::buildControlMoveAction(EGUAcceleration_, EGUAcceleration);
 }
 
+AMAction3 *CLSMAXvMotor::createEGUSetPositionAction(double EGUSetPosition)
+{
+	if(!isConnected())
+		return 0;
+
+	return AMActionSupport::buildControlMoveAction(EGUSetPosition_, EGUSetPosition);
+}
+
 AMAction3 *CLSMAXvMotor::createEGUOffsetAction(double EGUOffset)
 {
 	if(!isConnected())
@@ -749,6 +767,11 @@ void CLSMAXvMotor::setEGUBaseVelocity(double baseVelocity){
 void CLSMAXvMotor::setEGUAcceleration(double acceleration){
 	if(isConnected())
 		EGUAcceleration_->move(acceleration);
+}
+
+void CLSMAXvMotor::setEGUSetPosition(double EGUSetPosition){
+	if(isConnected())
+		EGUSetPosition_->move(EGUSetPosition);
 }
 
 void CLSMAXvMotor::setEGUOffset(double EGUOffset){

--- a/source/beamline/CLS/CLSMAXvMotor.h
+++ b/source/beamline/CLS/CLSMAXvMotor.h
@@ -120,6 +120,8 @@ public:
 	double EGUAcceleration() const;
 	/// Returns the (EGU) current velocity of the motor (zero when not moving, presumably non-zero when in motion).  Returns 0 if the motor isn't connected yet.
 	double EGUCurrentVelocity() const;
+	/// Returns the EGU set position of the motor. Returns 0 if the motor isn't connected yet.
+	double EGUSetPosition() const;
 	/// Returns the EGU offset of the motor. Returns 0 if the motor isn't connected yet.
 	double EGUOffset() const;
 
@@ -212,6 +214,8 @@ public:
 	AMAction3 *createEGUBaseVelocityAction(double EGUBaseVelocity);
 	/// Returns a newly created action to change the EGU acceleration. Returns 0 if the control is not connected.
 	AMAction3 *createEGUAccelerationAction(double EGUAcceleration);
+	/// Returns a newly created action to change the EGU Set Position. Returns 0 if the control is not connected.
+	AMAction3 *createEGUSetPositionAction(double EGUOffset);
 	/// Returns a newly created action to change the EGU offset. Returns 0 if the control is not connected.
 	AMAction3 *createEGUOffsetAction(double EGUOffset);
 
@@ -275,6 +279,8 @@ public slots:
 	void setEGUBaseVelocity(double EGUBaseVelocity);
 	/// Sets the (EGU) acceleration setting for the velocity profile
 	void setEGUAcceleration(double EGUAcceleration);
+	/// Sets the EGU offset for the motor
+	void setEGUSetPosition(double EGUSetPosition);
 	/// Sets the EGU offset for the motor
 	void setEGUOffset(double EGUOffset);
 
@@ -343,6 +349,8 @@ signals:
 	void EGUAccelerationChanged(double EGUAcceleration);
 	/// Emitted when the (EGU) current velocity reading changes
 	void EGUCurrentVelocityChanged(double EGUCurrentVelocity);
+	/// Emitted when the EGU set position changes
+	void EGUSetPositionChanged(double EGUSetPosition);
 	/// Emitted when the EGU offset changes
 	void EGUOffsetChanged(double EGUOffset);
 
@@ -451,6 +459,8 @@ protected:
 	AMPVControl *EGUAcceleration_;
 	/// Readonly control for actual (EGU) velocity feedback
 	AMReadOnlyPVControl *EGUCurrentVelocity_;
+	/// Read-write control for the EGU set position
+	AMPVControl *EGUSetPosition_;
 	/// Read-write control for the EGU offset
 	AMPVControl *EGUOffset_;
 


### PR DESCRIPTION
https://github.com/acquaman/acquaman/issues/1295

- Expose the ":unit:setPostn" for CLSMAXvMotor so that we can use it for calibration purpose
- modify the BioXASSRLMonochromator to use the new MAXv pv for calibration

@dretrex @davidChevrier @helfrij @beaured0 