### PR TITLE
Pull Request for Issue1348: Cleanup actions are not called when scans are cancelled.

### DIFF
--- a/source/acquaman/AMScanActionController.cpp
+++ b/source/acquaman/AMScanActionController.cpp
@@ -37,7 +37,7 @@ AMScanActionController::AMScanActionController(AMScanConfiguration *configuratio
 	scanningActions_ = 0;
 	initializationActions_ = 0;
 	cleanupActions_ = 0;
-	scanningActionsSucceeded_ = false;
+	scanningActionsFinalState_ = NotFinished;
 	scanControllerStateMachineFinished_ = false;
 
 	fileWriterThread_ = 0;
@@ -211,7 +211,7 @@ void AMScanActionController::onInitializationActionsListFailed()
 
 void AMScanActionController::onScanningActionsSucceeded()
 {
-	scanningActionsSucceeded_ = true;
+	scanningActionsFinalState_ = Succeeded;
 
 	disconnect(scanningActions_, SIGNAL(succeeded()), this, SLOT(onScanningActionsSucceeded()));
 	disconnect(scanningActions_, SIGNAL(failed()), this, SLOT(onScanningActionsFailed()));
@@ -298,7 +298,7 @@ void AMScanActionController::onCleanupActionsListSucceeded()
 	disconnect(cleanupActions_, SIGNAL(succeeded()), this, SLOT(onCleanupActionsListSucceeded()));
 	disconnect(cleanupActions_, SIGNAL(failed()), this, SLOT(onCleanupActionsListFailed()));
 
-	if(scanningActionsSucceeded_){
+	if(scanningActionsFinalState_){
 		scanControllerStateMachineFinished_ = true;
 		// Don't do anything else, if we're not ready for finished but we're succeeding then the file writing should finish soon and will check again
 		if(readyForFinished())

--- a/source/acquaman/AMScanActionController.h
+++ b/source/acquaman/AMScanActionController.h
@@ -79,14 +79,20 @@ protected slots:
 
 	/// Handles the cleanup after the initialization actions succeed.  Can be reimplemented for more specific behaviour.
 	virtual void onInitializationActionsListSucceeded();
+	/// Handles the cleanup after the initialization actions are cancelled.  Can be reimplemented for more specific behaviour.
+	virtual void onInitializationActionsListCancelled();
 	/// Handles the cleanup after the initialization actions fail.  Can be reimplemented for more specific behaviour.
 	virtual void onInitializationActionsListFailed();
 	/// Handles the cleanup after the cleanup actions succeed.  Can be reimplemented for more specific behaviour.
 	virtual void onCleanupActionsListSucceeded();
+	/// Handles the cleanup after the cleanup actions are cancelled.  Can be reimplemented for more specific behaviour.
+	virtual void onCleanupActionsListCancelled();
 	/// Handles the cleanup after the cleanup actions fail.  Can be reimplemented for more specific behaviour.
 	virtual void onCleanupActionsListFailed();
 	/// Handles starting the cleanup actions list after the scan controller actions tree completed successfully.  Can be reimplemented for more specific behaviour.
 	virtual void onScanningActionsSucceeded();
+	/// Handles starting the cleanup actions list after the scan controller actions tree is cancelled.  Can be reimplemented for more specific behaviour.
+	virtual void onScanningActionsCancelled();
 	/// Handles starting the cleanup actions list after the scan controller actions tree failed.  Can be reimplemented for more specific behaviour.
 	virtual void onScanningActionsFailed();
 
@@ -128,6 +134,11 @@ protected:
 	bool readyForFinished() const;
 
 protected:
+	/// Helper method that sets up the initialization actions for running and starts them.
+	void setupAndRunInitializationActions();
+	/// Helper method that sets up the cleanup actions for running and starts them.
+	void setupAndRunCleanupActions();
+
 	/// The pointer that holds the scanning actions.
 	AMAction3 *scanningActions_;
 	/// Flag holding whether the scan was successful or not.

--- a/source/acquaman/AMScanActionController.h
+++ b/source/acquaman/AMScanActionController.h
@@ -39,6 +39,16 @@ class AMScanActionController : public AMScanController
 	Q_OBJECT
 
 public:
+
+	/// Enum that holds what the final state of the scan action controller is.  This is important for setting the final state after the cleanup actions have been executed.
+	enum ScanningActionsFinalState
+	{
+		NotFinished = 0,
+		Succeeded,
+		Cancelled,
+		Failed
+	};
+
 	/// Constructor.  Requires the scan configuration.
 	AMScanActionController(AMScanConfiguration *configuration, QObject *parent = 0);
 	/// Destructor.
@@ -121,7 +131,7 @@ protected:
 	/// The pointer that holds the scanning actions.
 	AMAction3 *scanningActions_;
 	/// Flag holding whether the scan was successful or not.
-	bool scanningActionsSucceeded_;
+	ScanningActionsFinalState scanningActionsFinalState_;
 	/// The intialization actions for the scan.
 	AMAction3 *initializationActions_;
 	/// The cleanup actions for the scan.

--- a/source/acquaman/AMScanController.h
+++ b/source/acquaman/AMScanController.h
@@ -118,6 +118,8 @@ signals:
 	/// Scan failed (due to some reason out of the user's control). Synonym for stateChanged(anything, Failed).
 	void failed();
 
+	/// Notifier that the initization actions are starting.  This may not be emitted by all scan controller.
+	void initializingActionsStarted();
 	/// Notifier that the cleaning actions are being used.  This may not be emitted by all scan controllers.
 	void cleaningActionsStarted();
 

--- a/source/actions3/actions/AMScanAction.cpp
+++ b/source/actions3/actions/AMScanAction.cpp
@@ -137,6 +137,7 @@ void AMScanAction::startImplementation()
 	connect(controller_, SIGNAL(cancelled()), this, SLOT(onControllerCancelled()));
 	connect(controller_, SIGNAL(failed()), this, SLOT(onControllerFailed()));
 	connect(controller_, SIGNAL(finished()), this, SLOT(onControllerSucceeded()));
+	connect(controller_, SIGNAL(initializingActionsStarted()), this, SLOT(onControllerInitializing()));
 	connect(controller_, SIGNAL(cleaningActionsStarted()), this, SLOT(onControllerCleaningUp()));
 	connect(controller_, SIGNAL(progress(double,double)), this, SLOT(onControllerProgressChanged(double,double)));
 	connect(controller_, SIGNAL(stateChanged(int,int)), this, SLOT(onControllerStateChanged()));
@@ -282,6 +283,11 @@ void AMScanAction::onControllerSucceeded()
 		AMErrorMon::alert(this, AMSCANACTION_CONTROLLER_NOT_VALID_FOR_AUTOEXPORT, "Could not export, somehow the scan controller is not available.");
 
 	setSucceeded();
+}
+
+void AMScanAction::onControllerInitializing()
+{
+	setStatusText("Initializing");
 }
 
 void AMScanAction::onControllerCleaningUp()

--- a/source/actions3/actions/AMScanAction.h
+++ b/source/actions3/actions/AMScanAction.h
@@ -92,6 +92,8 @@ protected slots:
 	void onControllerFailed();
 	/// Handles all the wrap up and clean up if the controller succeeds.
 	void onControllerSucceeded();
+	/// Handles setting the status text when the initialization actions are started.
+	void onControllerInitializing();
 	/// Handles setting the status text when cleaning actions are started.
 	void onControllerCleaningUp();
 	/// Handles the progress changed passed up from the controller.

--- a/source/analysis/AM1DDerivativeAB.cpp
+++ b/source/analysis/AM1DDerivativeAB.cpp
@@ -182,6 +182,9 @@ AMNumber AM1DDerivativeAB::value(const AMnDIndex& indexes) const
 	if (!canAnalyze())
 		return AMNumber(AMNumber::InvalidError);
 
+	if (axes_.at(0).size == 1)
+		return AMNumber(AMNumber::DimensionError);
+
 #ifdef AM_ENABLE_BOUNDS_CHECKING
 		if((unsigned)indexes.i() >= (unsigned)axes_.at(0).size)
 			return AMNumber(AMNumber::OutOfBoundsError);
@@ -246,6 +249,9 @@ bool AM1DDerivativeAB::values(const AMnDIndex &indexStart, const AMnDIndex &inde
 	// Bools for knowing whether the indices we were given are at either extreme of the array.
 	bool veryStart = (offset == 0);
 	bool veryEnd = (totalSize == int(axes_.at(0).size));
+
+	if (totalSize == 1)
+		return false;
 
 	// Although substantially more code, I have split up each possibility so that it covers everything properly.  Perhaps later I'll find a code optimization.
 

--- a/source/ui/beamline/AMCurrentAmplifierCompositeView.cpp
+++ b/source/ui/beamline/AMCurrentAmplifierCompositeView.cpp
@@ -1,22 +1,22 @@
 #include "AMCurrentAmplifierCompositeView.h"
 
 AMCurrentAmplifierCompositeView::AMCurrentAmplifierCompositeView(AMCurrentAmplifier *amp1, AMCurrentAmplifier *amp2, QWidget *parent) :
-    AMCurrentAmplifierView(parent)
+	AMCurrentAmplifierView(parent)
 {
-    amplifier1_ = amp1;
+	amplifier1_ = amp1;
 
-    if (amplifier1_) {
-        connect( amplifier1_, SIGNAL(minimumValue(bool)), minus_, SLOT(setDisabled(bool)) );
-        connect( amplifier1_, SIGNAL(maximumValue(bool)), plus_, SLOT(setDisabled(bool)) );
-        connect( amplifier1_, SIGNAL(valueChanged()), this, SLOT(onAmplifierValueChanged()) );
-    }
+	if (amplifier1_) {
+		connect( amplifier1_, SIGNAL(minimumValue(bool)), minus_, SLOT(setDisabled(bool)) );
+		connect( amplifier1_, SIGNAL(maximumValue(bool)), plus_, SLOT(setDisabled(bool)) );
+		connect( amplifier1_, SIGNAL(valueChanged()), this, SLOT(onAmplifierValueChanged()) );
+	}
 
-    setContextMenuPolicy(Qt::CustomContextMenu);
-    connect( this, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)) );
+	setContextMenuPolicy(Qt::CustomContextMenu);
+	connect( this, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)) );
 
-    amplifier2_ = amp2;
+	amplifier2_ = amp2;
 
-    refreshView();
+	refreshView();
 }
 
 AMCurrentAmplifierCompositeView::~AMCurrentAmplifierCompositeView()
