### PR TITLE
Pull Request for Issue1347: VESPERS MAXv driver is too old to use current CLSMAXvMotor implementation

### DIFF
--- a/source/acquaman/BioXAS/BioXASMainXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASMainXASScanActionController.cpp
@@ -33,25 +33,25 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "dataman/export/AMExporterOptionGeneralAscii.h"
 
 BioXASMainXASScanActionController::BioXASMainXASScanActionController(BioXASMainXASScanConfiguration *configuration, QObject *parent) :
-    AMStepScanActionController(configuration, parent)
+	AMStepScanActionController(configuration, parent)
 {
-    configuration_ = configuration;
+	configuration_ = configuration;
 
-    scan_ = new AMXASScan();
-    scan_->setName(configuration_->name());
-    scan_->setFileFormat("amCDFv1");
-    scan_->setScanConfiguration(configuration);
-    scan_->setIndexType("fileSystem");
-    scan_->rawData()->addScanAxis(AMAxisInfo("eV", 0, "Incident Energy", "eV"));
-    scan_->setNotes(beamlineSettings());
+	scan_ = new AMXASScan();
+	scan_->setName(configuration_->name());
+	scan_->setFileFormat("amCDFv1");
+	scan_->setScanConfiguration(configuration);
+	scan_->setIndexType("fileSystem");
+	scan_->rawData()->addScanAxis(AMAxisInfo("eV", 0, "Incident Energy", "eV"));
+	scan_->setNotes(beamlineSettings());
 
-    AMControlInfoList list;
+	AMControlInfoList list;
 	list.append(BioXASMainBeamline::bioXAS()->mono()->energyControl()->toInfo());
-    configuration_->setAxisControlInfos(list);
+	configuration_->setAxisControlInfos(list);
 
 	useFeedback_ = true;
 
-    AMDetectorInfoSet detectorSet;
+	AMDetectorInfoSet detectorSet;
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("I0Detector")->toInfo());
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("ITDetector")->toInfo());
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("I2Detector")->toInfo());
@@ -61,10 +61,9 @@ BioXASMainXASScanActionController::BioXASMainXASScanActionController(BioXASMainX
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("MonoFeedback")->toInfo());
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("MonoMoveRetries")->toInfo());
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("MonoStepSetpoint")->toInfo());
-	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("MonoDegreeSetpoint")->toInfo());
 	detectorSet.addDetectorInfo(BioXASMainBeamline::bioXAS()->exposedDetectorByName("BraggAngle")->toInfo());
 
-    configuration_->setDetectorConfigurations(detectorSet);
+	configuration_->setDetectorConfigurations(detectorSet);
 
 	secondsElapsed_ = 0;
 	secondsTotal_ = configuration_->totalTime();
@@ -114,60 +113,60 @@ QString BioXASMainXASScanActionController::beamlineSettings()
 
 AMAction3* BioXASMainXASScanActionController::createInitializationActions()
 {
-    AMSequentialListAction3 *initializationAction = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Main Scan Initialization Actions", "BioXAS Main Scan Initialization Actions"));
-    CLSSIS3820Scaler *scaler = CLSBeamline::clsBeamline()->scaler();
-    double regionTime = double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime());
+	AMSequentialListAction3 *initializationAction = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Main Scan Initialization Actions", "BioXAS Main Scan Initialization Actions"));
+	CLSSIS3820Scaler *scaler = CLSBeamline::clsBeamline()->scaler();
+	double regionTime = double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime());
 
