### PR TITLE
Pull request for Issue1270: Adding bragg motor controls to exposed controls.

### DIFF
--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -190,8 +190,13 @@ void BioXASMainBeamline::setupComponents()
 
 void BioXASMainBeamline::setupExposedControls()
 {
+	// Mono controls.
+
 	addExposedControl(mono_->energyControl());
 	addExposedControl(mono_->regionControl());
+	addExposedControl(mono_->braggMotor()->EGUVelocityControl());
+	addExposedControl(mono_->braggMotor()->EGUBaseVelocityControl());
+	addExposedControl(mono_->braggMotor()->EGUAccelerationControl());
 }
 
 void BioXASMainBeamline::setupExposedDetectors()

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -226,12 +226,11 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 
 void BioXASSideBeamline::onConnectionChanged()
 {
-	qDebug() << pressureSet_->isConnected() << valveSet_->isConnected();
 	bool newState = (
 				// Mono.
 				mono_->isConnected() &&
 
-				//JJSlit
+				// JJSlit
 				jjSlit_->isConnected() &&
 
 				// Scaler.
@@ -242,10 +241,12 @@ void BioXASSideBeamline::onConnectionChanged()
 				carbonFilterFarm_->isConnected() &&
 
 				// Control sets.
-				//pressureSet_->isConnected() && valveSet_->isConnected() &&
 				pressureSet_->isConnected() &&
-				ionPumpSet_->isConnected() && flowTransducerSet_->isConnected() &&
-				flowSwitchSet_->isConnected() && temperatureSet_->isConnected()
+				//valveSet_->isConnected() &&
+				ionPumpSet_->isConnected() &&
+				flowTransducerSet_->isConnected() &&
+				flowSwitchSet_->isConnected() &&
+				temperatureSet_->isConnected()
 
 				);
 
@@ -777,6 +778,7 @@ void BioXASSideBeamline::setupComponents()
 	scaler_->channelAt(15)->setDetector(i2Detector_);
 
 	carbonFilterFarm_ = new BioXASSideCarbonFilterFarmControl(this);
+	connect( carbonFilterFarm_, SIGNAL(connected(bool)), this, SLOT(onConnectionChanged()) );
 
 	jjSlit_ = new CLSJJSlit("Side BL", "JJSlit of the side beamline", "PSL1607-6-I22-01", "PSL1607-6-I22-02");
 	connect(jjSlit_, SIGNAL(connected(bool)), this, SLOT(onConnectionChanged()));
@@ -820,10 +822,16 @@ void BioXASSideBeamline::setupExposedControls()
 	addExposedControl(mono_->energyControl());
 	addExposedControl(mono_->regionControl());
 
+	// JJ slit controls.
+
 	addExposedControl(jjSlit_->verticalBladesControl()->gapPVControl());
 	addExposedControl(jjSlit_->verticalBladesControl()->centerPVControl());
 	addExposedControl(jjSlit_->horizontalBladesControl()->gapPVControl());
 	addExposedControl(jjSlit_->horizontalBladesControl()->centerPVControl());
+
+	// Carbon filter farm control.
+
+	addExposedControl(carbonFilterFarm_);
 
 	// Detector stage controls.
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -821,6 +821,9 @@ void BioXASSideBeamline::setupExposedControls()
 
 	addExposedControl(mono_->energyControl());
 	addExposedControl(mono_->regionControl());
+	addExposedControl(mono_->braggMotor()->EGUVelocityControl());
+	addExposedControl(mono_->braggMotor()->EGUBaseVelocityControl());
+	addExposedControl(mono_->braggMotor()->EGUAccelerationControl());
 
 	// JJ slit controls.
 

--- a/source/beamline/CLS/CLSMAXvMotor.h
+++ b/source/beamline/CLS/CLSMAXvMotor.h
@@ -202,6 +202,12 @@ public:
 	AMReadOnlyPVControl *cwLimitControl() const { return cwLimit_; }
 	/// Returns the counter-clockwise limit status PV control.
 	AMReadOnlyPVControl *ccwLimitControl() const { return ccwLimit_; }
+	/// Returns the EGU velocity PV control.
+	AMPVControl* EGUVelocityControl() const { return EGUVelocity_; }
+	/// Returns the EGU base velocity PV control.
+	AMPVControl* EGUBaseVelocityControl() const { return EGUBaseVelocity_; }
+	/// Returns the EGU acceleration PV control.
+	AMPVControl* EGUAccelerationControl() const { return EGUAcceleration_; }
 
 	/// Returns a newly created action to move the motor. This is a convenience function that calls the EGU move action. Returns 0 if the control is not connected.
 	AMAction3* createMotorMoveAction(double position);


### PR DESCRIPTION
Created getters for the bragg motor properties of interest (EGU velocity, EGU base velocity, and EGU acceleration) in the CLSMAXvMotor interface. Added these controls as exposed controls in the Side and Main beamline classes.

As written, I think this pull request fulfills the requirements for #1270. It's ready to merge once reviewed.