### PR TITLE
Pull Request for Issue1375: It appears that skip doesn't necessarily work with the new scan controller changes

### DIFF
--- a/source/acquaman/AMStepScanActionController.cpp
+++ b/source/acquaman/AMStepScanActionController.cpp
@@ -256,6 +256,7 @@ bool AMStepScanActionController::event(QEvent *e)
 
 			if (isStopping() && stoppingAtEndOfLine_){
 
+				disconnect(AMActionRunner3::scanActionRunner()->currentAction(), SIGNAL(cancelled()), this, SLOT(onScanningActionsCancelled()));
 				connect(AMActionRunner3::scanActionRunner()->currentAction(), SIGNAL(cancelled()), this, SLOT(onScanningActionsSucceeded()));
 				AMActionRunner3::scanActionRunner()->cancelCurrentAction();
 				emit finishWritingToFile();
@@ -284,6 +285,7 @@ bool AMStepScanActionController::event(QEvent *e)
 
 			if (isStopping() && !stoppingAtEndOfLine_){
 
+				disconnect(AMActionRunner3::scanActionRunner()->currentAction(), SIGNAL(cancelled()), this, SLOT(onScanningActionsCancelled()));
 				connect(AMActionRunner3::scanActionRunner()->currentAction(), SIGNAL(cancelled()), this, SLOT(onScanningActionsSucceeded()));
 				AMActionRunner3::scanActionRunner()->cancelCurrentAction();
 				emit finishWritingToFile();

--- a/source/ui/BioXAS/BioXASMainXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASMainXASScanConfigurationView.cpp
@@ -66,7 +66,7 @@ BioXASMainXASScanConfigurationView::BioXASMainXASScanConfigurationView(BioXASMai
 		energy_->setValue(configuration_->energy());
 	}
 
-	connect(configuration_, SIGNAL(edgeChanged(QString)), this, SLOT(onEdgeChanged()));
+	connect(configuration_->dbObject(), SIGNAL(edgeChanged(QString)), this, SLOT(onEdgeChanged()));
 
 	QFormLayout *energySetpointLayout = new QFormLayout;
 	energySetpointLayout->addRow("Energy:", energy_);


### PR DESCRIPTION
This was a simple fix by removing the signal for cancelled to the cancelled code when skipping.  A missed signal/slot connection for the BioXAS scan configuration db object is also coming for the ride.