-    if (scaler) {
-	    AMListAction3 *stage1 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 1", "BioXAS Main Initialization Stage 1"), AMListAction3::Parallel);
-	    stage1->addSubAction(scaler->createContinuousEnableAction3(false));
+	if (scaler) {
+		AMListAction3 *stage1 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 1", "BioXAS Main Initialization Stage 1"), AMListAction3::Parallel);
+		stage1->addSubAction(scaler->createContinuousEnableAction3(false));
 
-	    AMListAction3 *stage2 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 2", "BioXAS Main Initialization Stage 2"), AMListAction3::Parallel);
+		AMListAction3 *stage2 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 2", "BioXAS Main Initialization Stage 2"), AMListAction3::Parallel);
 
-	    stage2->addSubAction(scaler->createStartAction3(false));
-	    stage2->addSubAction(scaler->createScansPerBufferAction3(1));
-	    stage2->addSubAction(scaler->createTotalScansAction3(1));
+		stage2->addSubAction(scaler->createStartAction3(false));
+		stage2->addSubAction(scaler->createScansPerBufferAction3(1));
+		stage2->addSubAction(scaler->createTotalScansAction3(1));
 
-	    AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 3", "BioXAS Main Initialization Stage 3"), AMListAction3::Parallel);
-	    stage3->addSubAction(scaler->createStartAction3(true));
-	    stage3->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
+		AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 3", "BioXAS Main Initialization Stage 3"), AMListAction3::Parallel);
+		stage3->addSubAction(scaler->createStartAction3(true));
+		stage3->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 
-	    AMListAction3 *stage4 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 4", "BioXAS Main Initialization Stage 4"), AMListAction3::Parallel);
-	    stage4->addSubAction(scaler->createStartAction3(true));
-	    stage4->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
+		AMListAction3 *stage4 = new AMListAction3(new AMListActionInfo3("BioXAS Main Initialization Stage 4", "BioXAS Main Initialization Stage 4"), AMListAction3::Parallel);
+		stage4->addSubAction(scaler->createStartAction3(true));
+		stage4->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 
-	    // if we have a valid scaler on the beamline, perform a dark current measurement for the same length of time as the dwell time.
-	    AMAction3 *darkCurrentSetup = scaler->createMeasureDarkCurrentAction((int)scaler->dwellTime());
+		// if we have a valid scaler on the beamline, perform a dark current measurement for the same length of time as the dwell time.
+		AMAction3 *darkCurrentSetup = scaler->createMeasureDarkCurrentAction((int)scaler->dwellTime());
 
-	    initializationAction->addSubAction(stage1);
-	    initializationAction->addSubAction(stage2);
-	    initializationAction->addSubAction(scaler->createDwellTimeAction3(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
-	    initializationAction->addSubAction(stage3);
-	    initializationAction->addSubAction(stage4);
-	    initializationAction->addSubAction(darkCurrentSetup);
+		initializationAction->addSubAction(stage1);
+		initializationAction->addSubAction(stage2);
+		initializationAction->addSubAction(scaler->createDwellTimeAction3(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
+		initializationAction->addSubAction(stage3);
+		initializationAction->addSubAction(stage4);
+		initializationAction->addSubAction(darkCurrentSetup);
 
-	    // Set the bragg motor power to PowerOn, must be on to move/scan.
-	    initializationAction->addSubAction(BioXASMainBeamline::bioXAS()->mono()->braggMotor()->createPowerAction(CLSMAXvMotor::PowerOn));
+		// Set the bragg motor power to PowerOn, must be on to move/scan.
+		initializationAction->addSubAction(BioXASMainBeamline::bioXAS()->mono()->braggMotor()->createPowerAction(CLSMAXvMotor::PowerOn));
 
-    } else {
-	    AMErrorMon::alert(this, BIOXASMAINXASSCANACTIONCONTROLLER_SCALER_NOT_FOUND, "Failed to complete scan initialization--valid scaler not found.");
-    }
+	} else {
+		AMErrorMon::alert(this, BIOXASMAINXASSCANACTIONCONTROLLER_SCALER_NOT_FOUND, "Failed to complete scan initialization--valid scaler not found.");
+	}
 
-    return initializationAction;
+	return initializationAction;
 }
 
 AMAction3* BioXASMainXASScanActionController::createCleanupActions()
 {
-    CLSSIS3820Scaler *scaler = BioXASMainBeamline::bioXAS()->scaler();
+	CLSSIS3820Scaler *scaler = BioXASMainBeamline::bioXAS()->scaler();
 
-    AMListAction3 *cleanup = new AMListAction3(new AMListActionInfo3("BioXAS Main Cleanup", "BioXAS Main Cleanup"), AMListAction3::Sequential);
-    cleanup->addSubAction(scaler->createDwellTimeAction3(1.0));
-    cleanup->addSubAction(scaler->createContinuousEnableAction3(true));
+	AMListAction3 *cleanup = new AMListAction3(new AMListActionInfo3("BioXAS Main Cleanup", "BioXAS Main Cleanup"), AMListAction3::Sequential);
+	cleanup->addSubAction(scaler->createDwellTimeAction3(1.0));
+	cleanup->addSubAction(scaler->createContinuousEnableAction3(true));
 
-    // Set the bragg motor power to PowerAutoHardware. The motor can get too warm when left on for too long, that's why we turn it off when not in use.
-    cleanup->addSubAction(BioXASMainBeamline::bioXAS()->mono()->braggMotor()->createPowerAction(CLSMAXvMotor::PowerAutoHardware));
+	// Set the bragg motor power to PowerAutoHardware. The motor can get too warm when left on for too long, that's why we turn it off when not in use.
+	cleanup->addSubAction(BioXASMainBeamline::bioXAS()->mono()->braggMotor()->createPowerAction(CLSMAXvMotor::PowerAutoHardware));
 
-    return cleanup;
+	return cleanup;
 }
 
 void BioXASMainXASScanActionController::buildScanControllerImplementation()
@@ -225,5 +224,5 @@ void BioXASMainXASScanActionController::buildScanControllerImplementation()
 
 void BioXASMainXASScanActionController::createScanAssembler()
 {
-    scanAssembler_ = new AMEXAFSScanActionControllerAssembler(this);
+	scanAssembler_ = new AMEXAFSScanActionControllerAssembler(this);
 }

--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -31,40 +31,39 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "analysis/AM1DExpressionAB.h"
 
 BioXASSideXASScanActionController::BioXASSideXASScanActionController(BioXASSideXASScanConfiguration *configuration, QObject *parent) :
-    AMStepScanActionController(configuration, parent)
+	AMStepScanActionController(configuration, parent)
 {
-    configuration_ = configuration;
+	configuration_ = configuration;
 
-    scan_ = new AMXASScan();
-    scan_->setName(configuration_->name());
-    scan_->setFileFormat("amCDFv1");
-    scan_->setScanConfiguration(configuration);
-    scan_->setIndexType("fileSystem");
-    scan_->rawData()->addScanAxis(AMAxisInfo("eV", 0, "Incident Energy", "eV"));
-    scan_->setNotes(beamlineSettings());
+	scan_ = new AMXASScan();
+	scan_->setName(configuration_->name());
+	scan_->setFileFormat("amCDFv1");
+	scan_->setScanConfiguration(configuration);
+	scan_->setIndexType("fileSystem");
+	scan_->rawData()->addScanAxis(AMAxisInfo("eV", 0, "Incident Energy", "eV"));
+	scan_->setNotes(beamlineSettings());
 
-    AMControlInfoList list;
-    list.append(BioXASSideBeamline::bioXAS()->mono()->energyControl()->toInfo());
-    configuration_->setAxisControlInfos(list);
+	AMControlInfoList list;
+	list.append(BioXASSideBeamline::bioXAS()->mono()->energyControl()->toInfo());
+	configuration_->setAxisControlInfos(list);
 
 	useFeedback_ = true;
 
-    AMDetectorInfoSet bioXASDetectors;
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->i0Detector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->iTDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->i2Detector()->toInfo());
+	AMDetectorInfoSet bioXASDetectors;
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->i0Detector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->iTDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->i2Detector()->toInfo());
 	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->energySetpointDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->energyFeedbackDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->dwellTimeDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->energyFeedbackDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->dwellTimeDetector()->toInfo());
 	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggDetector()->toInfo());
 	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggEncoderFeedbackDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggMoveRetriesDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggMoveRetriesMaxDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggStepSetpointDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggDegreeSetpointDetector()->toInfo());
-    bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggAngleDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggMoveRetriesDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggMoveRetriesMaxDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggStepSetpointDetector()->toInfo());
+	bioXASDetectors.addDetectorInfo(BioXASSideBeamline::bioXAS()->braggAngleDetector()->toInfo());
 
