### PR TITLE
Pull Request for Issue1309: Create a user configuration for BioXAS

### DIFF
--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -21,7 +21,8 @@ HEADERS += \
     source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h \
     source/ui/BioXAS/BioXASSIS3820ScalerChannelView.h \
     source/ui/BioXAS/BioXASSIS3820ScalerView.h \
-    source/ui/BioXAS/BioXASSIS3820ScalerChannelsView.h
+    source/ui/BioXAS/BioXASSIS3820ScalerChannelsView.h \
+    source/dataman/BioXAS/BioXASUserConfiguration.h
 
 SOURCES += \
 	source/beamline/BioXAS/BioXASPseudoMotorControl.cpp \
@@ -38,7 +39,10 @@ SOURCES += \
     source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp \
     source/ui/BioXAS/BioXASSIS3820ScalerChannelView.cpp \
     source/ui/BioXAS/BioXASSIS3820ScalerView.cpp \
-    source/ui/BioXAS/BioXASSIS3820ScalerChannelsView.cpp
+    source/ui/BioXAS/BioXASSIS3820ScalerChannelsView.cpp \
+    source/dataman/BioXAS/BioXASUserConfiguration.cpp
+
+
 
 
 

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -270,7 +270,7 @@ void BioXASSideAppController::onUserConfigurationLoadedFromDb()
 
 		AMRegionOfInterest *newRegion = region->createCopy();
 		detector->addRegionOfInterest(newRegion);
-//		configuration_->addRegionOfInterest(region);
+		configuration_->addRegionOfInterest(region);
 	}
 
 	// This is connected here because we want to listen to the detectors for updates, but don't want to double add regions on startup.
@@ -281,13 +281,13 @@ void BioXASSideAppController::onUserConfigurationLoadedFromDb()
 void BioXASSideAppController::onRegionOfInterestAdded(AMRegionOfInterest *region)
 {
 	userConfiguration_->addRegionOfInterest(region);
-//	configuration_->addRegionOfInterest(region);
+	configuration_->addRegionOfInterest(region);
 }
 
 void BioXASSideAppController::onRegionOfInterestRemoved(AMRegionOfInterest *region)
 {
 	userConfiguration_->removeRegionOfInterest(region);
-//	configuration_->removeRegionOfInterest(region);
+	configuration_->removeRegionOfInterest(region);
 }
 
 QGroupBox *BioXASSideAppController::createSqeezeGroupBoxWithView(QString title, QWidget *view)

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -52,6 +52,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/BioXAS/BioXAS32ElementGeDetectorView.h"
 #include "acquaman/BioXAS/BioXASXRFScanConfiguration.h"
 #include "ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h"
+#include "dataman/BioXAS/BioXASUserConfiguration.h"
 
 BioXASSideAppController::BioXASSideAppController(QObject *parent)
 	: AMAppController(parent)
@@ -61,6 +62,8 @@ BioXASSideAppController::BioXASSideAppController(QObject *parent)
 	configuration_ = 0;
 	configurationView_ = 0;
 	configurationViewHolder_ = 0;
+
+	userConfiguration_ = new BioXASUserConfiguration(this);
 }
 
 bool BioXASSideAppController::startup()
@@ -94,7 +97,15 @@ bool BioXASSideAppController::startup()
 		setupExporterOptions();
 		setupUserInterface();
 		makeConnections();
-        applyCurrentSettings();
+		applyCurrentSettings();
+
+		if (!userConfiguration_->loadFromDb(AMDatabase::database("user"), 1)){
+
+			userConfiguration_->storeToDb(AMDatabase::database("user"));
+			// This is connected here because our standard way for these signal connections is to load from db first, which clearly won't happen on the first time.
+			connect(BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(addedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestAdded(AMRegionOfInterest*)));
+			connect(BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(removedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestRemoved(AMRegionOfInterest*)));
+		}
 
 		return true;
 	}
