### PR TITLE
Pull Request for Issue1100: Some exposed controls aren't available to exporter (REIXS)

### DIFF
--- a/source/acquaman/REIXS/REIXSXASScanActionController.cpp
+++ b/source/acquaman/REIXS/REIXSXASScanActionController.cpp
@@ -107,6 +107,10 @@ void REIXSXASScanActionController::onInitializationActionSucceeded(){
 
 	AMControlInfoList positions;
 
+	positions.append(REIXSBeamline::bl()->photonSource()->ringCurrent()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->epuPolarization()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->epuPolarizationAngle()->toInfo());
+
 	positions.append(REIXSBeamline::bl()->photonSource()->energy()->toInfo());
 	positions.append(REIXSBeamline::bl()->photonSource()->userEnergyOffset()->toInfo());
 	positions.append(REIXSBeamline::bl()->photonSource()->monoSlit()->toInfo());
@@ -126,7 +130,9 @@ void REIXSXASScanActionController::onInitializationActionSucceeded(){
 		positions.append(polarizationAngle);
 	}
 	positions.append(REIXSBeamline::bl()->photonSource()->monoGratingSelector()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->monoGratingTranslation()->toInfo());
 	positions.append(REIXSBeamline::bl()->photonSource()->monoMirrorSelector()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->monoMirrorTranslation()->toInfo());
 	positions.append(REIXSBeamline::bl()->spectrometer()->spectrometerRotationDrive()->toInfo());
 	positions.append(REIXSBeamline::bl()->spectrometer()->detectorTranslation()->toInfo());
 	positions.append(REIXSBeamline::bl()->spectrometer()->detectorTiltDrive()->toInfo());

--- a/source/acquaman/REIXS/REIXSXESScanActionController.cpp
+++ b/source/acquaman/REIXS/REIXSXESScanActionController.cpp
@@ -170,57 +170,63 @@ void REIXSXESScanActionController::saveRawData(){
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Alert, 38, "Error saving the currently-running XES scan's raw data file to disk. Watch out... your data may not be saved! Please report this bug to the beamline software developers."));
 }
 