@@ -26,118 +26,117 @@ AMCurrentAmplifierCompositeView::~AMCurrentAmplifierCompositeView()
 
 AMCurrentAmplifier* AMCurrentAmplifierCompositeView::amplifier1() const
 {
-    return amplifier1_;
+	return amplifier1_;
 }
 
 AMCurrentAmplifier* AMCurrentAmplifierCompositeView::amplifier2() const
 {
-    return amplifier2_;
+	return amplifier2_;
 }
 
 bool AMCurrentAmplifierCompositeView::isValid() const
 {
-    if (amplifier1_ && amplifier2_ && amplifier1_->amplifierMode() == amplifier2_->amplifierMode())
-        return true;
-    else
-        return false;
+	return (amplifier1_ && amplifier2_
+			&& amplifier1_->isConnected() && amplifier2_->isConnected()
+			&& amplifier1_->amplifierMode() == amplifier2_->amplifierMode());
 }
 
 void AMCurrentAmplifierCompositeView::onAmplifierValueChanged()
 {
-    if (isValid()) {
-        amplifier1_->blockSignals(true);
-        amplifier2_->blockSignals(true);
+	if (isValid()) {
+		amplifier1_->blockSignals(true);
+		amplifier2_->blockSignals(true);
 
-        int newIndex = value_->findText( toDisplay(amplifier1_->value(), amplifier1_->units()) );
+		int newIndex = value_->findText( toDisplay(amplifier1_->value(), amplifier1_->units()) );
 
-        if (newIndex != -1) {
-            value_->setCurrentIndex(newIndex);
-        }
+		if (newIndex != -1) {
+			value_->setCurrentIndex(newIndex);
+		}
 
-        amplifier1_->blockSignals(false);
-        amplifier2_->blockSignals(false);
-    }
+		amplifier1_->blockSignals(false);
+		amplifier2_->blockSignals(false);
+	}
 }
 
 void AMCurrentAmplifierCompositeView::onValueComboBoxChangedImplementation(const QString &newText)
 {
-    amplifier1_->setValue(newText);
-    amplifier2_->setValue(newText);
+	amplifier1_->setValue(newText);
+	amplifier2_->setValue(newText);
 }
 
 void AMCurrentAmplifierCompositeView::onMinusClickedImplementation()
 {
-    amplifier1_->decreaseValue();
-    amplifier2_->decreaseValue();
+	amplifier1_->decreaseValue();
+	amplifier2_->decreaseValue();
 }
 
 void AMCurrentAmplifierCompositeView::onPlusClickedImplementation()
 {
-    amplifier1_->increaseValue();
-    amplifier2_->increaseValue();
+	amplifier1_->increaseValue();
+	amplifier2_->increaseValue();
 }
 
 void AMCurrentAmplifierCompositeView::refreshViewImplementation()
 {
-    refreshValues();
-    refreshButtons();
+	refreshValues();
+	refreshButtons();
 }
 
 void AMCurrentAmplifierCompositeView::onCustomContextMenuRequested(QPoint position)
 {
-    if (isValid()) {
-        QMenu menu(this);
+	if (isValid()) {
+		QMenu menu(this);
 
-        QAction *basic = menu.addAction("Basic view");
-        basic->setDisabled(viewMode_ == Basic);
+		QAction *basic = menu.addAction("Basic view");
+		basic->setDisabled(viewMode_ == Basic);
 
-        QAction *advanced = menu.addAction("Advanced view");
-        advanced->setDisabled(viewMode_ == Advanced);
+		QAction *advanced = menu.addAction("Advanced view");
+		advanced->setDisabled(viewMode_ == Advanced);
 
-        QAction *selected = menu.exec(mapToGlobal(position));
+		QAction *selected = menu.exec(mapToGlobal(position));
 
-        if (selected) {
-            if (selected->text() == "Basic view")
-                setViewMode(Basic);
+		if (selected) {
+			if (selected->text() == "Basic view")
+				setViewMode(Basic);
 
-            else if (selected->text() == "Advanced view")
-                setViewMode(Advanced);
-        }
-    }
+			else if (selected->text() == "Advanced view")
+				setViewMode(Advanced);
+		}
+	}
 }
 
 void AMCurrentAmplifierCompositeView::refreshValues()
 {
-    value_->clear();
+	value_->clear();
 
-    double minValue = 0;
-    double maxValue = 0;
+	double minValue = 0;
+	double maxValue = 0;
 
-    // (re)populate value_ with appropriate options provided by the amplifier.
-    QStringList unitsList = amplifier1_->unitsList();
-    QList<double> valuesList = amplifier1_->values();
+	// (re)populate value_ with appropriate options provided by the amplifier.
+	QStringList unitsList = amplifier1_->unitsList();
+	QList<double> valuesList = amplifier1_->values();
 
-    foreach (QString units, unitsList) {
-        foreach (double value, valuesList) {
+	foreach (QString units, unitsList) {
+		foreach (double value, valuesList) {
 
-            minValue = amplifier1_->minimumValueForUnits(units);
-            maxValue = amplifier1_->maximumValueForUnits(units);
+			minValue = amplifier1_->minimumValueForUnits(units);
+			maxValue = amplifier1_->maximumValueForUnits(units);
 
-            if (value >= minValue && value <= maxValue) {
-                QString item = toDisplay(value, units);
-                value_->addItem(item);
-            }
-        }
-    }
+			if (value >= minValue && value <= maxValue) {
+				QString item = toDisplay(value, units);
+				value_->addItem(item);
+			}
+		}
+	}
 
-    // values displayed should represent the amplifier's current state.
-    onAmplifierValueChanged();
+	// values displayed should represent the amplifier's current state.
+	onAmplifierValueChanged();
 }
 
 void AMCurrentAmplifierCompositeView::refreshButtons()
 {
-    minus_->setDisabled(amplifier1_->atMinimumValue());
-    plus_->setDisabled(amplifier1_->atMaximumValue());
+	minus_->setDisabled(amplifier1_->atMinimumValue());
+	plus_->setDisabled(amplifier1_->atMaximumValue());
 }
 
 

