### PR TITLE
Pull Request for Issue1370: Maximum time may not be set properly in BioXASScanConfigurationView when using "Auto EXAFS setup"

### DIFF
--- a/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
@@ -219,12 +219,10 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 					detectorSetDwellList->addSubAction(detectorSetDwellAction);
 			}
 
-			regionList->addSubAction(detectorSetDwellList);
-
 			AMAction3 *controlMove = AMActionSupport::buildControlMoveAction(axisControl, energyPositions.at(i), false);
-
 			controlMove->setGenerateScanActionMessage(true);
 			regionList->addSubAction(controlMove);
+			regionList->addSubAction(detectorSetDwellList);
 			AMListAction3 *nextLevelHolderAction = new AMListAction3(new AMListActionInfo3("Holder Action for the Next Sublevel", "Holder Action for the Next Sublevel"));
 			regionList->addSubAction(nextLevelHolderAction);
 			AMAxisValueFinishedActionInfo *axisValueFinishedInfo = new AMAxisValueFinishedActionInfo;
@@ -245,12 +243,10 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 					detectorSetDwellList->addSubAction(detectorSetDwellAction);
 			}
 
-			regionList->addSubAction(detectorSetDwellList);
-
 			AMAction3 *controlMove = AMActionSupport::buildControlMoveAction(axisControl, double(kCalculator.energy(exafsRegion->regionEnd())), false);
-
 			controlMove->setGenerateScanActionMessage(true);
 			regionList->addSubAction(controlMove);
+			regionList->addSubAction(detectorSetDwellList);
 			AMListAction3 *nextLevelHolderAction = new AMListAction3(new AMListActionInfo3("Holder Action for the Next Sublevel", "Holder Action for the Next Sublevel"));
 			regionList->addSubAction(nextLevelHolderAction);
 			AMAxisValueFinishedActionInfo *axisValueFinishedInfo = new AMAxisValueFinishedActionInfo;

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -38,6 +38,8 @@ class AMCurrentAmplifier;
 
 #include <QSignalMapper>
 
+#define CLSSIS3820SCALER_NOT_CONNECTED_OR_IS_SCANNING 456000
+
 /*!
   Builds an abstraction for the SIS 3820 scaler used throughout the CLS.  It takes in a base name of the PV's and builds all the PV's
   and makes the necessary connections.
@@ -153,7 +155,10 @@ protected slots:
 	void onModeSwitchSignal();
 	bool triggerScalerAcquisition(bool isContinuous);
 	void onReadingChanged(double value);
+	/// Handles the logic for the removing channels from the waiting list.
 	void onChannelReadingChanged(int channelIndex);
+	/// Handles checking to see if we are done the acquisition.
+	void triggerAcquisitionFinished();
 
 	void onDwellTimeSourceSetDwellTime(double dwellSeconds);
 

--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.cpp
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.cpp
@@ -1,7 +1,7 @@
 #include "CLSSIS3820ScalerControlsView.h"
 
 CLSSIS3820ScalerControlsView::CLSSIS3820ScalerControlsView(CLSSIS3820Scaler *scaler, QWidget *parent) :
-    QWidget(parent)
+	QWidget(parent)
 {
 	// Initialize member variables.
 
@@ -211,7 +211,7 @@ void CLSSIS3820ScalerControlsView::onDwellTimeChanged()
 	if (scaler_) {
 		scaler_->blockSignals(true);
 		double seconds = scaler_->dwellTime();
-		time_->setValue((int)seconds * MILLISECONDS_PER_SECOND);
+		time_->setValue(int(seconds * MILLISECONDS_PER_SECOND));
 		scaler_->blockSignals(false);
 	}
 }


### PR DESCRIPTION
Needed to alter the scaler to take into account the scanning PV because all the PVs were being captured in the same event loop and sometimes the scaler would think it's still scanning when it wasn't.  This fix now changes the scaler to listen to the scanning control as well as all the enabled channels.

@davidChevrier, I wouldn't mind a quick double check by you.  It has been tested and works, but I'd like to be extra careful for changes like these.