-void REIXSXESScanActionController::initializePositions(){
+void REIXSXESScanActionController::initializePositions()
+{
+	//Population Initial condition, prior to initialization moves
+	AMControlInfoList positions;
 
-//Population Initial condition, prior to initialization moves
-AMControlInfoList positions;
+	positions.append(REIXSBeamline::bl()->photonSource()->ringCurrent()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->epuPolarization()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->epuPolarizationAngle()->toInfo());
 
-positions.append(REIXSBeamline::bl()->photonSource()->energy()->toInfo());
-positions.append(REIXSBeamline::bl()->photonSource()->userEnergyOffset()->toInfo());
-positions.append(REIXSBeamline::bl()->photonSource()->monoSlit()->toInfo());
-positions.append(REIXSBeamline::bl()->sampleChamber()->x()->toInfo());
-positions.append(REIXSBeamline::bl()->sampleChamber()->y()->toInfo());
-positions.append(REIXSBeamline::bl()->sampleChamber()->z()->toInfo());
-positions.append(REIXSBeamline::bl()->sampleChamber()->r()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->gratingMask()->toInfo());  //D
-positions.append(REIXSBeamline::bl()->spectrometer()->toInfo());
-// add the polarization selection, since it's not a "control" anywhere.
-AMControlInfo polarization("beamlinePolarization", REIXSBeamline::bl()->photonSource()->epuPolarization()->value(), 0, 0, "[choice]", 0.1, "EPU Polarization");
-polarization.setEnumString(REIXSBeamline::bl()->photonSource()->epuPolarization()->enumNameAt(REIXSBeamline::bl()->photonSource()->epuPolarization()->value()));
-positions.append(polarization);
-	if(REIXSBeamline::bl()->photonSource()->epuPolarization()->value() == 5)
-	{
-		AMControlInfo polarizationAngle("beamlinePolarizationAngle", REIXSBeamline::bl()->photonSource()->epuPolarizationAngle()->value(), 0, 0, "degrees", 0.1, "EPU Polarization Angle");
-		positions.append(polarizationAngle);
-	}
-positions.append(REIXSBeamline::bl()->photonSource()->monoGratingSelector()->toInfo());
-positions.append(REIXSBeamline::bl()->photonSource()->monoMirrorSelector()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->spectrometerRotationDrive()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->detectorTranslation()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->detectorTiltDrive()->toInfo());
-// add the spectrometer grating selection, since it's not a "control" anywhere.
-AMControlInfo grating("spectrometerGrating", REIXSBeamline::bl()->spectrometer()->specifiedGrating(), 0, 0, "[choice]", 0.1, "Spectrometer Grating");
-grating.setEnumString(REIXSBeamline::bl()->spectrometer()->spectrometerCalibration()->gratingAt(int(grating.value())).name());
-positions.append(grating);
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->x()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->y()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->z()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->u()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->v()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->w()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->r()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->s()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->t()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->endstationTranslation()->toInfo());
-positions.append(REIXSBeamline::bl()->photonSource()->M5Pitch()->toInfo());
-positions.append(REIXSBeamline::bl()->photonSource()->M5Yaw()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->energy()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->userEnergyOffset()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->monoSlit()->toInfo());
+	positions.append(REIXSBeamline::bl()->sampleChamber()->x()->toInfo());
+	positions.append(REIXSBeamline::bl()->sampleChamber()->y()->toInfo());
+	positions.append(REIXSBeamline::bl()->sampleChamber()->z()->toInfo());
+	positions.append(REIXSBeamline::bl()->sampleChamber()->r()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->gratingMask()->toInfo());  //D
+	positions.append(REIXSBeamline::bl()->spectrometer()->toInfo());
+	// add the polarization selection, since it's not a "control" anywhere.
+	AMControlInfo polarization("beamlinePolarization", REIXSBeamline::bl()->photonSource()->epuPolarization()->value(), 0, 0, "[choice]", 0.1, "EPU Polarization");
+	polarization.setEnumString(REIXSBeamline::bl()->photonSource()->epuPolarization()->enumNameAt(REIXSBeamline::bl()->photonSource()->epuPolarization()->value()));
+	positions.append(polarization);
+		if(REIXSBeamline::bl()->photonSource()->epuPolarization()->value() == 5)
+		{
+			AMControlInfo polarizationAngle("beamlinePolarizationAngle", REIXSBeamline::bl()->photonSource()->epuPolarizationAngle()->value(), 0, 0, "degrees", 0.1, "EPU Polarization Angle");
+			positions.append(polarizationAngle);
+		}
+	positions.append(REIXSBeamline::bl()->photonSource()->monoGratingSelector()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->monoGratingTranslation()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->monoMirrorSelector()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->monoMirrorTranslation()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->spectrometerRotationDrive()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->detectorTranslation()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->detectorTiltDrive()->toInfo());
+	// add the spectrometer grating selection, since it's not a "control" anywhere.
+	AMControlInfo grating("spectrometerGrating", REIXSBeamline::bl()->spectrometer()->specifiedGrating(), 0, 0, "[choice]", 0.1, "Spectrometer Grating");
+	grating.setEnumString(REIXSBeamline::bl()->spectrometer()->spectrometerCalibration()->gratingAt(int(grating.value())).name());
+	positions.append(grating);
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->x()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->y()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->z()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->u()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->v()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->w()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->r()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->s()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->hexapod()->t()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->endstationTranslation()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->M5Pitch()->toInfo());
+	positions.append(REIXSBeamline::bl()->photonSource()->M5Yaw()->toInfo());
 
-positions.append(REIXSBeamline::bl()->spectrometer()->tmSOE()->toInfo());
-positions.append(REIXSBeamline::bl()->spectrometer()->tmMCPPreamp()->toInfo());
-positions.append(REIXSBeamline::bl()->sampleChamber()->tmSample()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->tmSOE()->toInfo());
+	positions.append(REIXSBeamline::bl()->spectrometer()->tmMCPPreamp()->toInfo());
+	positions.append(REIXSBeamline::bl()->sampleChamber()->tmSample()->toInfo());
 
 
-scan_->setScanInitialConditions(positions);
+	scan_->setScanInitialConditions(positions);
 }
 
 


### PR DESCRIPTION
Altered REIXSXESScanActionController/REIXSXASScanActionController::initializePositions() ~ Appended ringCurrent, epuPolarization, epuPolarizationAngle, monoGratingTranslation and monoMirrorTranslation to the list of controls which are used to set the scan's initial conditions.

#1100