-    configuration_->setDetectorConfigurations(bioXASDetectors);
+	configuration_->setDetectorConfigurations(bioXASDetectors);
 
 	secondsElapsed_ = 0;
 	secondsTotal_ = configuration_->totalTime();
@@ -169,6 +168,6 @@ void BioXASSideXASScanActionController::buildScanControllerImplementation()
 
 void BioXASSideXASScanActionController::createScanAssembler()
 {
-    scanAssembler_ = new AMEXAFSScanActionControllerAssembler(this);
+	scanAssembler_ = new AMEXAFSScanActionControllerAssembler(this);
 }
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -30,31 +30,31 @@ BioXASMainBeamline::~BioXASMainBeamline()
 
 QList<AMControl *> BioXASMainBeamline::getMotorsByType(BioXASBeamlineDef::BioXASMotorType category)
 {
-    QList<AMControl *> matchedMotors;
+	QList<AMControl *> matchedMotors;
 
-    switch (category) {
-    case BioXASBeamlineDef::FilterMotor: // BioXAS Filter motors
-        matchedMotors.append(carbonFilterFarm1_);
-        matchedMotors.append(carbonFilterFarm2_);
-        break;
+	switch (category) {
+	case BioXASBeamlineDef::FilterMotor: // BioXAS Filter motors
+		matchedMotors.append(carbonFilterFarm1_);
+		matchedMotors.append(carbonFilterFarm2_);
+		break;
 
-    case BioXASBeamlineDef::M1Motor:	// BioXAS M1 motors
-        matchedMotors.append(m1VertUpStreamINB_);
-        matchedMotors.append(m1VertUpStreamOUTB_);
-        matchedMotors.append(m1VertDownStream_);
-        matchedMotors.append(m1StripeSelect_);
-        matchedMotors.append(m1Yaw_);
-        matchedMotors.append(m1BenderUpstream_);
-        matchedMotors.append(m1BenderDownStream_);
-        matchedMotors.append(m1UpperSlitBlade_);
-        break;
+	case BioXASBeamlineDef::M1Motor:	// BioXAS M1 motors
+		matchedMotors.append(m1VertUpStreamINB_);
+		matchedMotors.append(m1VertUpStreamOUTB_);
+		matchedMotors.append(m1VertDownStream_);
+		matchedMotors.append(m1StripeSelect_);
+		matchedMotors.append(m1Yaw_);
+		matchedMotors.append(m1BenderUpstream_);
+		matchedMotors.append(m1BenderDownStream_);
+		matchedMotors.append(m1UpperSlitBlade_);
+		break;
 
-    case BioXASBeamlineDef::MaskMotor:	// BioXAS Variable Mask motors
-        matchedMotors.append(variableMaskVertUpperBlade_);
-        matchedMotors.append(variableMaskVertLowerBlade_);
-        break;
+	case BioXASBeamlineDef::MaskMotor:	// BioXAS Variable Mask motors
+		matchedMotors.append(variableMaskVertUpperBlade_);
+		matchedMotors.append(variableMaskVertLowerBlade_);
+		break;
 
-    case BioXASBeamlineDef::MonoMotor:	// BioXAS Mono motors
+	case BioXASBeamlineDef::MonoMotor:	// BioXAS Mono motors
 		matchedMotors.append(mono_->paddleMotor());
 		matchedMotors.append(mono_->braggMotor());
 		matchedMotors.append(mono_->verticalMotor());
@@ -64,9 +64,9 @@ QList<AMControl *> BioXASMainBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		matchedMotors.append(mono_->crystal1RollMotor());
 		matchedMotors.append(mono_->crystal2PitchMotor());
 		matchedMotors.append(mono_->crystal2RollMotor());
-        break;
+		break;
 
-    case BioXASBeamlineDef::M2Motor:	// BioXAS M2 motors
+	case BioXASBeamlineDef::M2Motor:	// BioXAS M2 motors
 		matchedMotors.append(m2Mirror_->verticalUpstreamInboundControl());
 		matchedMotors.append(m2Mirror_->verticalUpstreamOutboundControl());
 		matchedMotors.append(m2Mirror_->verticalDownstreamControl());
@@ -74,35 +74,35 @@ QList<AMControl *> BioXASMainBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		matchedMotors.append(m2Mirror_->yawControl());
 		matchedMotors.append(m2Mirror_->benderUpstreamControl());
 		matchedMotors.append(m2Mirror_->benderDownstreamControl());
-        break;
+		break;
 
-    case BioXASBeamlineDef::PseudoM1Motor: // BioXAS Pseudo M1 motor
-        matchedMotors.append(m1PseudoRoll_);
-        matchedMotors.append(m1PseudoPitch_);
-        matchedMotors.append(m1PseudoHeight_);
-        matchedMotors.append(m1PseudoYaw_);
-        matchedMotors.append(m1PseudoLateral_);
-        break;
+	case BioXASBeamlineDef::PseudoM1Motor: // BioXAS Pseudo M1 motor
+		matchedMotors.append(m1PseudoRoll_);
+		matchedMotors.append(m1PseudoPitch_);
+		matchedMotors.append(m1PseudoHeight_);
+		matchedMotors.append(m1PseudoYaw_);
+		matchedMotors.append(m1PseudoLateral_);
+		break;
 
-    case BioXASBeamlineDef::PseudoM2Motor: // BioXAS Pseudo M2 motor
+	case BioXASBeamlineDef::PseudoM2Motor: // BioXAS Pseudo M2 motor
 		matchedMotors.append(m2Mirror_->pseudoRollControl());
 		matchedMotors.append(m2Mirror_->pseudoPitchControl());
 		matchedMotors.append(m2Mirror_->pseudoYawControl());
 		matchedMotors.append(m2Mirror_->pseudoHeightControl());
 		matchedMotors.append(m2Mirror_->pseudoLateralControl());
-        break;
+		break;
 
-    case BioXASBeamlineDef::PseudoMonoMotor: // BioXAS Pseudo Mono motor
-        matchedMotors.append(monoPseudoEnergy_);
+	case BioXASBeamlineDef::PseudoMonoMotor: // BioXAS Pseudo Mono motor
+		matchedMotors.append(monoPseudoEnergy_);
 		matchedMotors.append(monoBraggAngle_);
-        break;
+		break;
 
-    default:
-        qDebug() << "ERROR: invalid BioXAS Motor category: " << category;
-        break;
-    }
+	default:
+		qDebug() << "ERROR: invalid BioXAS Motor category: " << category;
+		break;
+	}
 
-    return matchedMotors;
+	return matchedMotors;
 }
 
 void BioXASMainBeamline::onConnectedChanged()