--- a/source/ui/beamline/AMCurrentAmplifierSingleView.cpp
+++ b/source/ui/beamline/AMCurrentAmplifierSingleView.cpp
@@ -1,18 +1,18 @@
 #include "AMCurrentAmplifierSingleView.h"
 
 AMCurrentAmplifierSingleView::AMCurrentAmplifierSingleView(AMCurrentAmplifier *amplifier, QWidget *parent) :
-    AMCurrentAmplifierView(parent)
+	AMCurrentAmplifierView(parent)
 {
-    amplifier_ = amplifier;
-    connect( amplifier_, SIGNAL(amplifierModeChanged()), this, SLOT(refreshView()) );
-    connect( amplifier_, SIGNAL(valueChanged()), this, SLOT(onAmplifierValueChanged()) );
-    connect( amplifier_, SIGNAL(minimumValue(bool)), minus_, SLOT(setDisabled(bool)) );
-    connect( amplifier_, SIGNAL(maximumValue(bool)), plus_, SLOT(setDisabled(bool)) );
+	amplifier_ = amplifier;
+	connect( amplifier_, SIGNAL(amplifierModeChanged()), this, SLOT(refreshView()) );
+	connect( amplifier_, SIGNAL(valueChanged()), this, SLOT(onAmplifierValueChanged()) );
+	connect( amplifier_, SIGNAL(minimumValue(bool)), minus_, SLOT(setDisabled(bool)) );
+	connect( amplifier_, SIGNAL(maximumValue(bool)), plus_, SLOT(setDisabled(bool)) );
 
-    setContextMenuPolicy(Qt::CustomContextMenu);
-    connect( this, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)) );
+	setContextMenuPolicy(Qt::CustomContextMenu);
+	connect( this, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onCustomContextMenuRequested(QPoint)) );
 
