### PR TITLE
PullRequest for Issue1378: Add Ambiant SampleStage XPostion to the Scan configuration and moveAction

### DIFF
--- a/source/actions3/AMLoopActionInfo3.cpp
+++ b/source/actions3/AMLoopActionInfo3.cpp
@@ -22,7 +22,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
  AMLoopActionInfo3::~AMLoopActionInfo3(){}
 AMLoopActionInfo3::AMLoopActionInfo3(int iterations, const QString &shortDescription, const QString &longDescription, const QString &iconFileName, QObject *parent)
-	: AMListActionInfo3(shortDescription, longDescription, iconFileName, parent)
+	: AMListActionInfo3(QString("%1 (repeat %2 times)").arg(shortDescription).arg(iterations), longDescription, iconFileName, parent)
 {
 	loopCount_ = iterations;
 }

--- a/source/application/SXRMB/SXRMBAppController.cpp
+++ b/source/application/SXRMB/SXRMBAppController.cpp
@@ -517,7 +517,6 @@ void SXRMBAppController::onShowAmbiantSampleStageMotorsTriggered()
 	}
 
 	ambiantSampleStageMotorGroupView_->raise();
-	ambiantSampleStageMotorGroupView_->activateWindow();
 	ambiantSampleStageMotorGroupView_->showNormal();
 }
 

--- a/source/beamline/SXRMB/SXRMBBeamline.cpp
+++ b/source/beamline/SXRMB/SXRMBBeamline.cpp
@@ -128,6 +128,7 @@ void SXRMBBeamline::switchEndstation(SXRMB::Endstation endstation)
 
 		case SXRMB::AmbiantWithGasChamber:
 
+			addExposedControl(ambiantSampleStageX_);
 			addExposedControl(ambiantSampleHolderZ_);
 			addExposedControl(ambiantSampleHolderR_);
 
@@ -199,13 +200,13 @@ AMPVwStatusControl* SXRMBBeamline::endstationSampleStageX(SXRMB::Endstation ends
 	case SXRMB::SolidState:
 		statusControl = solidStateSampleStageX();
 		break;
+	case SXRMB::AmbiantWithGasChamber:
 	case SXRMB::AmbiantWithoutGasChamber:
 		statusControl = ambiantSampleStageX();
 		break;
 	case SXRMB::Microprobe:
 		statusControl = microprobeSampleStageX();
 		break;
-	case SXRMB::AmbiantWithGasChamber:
 	default:
 		statusControl = 0;
 	}
@@ -766,7 +767,7 @@ void SXRMBBeamline::setupHVControls()
 {
 	i0HVControl_ = new SXRMBHVControl("I0", "PS1606506:100", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 	teyHVControl_ = new SXRMBHVControl("TEY", "PS1606506:101", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
-	microprobeTEYHVControl_ = new SXRMBHVControl("CHANNEL02", "PS1606506:102", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
+	microprobeTEYHVControl_ = new SXRMBHVControl("Microbe TEY", "PS1606506:102", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 	ambiantIC0HVControl_ = new SXRMBHVControl("IC0", "PS1606506:103", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 	ambiantIC1HVControl_ = new SXRMBHVControl("IC1", "PS1606506:104", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 

--- a/source/beamline/SXRMB/SXRMBBeamline.cpp
+++ b/source/beamline/SXRMB/SXRMBBeamline.cpp
@@ -767,7 +767,7 @@ void SXRMBBeamline::setupHVControls()
 {
 	i0HVControl_ = new SXRMBHVControl("I0", "PS1606506:100", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 	teyHVControl_ = new SXRMBHVControl("TEY", "PS1606506:101", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
-	microprobeTEYHVControl_ = new SXRMBHVControl("Microbe TEY", "PS1606506:102", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
+	microprobeTEYHVControl_ = new SXRMBHVControl("Microprobe TEY", "PS1606506:102", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 	ambiantIC0HVControl_ = new SXRMBHVControl("IC0", "PS1606506:103", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 	ambiantIC1HVControl_ = new SXRMBHVControl("IC1", "PS1606506:104", ":vmon", ":v0set", ":pwonoff", ":status", ":imon");
 


### PR DESCRIPTION
- expose the AmbiantSampleStageX motor to workflow moveAction
- Add SampleStageX motor to EXAFS scan configuration
- Add loop information to the AMLoopActions
- Rename the Microprobe TEY HV control name