@@ -216,22 +227,57 @@ void BioXASSideAppController::setupUserInterface()
 
 void BioXASSideAppController::makeConnections()
 {
-    connect( BioXASSideBeamline::bioXAS()->scaler(), SIGNAL(connectedChanged(bool)), this, SLOT(onScalerConnected()) );
-    connect( BioXASSideBeamline::bioXAS(), SIGNAL(connected(bool)), this, SLOT(onBeamlineConnected()) );
+	connect( BioXASSideBeamline::bioXAS()->scaler(), SIGNAL(connectedChanged(bool)), this, SLOT(onScalerConnected()) );
+	connect( BioXASSideBeamline::bioXAS(), SIGNAL(connected(bool)), this, SLOT(onBeamlineConnected()) );
+
+	// It is sufficient to only connect the user configuration to the single element because the single element and four element are synchronized together.
+	connect(userConfiguration_, SIGNAL(loadedFromDb()), this, SLOT(onUserConfigurationLoadedFromDb()));
 }
 
 void BioXASSideAppController::applyCurrentSettings()
 {
-    onScalerConnected();
-    onBeamlineConnected();
+	onScalerConnected();
+	onBeamlineConnected();
 }
 
 void BioXASSideAppController::onCurrentScanActionStartedImplementation(AMScanAction *action)
 {
 	Q_UNUSED(action)
+
+	userConfiguration_->storeToDb(AMDatabase::database("user"));
 }
 
 void BioXASSideAppController::onCurrentScanActionFinishedImplementation(AMScanAction *action)
 {
 	Q_UNUSED(action)
+
+	userConfiguration_->storeToDb(AMDatabase::database("user"));
+}
+
+void BioXASSideAppController::onUserConfigurationLoadedFromDb()
+{
+	AMXRFDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
+
+	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
+
+		AMRegionOfInterest *newRegion = region->createCopy();
+		detector->addRegionOfInterest(newRegion);
+//		configuration_->addRegionOfInterest(region);
+	}
+
+	// This is connected here because we want to listen to the detectors for updates, but don't want to double add regions on startup.
+	connect(BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(addedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestAdded(AMRegionOfInterest*)));
+	connect(BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(removedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestRemoved(AMRegionOfInterest*)));
+}
+
+void BioXASSideAppController::onRegionOfInterestAdded(AMRegionOfInterest *region)
+{
+	userConfiguration_->addRegionOfInterest(region);
+//	configuration_->addRegionOfInterest(region);
+}
+
+void BioXASSideAppController::onRegionOfInterestRemoved(AMRegionOfInterest *region)
+{
+	userConfiguration_->removeRegionOfInterest(region);
+//	configuration_->removeRegionOfInterest(region);
 }

--- a/source/application/BioXAS/BioXASSideAppController.h
+++ b/source/application/BioXAS/BioXASSideAppController.h
@@ -30,6 +30,8 @@ class BioXASSideXASScanConfiguration;
 class BioXASSideXASScanConfigurationView;
 class AMScanConfigurationViewHolder3;
 class BioXASSSRLMonochromatorConfigurationView;
+class BioXASUserConfiguration;
+class AMRegionOfInterest;
 
 class BioXASSideAppController : public AMAppController
 {
@@ -48,8 +50,15 @@ public:
 	virtual void shutdown();
 
 protected slots:
-    void onScalerConnected();
-    void onBeamlineConnected();
+	void onScalerConnected();
+	void onBeamlineConnected();
+
+	/// Handles setting up all the necessary settings based on the loaded user configuration.
+	void onUserConfigurationLoadedFromDb();
+	/// Handles adding regions of interest to all the configurations that would care.
+	void onRegionOfInterestAdded(AMRegionOfInterest *region);
+	/// Handles removing regions of interest from all the configurations that would care.
+	void onRegionOfInterestRemoved(AMRegionOfInterest *region);
 
 protected:
 	/// Implementation method that individual applications can flesh out if extra setup is required when a scan action is started.  This is not pure virtual because there is no requirement to do anything to scan actions.
@@ -65,25 +74,26 @@ protected:
 	/// Sets up the user interface by specifying the extra pieces that will be added to the main window.
 	void setupUserInterface();
 	/// Sets up all of the connections.
-	void makeConnections();    
-    /// Applies the current settings.
-    void applyCurrentSettings();
+	void makeConnections();
+	/// Applies the current settings.
+	void applyCurrentSettings();
 
 protected:
-    /// View for the BioXAS Side scaler.
-    CLSSIS3820ScalerView *scalerView_;
-    /// The mono configuration view.
-    BioXASSSRLMonochromatorConfigurationView *monoConfigView_;
+	/// View for the BioXAS Side scaler.
+	CLSSIS3820ScalerView *scalerView_;
+	/// The mono configuration view.
+	BioXASSSRLMonochromatorConfigurationView *monoConfigView_;
 
-    BioXASSidePersistentView *persistentPanel_;
+	BioXASSidePersistentView *persistentPanel_;
 
-    BioXASSideXASScanConfiguration *configuration_;
+	BioXASSideXASScanConfiguration *configuration_;
 
-    BioXASSideXASScanConfigurationView *configurationView_;
+	BioXASSideXASScanConfigurationView *configurationView_;
 
-    AMScanConfigurationViewHolder3 *configurationViewHolder_;
+	AMScanConfigurationViewHolder3 *configurationViewHolder_;
 
-
+	/// Holds the user configuration used for automatically setting up some simple aspects of the user interface.
+	BioXASUserConfiguration *userConfiguration_;
 };
 
 #endif // BIOXASSIDEAPPCONTROLLER_H