@@ -136,11 +136,11 @@ void BioXASMainBeamline::setupControlSets()
 
 void BioXASMainBeamline::setupDetectors()
 {
-    i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0 Detector", scaler_, 0, this);
+	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0 Detector", scaler_, 0, this);
 
-    iTDetector_ = new CLSBasicScalerChannelDetector("ITDetector", "IT Detector", scaler_, 1, this);
+	iTDetector_ = new CLSBasicScalerChannelDetector("ITDetector", "IT Detector", scaler_, 1, this);
 
-    i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2 Detector", scaler_, 15, this);
+	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2 Detector", scaler_, 15, this);
 }
 
 void BioXASMainBeamline::setupSampleStage()
@@ -156,33 +156,33 @@ void BioXASMainBeamline::setupMono()
 
 void BioXASMainBeamline::setupComponents()
 {
-    // Scaler
+	// Scaler
 
-    scaler_ = new CLSSIS3820Scaler("BL1607-5-I21:mcs", this);
+	scaler_ = new CLSSIS3820Scaler("BL1607-5-I21:mcs", this);
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(onConnectedChanged()) );
 
-    scalerDwellTime_ = new AMReadOnlyPVControl("ScalerDwellTime", "BL1607-5-I21:mcs:delay", this, "Scaler dwell time");
+	scalerDwellTime_ = new AMReadOnlyPVControl("ScalerDwellTime", "BL1607-5-I21:mcs:delay", this, "Scaler dwell time");
 
-    // Detectors
+	// Detectors
 
-    setupDetectors();
+	setupDetectors();
 
-    // Amplifiers
+	// Amplifiers
 
-    i0Keithley_ = new CLSKeithley428("I0 Channel", "AMP1607-701", this);
-    scaler_->channelAt(0)->setCustomChannelName("I0 Channel");
-    scaler_->channelAt(0)->setCurrentAmplifier(i0Keithley_);
-    scaler_->channelAt(0)->setDetector(i0Detector_);
+	i0Keithley_ = new CLSKeithley428("I0 Channel", "AMP1607-701", this);
+	scaler_->channelAt(0)->setCustomChannelName("I0 Channel");
+	scaler_->channelAt(0)->setCurrentAmplifier(i0Keithley_);
+	scaler_->channelAt(0)->setDetector(i0Detector_);
 
-    iTKeithley_ = new CLSKeithley428("IT Channel", "AMP1607-702", this);
-    scaler_->channelAt(1)->setCustomChannelName("IT Channel");
-    scaler_->channelAt(1)->setCurrentAmplifier(iTKeithley_);
-    scaler_->channelAt(1)->setDetector(iTDetector_);
+	iTKeithley_ = new CLSKeithley428("IT Channel", "AMP1607-702", this);
+	scaler_->channelAt(1)->setCustomChannelName("IT Channel");
+	scaler_->channelAt(1)->setCurrentAmplifier(iTKeithley_);
+	scaler_->channelAt(1)->setDetector(iTDetector_);
 
-    i2Keithley_ = new CLSKeithley428("I2 Channel", "AMP1607-703", this);
-    scaler_->channelAt(15)->setCustomChannelName("I2 Channel");
-    scaler_->channelAt(15)->setCurrentAmplifier(iTKeithley_);
-    scaler_->channelAt(15)->setDetector(i2Detector_);
+	i2Keithley_ = new CLSKeithley428("I2 Channel", "AMP1607-703", this);
+	scaler_->channelAt(15)->setCustomChannelName("I2 Channel");
+	scaler_->channelAt(15)->setCurrentAmplifier(iTKeithley_);
+	scaler_->channelAt(15)->setDetector(i2Detector_);
 
 	// M2 Mirror.
 
