### PR TITLE
Pull Request for Issue1385: Crash on scan cancel

### DIFF
--- a/source/acquaman/AMScanActionController.cpp
+++ b/source/acquaman/AMScanActionController.cpp
@@ -153,10 +153,7 @@ void AMScanActionController::resumeImplementation()
 
 void AMScanActionController::cancelImplementation()
 {
-	if (AMActionRunner3::scanActionRunner()->cancelCurrentAction())
-		setCancelled();
-
-	else
+	if (!AMActionRunner3::scanActionRunner()->cancelCurrentAction())
 		AMErrorMon::alert(this, AMSCANACTIONCONTROLLER_CANNOT_CANCEL, "Was unable to cancel the current action.");
 }
 


### PR DESCRIPTION
```setCancelled()``` was erroneously being called twice causing a crash. This has now been fixed.