--- a/source/dataman/BioXAS/BioXASUserConfiguration.cpp
+++ b/source/dataman/BioXAS/BioXASUserConfiguration.cpp
@@ -1,0 +1,51 @@
+#include "BioXASUserConfiguration.h"
+
+BioXASUserConfiguration::BioXASUserConfiguration(QObject *parent)
+	: AMDbObject(parent)
+{
+	setName("User Configuration");
+}
+
+BioXASUserConfiguration::~BioXASUserConfiguration()
+{
+
+}
+
+AMDbObjectList BioXASUserConfiguration::dbReadRegionsOfInterest()
+{
+	AMDbObjectList listToBeSaved;
+
+	foreach (AMRegionOfInterest *region, regionsOfInterest_)
+		listToBeSaved << region;
+
+	return listToBeSaved;
+}
+
+void BioXASUserConfiguration::dbLoadRegionsOfInterest(const AMDbObjectList &newRegions)
+{
+	regionsOfInterest_.clear();
+
+	foreach (AMDbObject *newObject, newRegions){
+
+		AMRegionOfInterest *region = qobject_cast<AMRegionOfInterest *>(newObject);
+
+		if (region)
+			regionsOfInterest_.append(region);
+	}
+}
+
+void BioXASUserConfiguration::addRegionOfInterest(AMRegionOfInterest *region)
+{
+	regionsOfInterest_.append(region);
+	setModified(true);
+}
+
+void BioXASUserConfiguration::removeRegionOfInterest(AMRegionOfInterest *region)
+{
+	foreach (AMRegionOfInterest *regionToBeRemoved, regionsOfInterest_)
+		if (regionToBeRemoved->name() == region->name()){
+
+			regionsOfInterest_.removeOne(regionToBeRemoved);
+			setModified(true);
+		}
+}

--- a/source/dataman/BioXAS/BioXASUserConfiguration.h
+++ b/source/dataman/BioXAS/BioXASUserConfiguration.h
@@ -1,0 +1,41 @@
+#ifndef BIOXASUSERCONFIGURATION_H
+#define BIOXASUSERCONFIGURATION_H
+
+#include "dataman/database/AMDbObject.h"
+#include "dataman/AMRegionOfInterest.h"
+
+/// A class that holds onto the latest experiment configuration and saves it to a database.
+class BioXASUserConfiguration : public AMDbObject
+{
+	Q_OBJECT
+
+	Q_PROPERTY(AMDbObjectList regionsOfInterest READ dbReadRegionsOfInterest WRITE dbLoadRegionsOfInterest)
+
+	Q_CLASSINFO("AMDbObject_Attributes", "description=BioXAS User Configuration Database Object")
+
+public:
+	/// Constructor. Builds a user configuration.
+	Q_INVOKABLE BioXASUserConfiguration(QObject *parent = 0);
+	/// Destructor.
+	virtual ~BioXASUserConfiguration();
+
+	/// Returns the list of regions the configuration has a hold of.
+	QList<AMRegionOfInterest *> regionsOfInterest() const { return regionsOfInterest_; }
+
+public slots:
+	/// Adds a region of interest to the list.
+	void addRegionOfInterest(AMRegionOfInterest *region);
+	/// Removes a region of interest from the list.
+	void removeRegionOfInterest(AMRegionOfInterest *region);
+
+protected:
+	/// Returns the regions of interest list.
+	AMDbObjectList dbReadRegionsOfInterest();
+	/// Called by the dtabase system on loadFromDb() to give us our new list of AMRegionOfInterest.
+	void dbLoadRegionsOfInterest(const AMDbObjectList &newRegions);
+
+	/// The list of the regions of interest.
+	QList<AMRegionOfInterest *> regionsOfInterest_;
+};
+
+#endif // BIOXASUSERCONFIGURATION_H


### PR DESCRIPTION
Added a user configuration that saves configuration details on a scan by scan basis for a user.  For the time being there is only the regions of interest for the 32 element detector.  It has commented out lines for adding the regions to the scan configuration because that is stored in the BioXASScanConfigurationDbObject which is handled in #1300 and hasn't been merged in yet.  Once it is, those lines can be uncommented and then merged in.