@@ -213,49 +213,48 @@ void BioXASMainBeamline::setupExposedControls()
 
 void BioXASMainBeamline::setupExposedDetectors()
 {
-    addExposedDetector(i0Detector_);
-    addExposedDetector(iTDetector_);
-    addExposedDetector(i2Detector_);
+	addExposedDetector(i0Detector_);
+	addExposedDetector(iTDetector_);
+	addExposedDetector(i2Detector_);
 	addExposedDetector(energySetpointDetector_);
 	addExposedDetector(energyFeedbackDetector_);
 	addExposedDetector(dwellTimeDetector_);
 	addExposedDetector(braggDetector_);
-    addExposedDetector(braggMoveRetriesDetector_);
-    addExposedDetector(braggStepSetpointDetector_);
-    addExposedDetector(braggDegreeSetpointDetector_);
-    addExposedDetector(braggAngleDetector_);
+	addExposedDetector(braggMoveRetriesDetector_);
+	addExposedDetector(braggStepSetpointDetector_);
+	addExposedDetector(braggAngleDetector_);
 }
 
 void BioXASMainBeamline::setupMotorGroup()
 {
-    // BioXAS filter motors
-    carbonFilterFarm1_ = new CLSMAXvMotor(QString("SMTR1607-5-I00-03 Filter 1"), QString("SMTR1607-5-I00-03"), QString("SMTR1607-5-I00-03 Filter 1"), true, 0.05, 2.0, this, QString(":mm"));
-    carbonFilterFarm2_ = new CLSMAXvMotor(QString("SMTR1607-5-I00-04 Filter 2"), QString("SMTR1607-5-I00-04"), QString("SMTR1607-5-I00-04 Filter 2"), true, 0.05, 2.0, this, QString(":mm"));
+	// BioXAS filter motors
+	carbonFilterFarm1_ = new CLSMAXvMotor(QString("SMTR1607-5-I00-03 Filter 1"), QString("SMTR1607-5-I00-03"), QString("SMTR1607-5-I00-03 Filter 1"), true, 0.05, 2.0, this, QString(":mm"));
+	carbonFilterFarm2_ = new CLSMAXvMotor(QString("SMTR1607-5-I00-04 Filter 2"), QString("SMTR1607-5-I00-04"), QString("SMTR1607-5-I00-04 Filter 2"), true, 0.05, 2.0, this, QString(":mm"));
 
-    // BioXAS M1 motors
-    m1VertUpStreamINB_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I21-01"), QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), true, 0.05, 2.0, this, QString(":mm"));
-    m1VertUpStreamOUTB_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I21-02"), QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), true, 0.05, 2.0, this, QString(":mm"));
-    m1VertDownStream_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I21-03"), QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), true, 0.05, 2.0, this, QString(":mm"));
-    m1StripeSelect_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-04 STRIPE SELECT"), QString("SMTR1607-5-I21-04"), QString("SMTR1607-5-I21-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm"));
-    m1Yaw_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-05 YAW"), QString("SMTR1607-5-I21-05"), QString("SMTR1607-5-I21-05 YAW"), true, 0.05, 2.0, this, QString(":mm"));
-    m1BenderUpstream_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I21-06"), QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), true, 0.05, 2.0, this, QString(":lbs"));
-    m1BenderDownStream_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I21-07"), QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), true, 0.05, 2.0, this, QString(":lbs"));
-    m1UpperSlitBlade_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-08 UPPER SLIT BLADE"), QString("SMTR1607-5-I21-08"), QString("SMTR1607-5-I21-08 UPPER SLIT BLADE"), true, 0.05, 2.0, this, QString(":mm"));
+	// BioXAS M1 motors
+	m1VertUpStreamINB_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I21-01"), QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), true, 0.05, 2.0, this, QString(":mm"));
+	m1VertUpStreamOUTB_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I21-02"), QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), true, 0.05, 2.0, this, QString(":mm"));
+	m1VertDownStream_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I21-03"), QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), true, 0.05, 2.0, this, QString(":mm"));
+	m1StripeSelect_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-04 STRIPE SELECT"), QString("SMTR1607-5-I21-04"), QString("SMTR1607-5-I21-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm"));
+	m1Yaw_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-05 YAW"), QString("SMTR1607-5-I21-05"), QString("SMTR1607-5-I21-05 YAW"), true, 0.05, 2.0, this, QString(":mm"));
+	m1BenderUpstream_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I21-06"), QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), true, 0.05, 2.0, this, QString(":lbs"));
+	m1BenderDownStream_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I21-07"), QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), true, 0.05, 2.0, this, QString(":lbs"));
+	m1UpperSlitBlade_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-08 UPPER SLIT BLADE"), QString("SMTR1607-5-I21-08"), QString("SMTR1607-5-I21-08 UPPER SLIT BLADE"), true, 0.05, 2.0, this, QString(":mm"));
 
-    // BioXAS Variable Mask motors
-    variableMaskVertUpperBlade_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), QString("SMTR1607-5-I21-09"), QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), true, 0.05, 2.0, this, QString(":mm"));
-    variableMaskVertLowerBlade_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), QString("SMTR1607-5-I21-10"), QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), true, 0.05, 2.0, this, QString(":mm"));
+	// BioXAS Variable Mask motors
+	variableMaskVertUpperBlade_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), QString("SMTR1607-5-I21-09"), QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), true, 0.05, 2.0, this, QString(":mm"));
+	variableMaskVertLowerBlade_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), QString("SMTR1607-5-I21-10"), QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), true, 0.05, 2.0, this, QString(":mm"));
 
-    // BioXAS M1 Pseudo motors					   name,				   pvBaseName,				readPVname,	writePVname, movingPVname,	enabledPVname, stopPVname, tolerance, moveStartTimeoutSeconds, statusChecker, stopValue, description, parent = 0
-    m1PseudoRoll_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Roll", "BL1607-5-I21:M1:Roll", ":deg:fbk", ":deg", ":status", ":enabled", ":stop");
-    m1PseudoPitch_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Pitch", "BL1607-5-I21:M1:Pitch", ":deg:fbk", ":deg", ":status", ":enabled", ":stop");
-    m1PseudoHeight_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Height", "BL1607-5-I21:M1:Height", ":mm:fbk", ":mm", ":status", ":enabled", ":stop");
-    m1PseudoYaw_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Yaw", "BL1607-5-I21:M1:Yaw", ":deg:fbk", ":deg", ":status", ":enabled", ":stop");
-    m1PseudoLateral_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Lateral", "BL1607-5-I21:M1:Lateral", ":mm:fbk", ":mm", ":status", ":enabled", ":stop");
+	// BioXAS M1 Pseudo motors					   name,				   pvBaseName,				readPVname,	writePVname, movingPVname,	enabledPVname, stopPVname, tolerance, moveStartTimeoutSeconds, statusChecker, stopValue, description, parent = 0
+	m1PseudoRoll_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Roll", "BL1607-5-I21:M1:Roll", ":deg:fbk", ":deg", ":status", ":enabled", ":stop");
+	m1PseudoPitch_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Pitch", "BL1607-5-I21:M1:Pitch", ":deg:fbk", ":deg", ":status", ":enabled", ":stop");
+	m1PseudoHeight_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Height", "BL1607-5-I21:M1:Height", ":mm:fbk", ":mm", ":status", ":enabled", ":stop");
+	m1PseudoYaw_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Yaw", "BL1607-5-I21:M1:Yaw", ":deg:fbk", ":deg", ":status", ":enabled", ":stop");
+	m1PseudoLateral_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main M1 Lateral", "BL1607-5-I21:M1:Lateral", ":mm:fbk", ":mm", ":status", ":enabled", ":stop");
 