-    refreshView();
+	refreshView();
 }
 
 AMCurrentAmplifierSingleView::~AMCurrentAmplifierSingleView()
@@ -22,122 +22,122 @@ AMCurrentAmplifierSingleView::~AMCurrentAmplifierSingleView()
 
 AMCurrentAmplifier* AMCurrentAmplifierSingleView::amplifier() const
 {
-    return amplifier_;
+	return amplifier_;
 }
 
 bool AMCurrentAmplifierSingleView::isValid() const
 {
-    if (amplifier_)
-        return true;
-    else
-        return false;
+	if (amplifier_ && amplifier_->isConnected())
+		return true;
+	else
+		return false;
 }
 
 void AMCurrentAmplifierSingleView::onAmplifierValueChanged()
 {
-    if (isValid()) {
-        amplifier_->blockSignals(true);
+	if (isValid()) {
+		amplifier_->blockSignals(true);
 
-        int newIndex = value_->findText( toDisplay(amplifier_->value(), amplifier_->units()) );
+		int newIndex = value_->findText( toDisplay(amplifier_->value(), amplifier_->units()) );
 
-        if (newIndex != -1)
-            value_->setCurrentIndex(newIndex);
+		if (newIndex != -1)
+			value_->setCurrentIndex(newIndex);
 
-        amplifier_->blockSignals(false);
-    }
+		amplifier_->blockSignals(false);
+	}
 }
 
 void AMCurrentAmplifierSingleView::onValueComboBoxChangedImplementation(const QString &newText)
 {
-    amplifier_->setValue(newText);
+	amplifier_->setValue(newText);
 }
 
 void AMCurrentAmplifierSingleView::onMinusClickedImplementation()
 {
-    amplifier_->decreaseValue();
+	amplifier_->decreaseValue();
 }
 
 void AMCurrentAmplifierSingleView::onPlusClickedImplementation()
 {
-    amplifier_->increaseValue();
+	amplifier_->increaseValue();
 }
 
 void AMCurrentAmplifierSingleView::refreshViewImplementation()
 {
-    refreshValues();
-    refreshButtons();
+	refreshValues();
+	refreshButtons();
 }
 
 void AMCurrentAmplifierSingleView::onCustomContextMenuRequested(QPoint position)
 {
-    if (isValid()) {
-        QMenu menu(this);
+	if (isValid()) {
+		QMenu menu(this);
 
-        QAction *basic = menu.addAction("Basic view");
-        basic->setDisabled(viewMode_ == AMCurrentAmplifierView::Basic);
+		QAction *basic = menu.addAction("Basic view");
+		basic->setDisabled(viewMode_ == AMCurrentAmplifierView::Basic);
 
-        QAction *advanced = menu.addAction("Advanced view");
-        advanced->setDisabled(viewMode_ == AMCurrentAmplifierView::Advanced);
+		QAction *advanced = menu.addAction("Advanced view");
+		advanced->setDisabled(viewMode_ == AMCurrentAmplifierView::Advanced);
 
-        if (amplifier_ && amplifier_->supportsGainMode() && amplifier_->supportsSensitivityMode() && viewMode_ == AMCurrentAmplifierView::Advanced) {
-            menu.addSeparator();
+		if (amplifier_ && amplifier_->supportsGainMode() && amplifier_->supportsSensitivityMode() && viewMode_ == AMCurrentAmplifierView::Advanced) {
+			menu.addSeparator();
 
-            QAction *gain = menu.addAction("Gain view");
-            gain->setDisabled(amplifier_->inGainMode());
+			QAction *gain = menu.addAction("Gain view");
+			gain->setDisabled(amplifier_->inGainMode());
 
-            QAction *sensitivity = menu.addAction("Sensitivity view");
-            sensitivity->setDisabled(amplifier_->inSensitivityMode());
-        }
+			QAction *sensitivity = menu.addAction("Sensitivity view");
+			sensitivity->setDisabled(amplifier_->inSensitivityMode());
+		}
 
-        QAction *selected = menu.exec(mapToGlobal(position));
+		QAction *selected = menu.exec(mapToGlobal(position));
 
-        if (selected) {
-            if (selected->text() == "Basic view")
-                setViewMode(Basic);
+		if (selected) {
+			if (selected->text() == "Basic view")
+				setViewMode(Basic);
 
-            else if (selected->text() == "Advanced view")
-                setViewMode(Advanced);
+			else if (selected->text() == "Advanced view")
+				setViewMode(Advanced);
 
-            else if (selected->text() == "Gain view")
-                amplifier_->setAmplifierMode(AMCurrentAmplifier::Gain);
+			else if (selected->text() == "Gain view")
+				amplifier_->setAmplifierMode(AMCurrentAmplifier::Gain);
 
-            else if (selected->text() == "Sensitivity view")
-                amplifier_->setAmplifierMode(AMCurrentAmplifier::Sensitivity);
-        }
-    }
+			else if (selected->text() == "Sensitivity view")
+				amplifier_->setAmplifierMode(AMCurrentAmplifier::Sensitivity);
+		}
+	}
 }
 
 void AMCurrentAmplifierSingleView::refreshValues()
 {
-    value_->clear();
+	value_->clear();
 
-    double minValue = 0;
-    double maxValue = 0;
+	double minValue = 0;
+	double maxValue = 0;
 
-    // (re)populate value_ with appropriate options provided by the amplifier.
-    QStringList unitsList = amplifier_->unitsList();
+	// (re)populate value_ with appropriate options provided by the amplifier.
+	QStringList unitsList = amplifier_->unitsList();
 
-    QList<double> valuesList = amplifier_->values();
+	QList<double> valuesList = amplifier_->values();
 
-    foreach (QString units, unitsList) {
-        foreach (double value, valuesList) {
+	foreach (QString units, unitsList) {
+		foreach (double value, valuesList) {
 
-            minValue = amplifier_->minimumValueForUnits(units);
-            maxValue = amplifier_->maximumValueForUnits(units);
+			minValue = amplifier_->minimumValueForUnits(units);
+			maxValue = amplifier_->maximumValueForUnits(units);
 
-            if (value >= minValue && value <= maxValue) {
-                QString item = toDisplay(value, units);
-                value_->addItem(item);
-            }
-        }
-    }
+			if (value >= minValue && value <= maxValue) {
+				QString item = toDisplay(value, units);
+				value_->addItem(item);
+			}
+		}
+	}
 
-    // values displayed should represent the amplifier's current state.
-    onAmplifierValueChanged();
+	// values displayed should represent the amplifier's current state.
+	onAmplifierValueChanged();
 }
 
 void AMCurrentAmplifierSingleView::refreshButtons()
 {
-    minus_->setDisabled(amplifier_->atMinimumValue());
-    plus_->setDisabled(amplifier_->atMaximumValue());
+	minus_->setDisabled(amplifier_->atMinimumValue());
+	plus_->setDisabled(amplifier_->atMaximumValue());
 }


### PR DESCRIPTION
Made the scan action controller a little more robust rather than just adding in the cancelled aspect of the state machine cleanup.  @davidChevrier could you go over this for me?