-    // BioXAS Mono Pseudo motors					   name,				   pvBaseName,				readPVname,	writePVname, movingPVname,	enabledPVname, stopPVname, tolerance, moveStartTimeoutSeconds, statusChecker, stopValue, description, parent = 0
-    monoPseudoEnergy_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main Mono Energy", "BL1607-5-I21:Energy", ":EV:fbk", ":EV", ":status", ":enabled", ":stop");
-    monoBraggAngle_ = new AMPVwStatusControl("BL1607-5-I21 Main Mono Bragg Angle", "BL1607-5-I21:Energy:EV:fbk:tr.K", "BL1607-5-I21:Energy:EV:sp:tr.E", "BL1607-5-I21:Energy:status", "BL1607-5-I21:Energy:stop", this, 0.05);
+	// BioXAS Mono Pseudo motors					   name,				   pvBaseName,				readPVname,	writePVname, movingPVname,	enabledPVname, stopPVname, tolerance, moveStartTimeoutSeconds, statusChecker, stopValue, description, parent = 0
+	monoPseudoEnergy_ = new BioXASPseudoMotorControl("BL1607-5-I21 Main Mono Energy", "BL1607-5-I21:Energy", ":EV:fbk", ":EV", ":status", ":enabled", ":stop");
+	monoBraggAngle_ = new AMPVwStatusControl("BL1607-5-I21 Main Mono Bragg Angle", "BL1607-5-I21:Energy:EV:fbk:tr.K", "BL1607-5-I21:Energy:EV:sp:tr.E", "BL1607-5-I21:Energy:status", "BL1607-5-I21:Energy:stop", this, 0.05);
 }
 
 void BioXASMainBeamline::setupControlsAsDetectors()
@@ -284,10 +283,6 @@ void BioXASMainBeamline::setupControlsAsDetectors()
 	braggStepSetpointDetector_->setHiddenFromUsers(false);
 	braggStepSetpointDetector_->setIsVisible(true);
 
-	braggDegreeSetpointDetector_ = new AMBasicControlDetectorEmulator("MonoDegreeSetpoint", "Mono bragg motor degree setpoint", mono_->braggMotor()->degreeSetpointControl(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
-	braggDegreeSetpointDetector_->setHiddenFromUsers(false);
-	braggDegreeSetpointDetector_->setIsVisible(true);
-
 	braggAngleDetector_ = new AMBasicControlDetectorEmulator("BraggAngle", "Physical bragg angle", mono_->energyControl()->braggAngleControl(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 	braggAngleDetector_->setHiddenFromUsers(false);
 	braggAngleDetector_->setIsVisible(true);
@@ -296,15 +291,15 @@ void BioXASMainBeamline::setupControlsAsDetectors()
 BioXASMainBeamline::BioXASMainBeamline()
 	: BioXASBeamline("BioXAS Beamline - Main Endstation")
 {
-    connected_ = false;
+	connected_ = false;
 
-    setupComponents();
-    setupDiagnostics();
-    setupSampleStage();
-    setupControlSets();
-    setupMono();
-    setupMotorGroup();
-    setupControlsAsDetectors();
-    setupExposedControls();
-    setupExposedDetectors();
+	setupComponents();
+	setupDiagnostics();
+	setupSampleStage();
+	setupControlSets();
+	setupMono();
+	setupMotorGroup();
+	setupControlsAsDetectors();
+	setupExposedControls();
+	setupExposedDetectors();
 }

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -63,29 +63,29 @@ public:
 	/// Destructor.
 	virtual ~BioXASMainBeamline();
 
-    /// Returns true if all beamline components are connected, false otherwise.
-    virtual bool isConnected() const { return connected_; }
+	/// Returns true if all beamline components are connected, false otherwise.
+	virtual bool isConnected() const { return connected_; }
 
 	/// Returns the beamline m2 mirror.
 	virtual BioXASM2Mirror *m2Mirror() const { return m2Mirror_; }
 	/// Returns the beamline monochromator.
 	virtual BioXASMainMonochromator *mono() const { return mono_; }
-    /// Returns the scaler.
-    virtual CLSSIS3820Scaler* scaler() const { return scaler_; }
+	/// Returns the scaler.
+	virtual CLSSIS3820Scaler* scaler() const { return scaler_; }
 
-    /// Returns the I0 amplifier.
-    CLSKeithley428* i0Keithley() const { return i0Keithley_; }
-    /// Returns the IT amplifier.
-    CLSKeithley428* iTKeithley() const { return iTKeithley_; }
-    /// Returns the I2 amplifier.
-    CLSKeithley428* i2Keithley() const { return i2Keithley_; }
+	/// Returns the I0 amplifier.
+	CLSKeithley428* i0Keithley() const { return i0Keithley_; }
+	/// Returns the IT amplifier.
+	CLSKeithley428* iTKeithley() const { return iTKeithley_; }
+	/// Returns the I2 amplifier.
+	CLSKeithley428* i2Keithley() const { return i2Keithley_; }
 
-    /// Returns the I0 detector.
-    CLSBasicScalerChannelDetector* i0Detector() const { return i0Detector_; }
-    /// Returns the IT detector.
-    CLSBasicScalerChannelDetector* iTDetector() const { return iTDetector_; }
-    /// Returns the I2 detector.
-    CLSBasicScalerChannelDetector* i2Detector() const { return i2Detector_; }
+	/// Returns the I0 detector.
+	CLSBasicScalerChannelDetector* i0Detector() const { return i0Detector_; }
+	/// Returns the IT detector.
+	CLSBasicScalerChannelDetector* iTDetector() const { return iTDetector_; }
+	/// Returns the I2 detector.
+	CLSBasicScalerChannelDetector* i2Detector() const { return i2Detector_; }
 	/// Returns the energy setpoint detector.
 	AMBasicControlDetectorEmulator* energySetpointDetector() const { return energySetpointDetector_; }
 	/// Returns the energy feedback detector.
@@ -94,16 +94,14 @@ public:
 	AMBasicControlDetectorEmulator* dwellTimeDetector() const { return dwellTimeDetector_; }
 	/// Returns the bragg motor detector.
 	AMBasicControlDetectorEmulator* braggDetector() const { return braggDetector_; }
-    /// Returns the bragg move retries detector.
-    AMBasicControlDetectorEmulator* braggMoveRetriesDetector() const { return braggMoveRetriesDetector_; }
-    /// Returns the bragg step setpoint detector.
-    AMBasicControlDetectorEmulator* braggStepSetpointDetector() const { return braggStepSetpointDetector_; }
-    /// Returns the bragg degree setpoint detector.
-    AMBasicControlDetectorEmulator* braggDegreeSetpointDetector() const { return braggDegreeSetpointDetector_; }
-    /// Returns the physical bragg angle detector.
-    AMBasicControlDetectorEmulator* braggAngleDetector() const { return braggAngleDetector_; }
+	/// Returns the bragg move retries detector.
+	AMBasicControlDetectorEmulator* braggMoveRetriesDetector() const { return braggMoveRetriesDetector_; }
+	/// Returns the bragg step setpoint detector.
+	AMBasicControlDetectorEmulator* braggStepSetpointDetector() const { return braggStepSetpointDetector_; }
+	/// Returns the physical bragg angle detector.
+	AMBasicControlDetectorEmulator* braggAngleDetector() const { return braggAngleDetector_; }
 
-    /// Return the set of BioXAS Motors by given motor category.
+	/// Return the set of BioXAS Motors by given motor category.
 	QList<AMControl *> getMotorsByType(BioXASBeamlineDef::BioXASMotorType category);
 
 protected slots:
@@ -154,9 +152,9 @@ protected:
 	CLSMAXvMotor *variableMaskVertUpperBlade_;
 	CLSMAXvMotor *variableMaskVertLowerBlade_;
 
-    // Monochromator
+	// Monochromator
 
-    BioXASMainMonochromator *mono_;
+	BioXASMainMonochromator *mono_;
 
 	// M2 mirror
 
@@ -179,30 +177,29 @@ protected:
 	AMPVwStatusControl *monoBraggAngle_;
 
 protected:
-    // Connected
-    bool connected_;
+	// Connected
+	bool connected_;
 
-    // Detectors
-    CLSBasicScalerChannelDetector *i0Detector_;
-    CLSBasicScalerChannelDetector *iTDetector_;
-    CLSBasicScalerChannelDetector *i2Detector_;
+	// Detectors
+	CLSBasicScalerChannelDetector *i0Detector_;
+	CLSBasicScalerChannelDetector *iTDetector_;
+	CLSBasicScalerChannelDetector *i2Detector_;
 	AMBasicControlDetectorEmulator *energySetpointDetector_;
 	AMBasicControlDetectorEmulator *energyFeedbackDetector_;
-    AMBasicControlDetectorEmulator *dwellTimeDetector_;
+	AMBasicControlDetectorEmulator *dwellTimeDetector_;
 	AMBasicControlDetectorEmulator *braggDetector_;
-    AMBasicControlDetectorEmulator *braggMoveRetriesDetector_;
-    AMBasicControlDetectorEmulator *braggStepSetpointDetector_;
-    AMBasicControlDetectorEmulator *braggDegreeSetpointDetector_;
-    AMBasicControlDetectorEmulator *braggAngleDetector_;
+	AMBasicControlDetectorEmulator *braggMoveRetriesDetector_;
+	AMBasicControlDetectorEmulator *braggStepSetpointDetector_;
+	AMBasicControlDetectorEmulator *braggAngleDetector_;
 
-    // Scaler
-    CLSSIS3820Scaler *scaler_;
-    AMReadOnlyPVControl *scalerDwellTime_;
+	// Scaler
+	CLSSIS3820Scaler *scaler_;
+	AMReadOnlyPVControl *scalerDwellTime_;
 
-    // Amplifiers
-    CLSKeithley428 *i0Keithley_;
-    CLSKeithley428 *iTKeithley_;
-    CLSKeithley428 *i2Keithley_;
+	// Amplifiers
+	CLSKeithley428 *i0Keithley_;
+	CLSKeithley428 *iTKeithley_;
+	CLSKeithley428 *i2Keithley_;
 };
 
 #endif // BIOXASMAINBEAMLINE_H

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -798,7 +798,7 @@ void BioXASSideBeamline::setupComponents()
 }
 
 void BioXASSideBeamline::setupControlsAsDetectors()
-{	
+{
 	energySetpointDetector_ = new AMBasicControlDetectorEmulator("EnergySetpoint", "EnergySetpoint", new AMReadOnlyPVControl("EnergySetpoint", "BL1607-5-I22:Energy:EV", this), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 	energySetpointDetector_->setHiddenFromUsers(false);
 	energySetpointDetector_->setIsVisible(true);
@@ -830,10 +830,6 @@ void BioXASSideBeamline::setupControlsAsDetectors()
 	braggStepSetpointDetector_ = new AMBasicControlDetectorEmulator("BraggStepSetpoint", "Bragg motor step setpoint", mono_->braggMotor()->stepSetpointControl(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 	braggStepSetpointDetector_->setHiddenFromUsers(false);
 	braggStepSetpointDetector_->setIsVisible(true);
-
-	braggDegreeSetpointDetector_ = new AMBasicControlDetectorEmulator("BraggDegreeSetpoint", "Bragg motor degree setpoint", mono_->braggMotor()->degreeSetpointControl(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
-	braggDegreeSetpointDetector_->setHiddenFromUsers(false);
-	braggDegreeSetpointDetector_->setIsVisible(true);
 
 	braggAngleDetector_ = new AMBasicControlDetectorEmulator("PhysicalBraggAngle", "Physical bragg angle", mono_->energyControl()->braggAngleControl(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 	braggAngleDetector_->setHiddenFromUsers(false);
@@ -898,7 +894,6 @@ void BioXASSideBeamline::setupExposedDetectors()
 	addExposedDetector(braggMoveRetriesDetector_);
 	addExposedDetector(braggMoveRetriesMaxDetector_);
 	addExposedDetector(braggStepSetpointDetector_);
-	addExposedDetector(braggDegreeSetpointDetector_);
 	addExposedDetector(braggAngleDetector_);
 	addExposedDetector(ge32ElementDetector_);
 }

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -245,8 +245,6 @@ public:
 	AMBasicControlDetectorEmulator* braggMoveRetriesMaxDetector() const { return braggMoveRetriesMaxDetector_; }
 	/// Returns the bragg step setpoint detector.
 	AMBasicControlDetectorEmulator* braggStepSetpointDetector() const { return braggStepSetpointDetector_; }
-	/// Returns the bragg degree setpoint detector.
-	AMBasicControlDetectorEmulator* braggDegreeSetpointDetector() const { return braggDegreeSetpointDetector_; }
 	/// Returns the physical bragg angle detector.
 	AMBasicControlDetectorEmulator* braggAngleDetector() const { return braggAngleDetector_; }
 	/// Returns the 32 element Ge detector.
@@ -339,7 +337,6 @@ protected:
 	AMBasicControlDetectorEmulator *braggMoveRetriesDetector_;
 	AMBasicControlDetectorEmulator *braggMoveRetriesMaxDetector_;
 	AMBasicControlDetectorEmulator *braggStepSetpointDetector_;
-	AMBasicControlDetectorEmulator *braggDegreeSetpointDetector_;
 	AMBasicControlDetectorEmulator *braggAngleDetector_;
 	AMBasicControlDetectorEmulator *braggEncoderFeedbackDetector_;
 	BioXAS32ElementGeDetector *ge32ElementDetector_;

--- a/source/beamline/CLS/CLSMAXvMotor.cpp
+++ b/source/beamline/CLS/CLSMAXvMotor.cpp
@@ -36,7 +36,6 @@ CLSMAXvMotor::CLSMAXvMotor(const QString &name, const QString &baseName, const Q
 	killPV_ = new AMProcessVariable(baseName+":kill", true, this);
 
 	stepSetpoint_ = new AMReadOnlyPVControl(name+"StepSetpoint", baseName+":step:sp", this);
-	degreeSetpoint_ = new AMReadOnlyPVControl(name+"DegreeSetpoint", baseName+":deg", this);
 
 	EGUVelocity_ = new AMPVControl(name+"EGUVelocity", baseName+":vel"+pvUnitFieldName+"ps:sp", baseName+":velo"+pvUnitFieldName+"ps", QString(), this, 0.05);
 	EGUBaseVelocity_ = new AMPVControl(name+"EGUBaseVelocity", baseName+":vBase"+pvUnitFieldName+"ps:sp", baseName+":vBase"+pvUnitFieldName+"ps", QString(), this, 0.05);

--- a/source/beamline/CLS/CLSMAXvMotor.h
+++ b/source/beamline/CLS/CLSMAXvMotor.h
@@ -194,8 +194,6 @@ public:
 	AMReadOnlyPVControl *maxRetriesControl() const { return maxRetries_; }
 	/// Returns the step setpoint PV control.
 	AMReadOnlyPVControl *stepSetpointControl() const { return stepSetpoint_; }
-	/// Returns the degree setpoint PV control.
-	AMReadOnlyPVControl *degreeSetpointControl() const { return degreeSetpoint_; }
 	/// Returns the power state PV control.
 	AMPVControl *powerStateControl() const { return powerState_; }
 	/// Returns the clockwise limit status PV control.
@@ -475,8 +473,6 @@ protected:
 
 	/// Read-only control for the step setpoint.
 	AMReadOnlyPVControl *stepSetpoint_;
-	/// Read-only control for the degree setpoint.
-	AMReadOnlyPVControl *degreeSetpoint_;
 
 	/// Read-write control for the (EGU) velocity setting
 	AMPVControl *EGUVelocity_;

--- a/source/beamline/VESPERS/VESPERSBeamline.h
+++ b/source/beamline/VESPERS/VESPERSBeamline.h
@@ -550,7 +550,7 @@ protected slots:
 	/// Determines is currently active on startup.  Also keeps track if the beam is changed outside of Acquaman.  Beam is set to None is if not inside any of the tolerances for the known beam positions.
 	void determineBeam();
 	/// Helper slot to determine what the beam is on startup.
-	void onBeamSelectionMotorConnected() { disconnect(beamSelectionMotor_, SIGNAL(valueChanged(double)), this, SLOT(onBeamSelectionMotorConnected())); determineBeam(); }
+	void onBeamSelectionMotorConnected();
 
 	/// Sets up any connections for the pressure controls once the whole set is connected.  Also checks if there are any errors with everything started up.
 	void pressureConnected(bool connected);

--- a/source/beamline/VESPERS/VESPERSEndstation.cpp
+++ b/source/beamline/VESPERS/VESPERSEndstation.cpp
@@ -36,10 +36,10 @@ VESPERSEndstation::VESPERSEndstation(QObject *parent)
 	wasConnected_ = false;
 
 	// The controls used for the control window.
-	ccdControl_ = new CLSMAXvMotor("CCD motor", "SMTR1607-2-B21-18", "CCD motor", true, 1.0, 2.0, this);
-	microscopeControl_ = new CLSMAXvMotor("Microscope motor", "SMTR1607-2-B21-17", "Microscope motor", false, 1.0, 2.0, this);
-	fourElControl_ = new CLSMAXvMotor("4-Element Vortex motor", "SMTR1607-2-B21-27", "4-Element Vortex motor", true, 1.0, 2.0, this);
-	singleElControl_ = new CLSMAXvMotor("1-Element Vortex motor", "SMTR1607-2-B21-15", "1-Element Vortex motor", true, 1.0, 2.0, this);
+	ccdControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-18:mm:fbk", "SMTR1607-2-B21-18:mm", "SMTR1607-2-B21-18:status", "SMTR1607-2-B21-18:stop", this, 1.0, 2.0);
+	microscopeControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-17:mm:sp", "SMTR1607-2-B21-17:mm", "SMTR1607-2-B21-17:status", "SMTR1607-2-B21-17:stop", this, 1.0, 2.0);
+	fourElControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-27:mm:fbk", "SMTR1607-2-B21-27:mm", "SMTR1607-2-B21-27:status", "SMTR1607-2-B21-27:stop", this, 1.0, 2.0);
+	singleElControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-15:mm:fbk", "SMTR1607-2-B21-15:mm", "SMTR1607-2-B21-15:status", "SMTR1607-2-B21-15:stop", this, 1.0, 2.0);
 
 	laserPositionControl_ = new AMReadOnlyPVControl("Laser Position", "PSD1607-2-B20-01:OUT1:fbk", this);
 	laserPositionStatusControl_ = new AMReadOnlyPVControl("Laser Position Status", "PSD1607-2-B20-01:OUT1:fbk:status", this);


### PR DESCRIPTION
I removed the dependency of CLSMAXvMotor from VESPERS and removed the degree setpoint control from CLSMAXvMotor.  I also removed the detector emulator from BioXASSideBeamline and BioXASMainBeamline since it currently isn't required.  