### PR TITLE
PullRequest for Issue678: Refine the stop logic so that we display the correct message when controlAction failed

### DIFF
--- a/source/actions3/actions/AMControlMoveAction3.cpp
+++ b/source/actions3/actions/AMControlMoveAction3.cpp
@@ -151,7 +151,6 @@ void AMControlMoveAction3::onMoveReTargetted()
 
 void AMControlMoveAction3::onMoveFailed(int reason)
 {
-	bool reportMoveError = true;
 	bool retryAvailable = false;
 
 	int definedFailureReason;
@@ -169,7 +168,6 @@ void AMControlMoveAction3::onMoveFailed(int reason)
 		break;
 	case AMControl::WasStoppedFailure:
 		definedFailureReason = AMCONTROLMOVEACTION3_WAS_STOPPED_FAILURE;
-		reportMoveError = false;
 		break;
 	case AMControl::AlreadyMovingFailure:
 		definedFailureReason = AMCONTROLMOVEACTION3_ALREADY_MOVING_FAILURE;
@@ -194,11 +192,13 @@ void AMControlMoveAction3::onMoveFailed(int reason)
 	if(retryAvailable)
 		retryAvailableString = "Yes";
 	QString fundamentalFailureMessage = QString("There was an error moving the control '%1' into position (Retry %2, attempt %3 of %4). Target: %5 %6. Actual position: %7 %8. Tolerance %9. Reason: %10.").arg(control_->name()).arg(retryAvailableString).arg(attempts_).arg(retries_+1).arg(control_->setpoint()).arg(control_->units()).arg(control_->value()).arg(control_->units()).arg(control_->tolerance()).arg(AMControl::failureExplanation(reason));
-	if (reportMoveError) {
+	if (reason == AMControl::WasStoppedFailure) {
+
+		AMErrorMon::alert(this, definedFailureReason, fundamentalFailureMessage);
+	} else {
+
 		// error message with reason
 		AMErrorMon::alert(this, definedFailureReason, QString("%1. Please report this problem to the beamline staff.").arg(fundamentalFailureMessage));
-	} else {
-		AMErrorMon::alert(this, definedFailureReason, fundamentalFailureMessage);
 	}
 
 	if(retryAvailable){

--- a/source/actions3/actions/AMControlMoveAction3.cpp
+++ b/source/actions3/actions/AMControlMoveAction3.cpp
@@ -151,6 +151,7 @@ void AMControlMoveAction3::onMoveReTargetted()
 
 void AMControlMoveAction3::onMoveFailed(int reason)
 {
+	bool reportMoveError = true;
 	bool retryAvailable = false;
 
 	int definedFailureReason;
@@ -168,6 +169,7 @@ void AMControlMoveAction3::onMoveFailed(int reason)
 		break;
 	case AMControl::WasStoppedFailure:
 		definedFailureReason = AMCONTROLMOVEACTION3_WAS_STOPPED_FAILURE;
+		reportMoveError = false;
 		break;
 	case AMControl::AlreadyMovingFailure:
 		definedFailureReason = AMCONTROLMOVEACTION3_ALREADY_MOVING_FAILURE;
@@ -192,8 +194,12 @@ void AMControlMoveAction3::onMoveFailed(int reason)
 	if(retryAvailable)
 		retryAvailableString = "Yes";
 	QString fundamentalFailureMessage = QString("There was an error moving the control '%1' into position (Retry %2, attempt %3 of %4). Target: %5 %6. Actual position: %7 %8. Tolerance %9. Reason: %10.").arg(control_->name()).arg(retryAvailableString).arg(attempts_).arg(retries_+1).arg(control_->setpoint()).arg(control_->units()).arg(control_->value()).arg(control_->units()).arg(control_->tolerance()).arg(AMControl::failureExplanation(reason));
-	// error message with reason
-	AMErrorMon::alert(this, definedFailureReason, QString("%1. Please report this problem to the beamline staff.").arg(fundamentalFailureMessage));
+	if (reportMoveError) {
+		// error message with reason
+		AMErrorMon::alert(this, definedFailureReason, QString("%1. Please report this problem to the beamline staff.").arg(fundamentalFailureMessage));
+	} else {
+		AMErrorMon::alert(this, definedFailureReason, fundamentalFailureMessage);
+	}
 
 	if(retryAvailable){
 		attempts_++;

--- a/source/beamline/REIXS/REIXSBeamline.cpp
+++ b/source/beamline/REIXS/REIXSBeamline.cpp
@@ -874,8 +874,8 @@ AMControl::FailureExplanation REIXSBrokenMonoControl::move(double setpoint)
 bool REIXSBrokenMonoControl::stop()
 {
 	if(moveAction_) {
-		moveAction_->cancel();
 		stopInProgress_ = true;
+		moveAction_->cancel();
 	}
 	bool success = control_->stop();
 	QTimer *repeat = new QTimer(this);
@@ -933,6 +933,8 @@ void REIXSBrokenMonoControl::onMoveActionSucceeded()
 	else {
 		emit moveFailed(AMControl::ToleranceFailure);
 	}
+
+	stopInProgress_ = false;
 }
 
 void REIXSBrokenMonoControl::onMonoAngleError(double error)

--- a/source/ui/REIXS/REIXSActionBasedControlEditor.cpp
+++ b/source/ui/REIXS/REIXSActionBasedControlEditor.cpp
@@ -19,12 +19,12 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "REIXSActionBasedControlEditor.h"
-#include "util/AMErrorMonitor.h"
+
 #include "beamline/AMControl.h"
 #include "actions3/AMAction3.h"
-#include "actions3/actions/AMControlMoveAction3.h"
+#include "actions3/AMActionSupport.h"
+#include "util/AMErrorMonitor.h"
 
-#include <QApplication>
 
 REIXSActionBasedControlEditor::REIXSActionBasedControlEditor(AMControl* control, bool okToRunInBackground, QWidget *parent) :
 	AMControlEditor(control, 0, parent)
@@ -39,10 +39,7 @@ void REIXSActionBasedControlEditor::onNewSetpointChosen(double value)
 	if(!control_)
 		return;
 
-	AMControlInfo setpoint = control_->toInfo();
-	setpoint.setValue(value);
-
-	AMAction3* action = new AMControlMoveAction3(new AMControlMoveActionInfo3(setpoint), control_);
+	AMAction3* action = AMActionSupport::buildControlMoveAction(control_, value);
 	connect(action, SIGNAL(succeeded()), action, SLOT(deleteLater()));
 	connect(action, SIGNAL(failed()), action, SLOT(deleteLater()));
 	connect(action, SIGNAL(cancelled()), action, SLOT(deleteLater()));

--- a/source/ui/REIXS/REIXSActionBasedControlEditor.cpp
+++ b/source/ui/REIXS/REIXSActionBasedControlEditor.cpp
@@ -21,6 +21,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "REIXSActionBasedControlEditor.h"
 #include "util/AMErrorMonitor.h"
 #include "beamline/AMControl.h"
+#include "actions3/AMAction3.h"
 #include "actions3/actions/AMControlMoveAction3.h"
 
 #include <QApplication>
@@ -29,34 +30,21 @@ REIXSActionBasedControlEditor::REIXSActionBasedControlEditor(AMControl* control,
 	AMControlEditor(control, 0, parent)
 {
 	okToRunInBackground_ = okToRunInBackground;
-	controlMoveAction_ = 0;
 }
 
 REIXSActionBasedControlEditor::~REIXSActionBasedControlEditor(){}
 
-void REIXSActionBasedControlEditor::onControlMoveActionFinished()
-{
-	if (controlMoveAction_) {
-		disconnect(controlMoveAction_, SIGNAL(succeeded()));
-		disconnect(controlMoveAction_, SIGNAL(failed()));
-		disconnect(controlMoveAction_, SIGNAL(cancelled()));
-
-		controlMoveAction_->deleteLater();
-		controlMoveAction_ = 0;
-	}
-}
-
 void REIXSActionBasedControlEditor::onNewSetpointChosen(double value)
 {
-	if(!control_ || controlMoveAction_)
+	if(!control_)
 		return;
 
 	AMControlInfo setpoint = control_->toInfo();
 	setpoint.setValue(value);
 
-	controlMoveAction_ = new AMControlMoveAction3(new AMControlMoveActionInfo3(setpoint), control_);
-	connect(controlMoveAction_, SIGNAL(succeeded()), this, SLOT(onControlMoveActionFinished()));
-	connect(controlMoveAction_, SIGNAL(failed()), this, SLOT(onControlMoveActionFinished()));
-	connect(controlMoveAction_, SIGNAL(cancelled()), this, SLOT(onControlMoveActionFinished()));
-	controlMoveAction_->start();
+	AMAction3* action = new AMControlMoveAction3(new AMControlMoveActionInfo3(setpoint), control_);
+	connect(action, SIGNAL(succeeded()), action, SLOT(deleteLater()));
+	connect(action, SIGNAL(failed()), action, SLOT(deleteLater()));
+	connect(action, SIGNAL(cancelled()), action, SLOT(deleteLater()));
+	action->start();
 }

--- a/source/ui/REIXS/REIXSActionBasedControlEditor.h
+++ b/source/ui/REIXS/REIXSActionBasedControlEditor.h
@@ -21,6 +21,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef REIXSACTIONBASEDCONTROLEDITOR_H
 #define REIXSACTIONBASEDCONTROLEDITOR_H
 
+#include "actions3/AMAction3.h"
 #include "ui/beamline/AMControlEditor.h"
 
 /// Re-implements AMControlEditor to do its moves inside AMActionRunner with a REIXSControlMoveAction.
@@ -32,6 +33,9 @@ public:
  	virtual ~REIXSActionBasedControlEditor();
 	REIXSActionBasedControlEditor(AMControl* control, bool okToRunInBackground = false, QWidget *parent = 0);
 
+public slots:
+	/// the slot to release resouces when the contol move is done (succeeded, cancelled or failed)
+	void onControlMoveActionFinished();
 
 protected slots:
 	/// Re-implemented from AMControlEditor
@@ -40,6 +44,7 @@ protected slots:
 protected:
 	bool okToRunInBackground_;
 
+	AMAction3* controlMoveAction_;
 };
 
 #endif // REIXSACTIONBASEDCONTROLEDITOR_H

--- a/source/ui/REIXS/REIXSActionBasedControlEditor.h
+++ b/source/ui/REIXS/REIXSActionBasedControlEditor.h
@@ -21,7 +21,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef REIXSACTIONBASEDCONTROLEDITOR_H
 #define REIXSACTIONBASEDCONTROLEDITOR_H
 
-#include "actions3/AMAction3.h"
 #include "ui/beamline/AMControlEditor.h"
 
 /// Re-implements AMControlEditor to do its moves inside AMActionRunner with a REIXSControlMoveAction.
@@ -33,18 +32,12 @@ public:
  	virtual ~REIXSActionBasedControlEditor();
 	REIXSActionBasedControlEditor(AMControl* control, bool okToRunInBackground = false, QWidget *parent = 0);
 
-public slots:
-	/// the slot to release resouces when the contol move is done (succeeded, cancelled or failed)
-	void onControlMoveActionFinished();
-
 protected slots:
 	/// Re-implemented from AMControlEditor
 	virtual void onNewSetpointChosen(double value);
 
 protected:
 	bool okToRunInBackground_;
-
-	AMAction3* controlMoveAction_;
 };
 
 #endif // REIXSACTIONBASEDCONTROLEDITOR_H

--- a/source/ui/REIXS/REIXSSidebar.cpp
+++ b/source/ui/REIXS/REIXSSidebar.cpp
@@ -10,6 +10,7 @@ the Free Software Foundation, either version 3 of the License, or
 
 Acquaman is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
+
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
@@ -107,6 +108,7 @@ void REIXSSidebar::onScalerContinuousModeChanged(double on)
 void REIXSSidebar::on_MonoStopButton_clicked()
 {
 	REIXSBeamline::bl()->photonSource()->energy()->stop();
+	beamlineEnergyEditor_->onControlMoveActionFinished();
 	AMActionRunner3::scanActionRunner()->cancelCurrentAction();
 	AMActionRunner3::workflow()->cancelCurrentAction();
 }

--- a/source/ui/REIXS/REIXSSidebar.cpp
+++ b/source/ui/REIXS/REIXSSidebar.cpp
@@ -10,7 +10,6 @@ the Free Software Foundation, either version 3 of the License, or
 
 Acquaman is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
@@ -108,7 +107,6 @@ void REIXSSidebar::onScalerContinuousModeChanged(double on)
 void REIXSSidebar::on_MonoStopButton_clicked()
 {
 	REIXSBeamline::bl()->photonSource()->energy()->stop();
-	beamlineEnergyEditor_->onControlMoveActionFinished();
 	AMActionRunner3::scanActionRunner()->cancelCurrentAction();
 	AMActionRunner3::workflow()->cancelCurrentAction();
 }
@@ -149,7 +147,7 @@ void REIXSSidebar::setupConnections()
 	connect(REIXSBeamline::bl()->photonSource()->ringCurrent(), SIGNAL(valueChanged(double)), this, SLOT(onRingCurrentChanged(double)));
 }
 
-void *REIXSSidebar::layoutBeamlineContent()
+void REIXSSidebar::layoutBeamlineContent()
 {
 
 	QFont font;
@@ -215,7 +213,7 @@ void *REIXSSidebar::layoutBeamlineContent()
 	beamlineGroupBox_->setLayout(beamlineFormLayout);
 }
 
-void *REIXSSidebar::layoutDetectorContent()
+void REIXSSidebar::layoutDetectorContent()
 {
 	XESValue_ = new QLabel("XES:\t\t0 counts");
 	XESValue_->setFixedHeight(55);

--- a/source/ui/REIXS/REIXSSidebar.h
+++ b/source/ui/REIXS/REIXSSidebar.h
@@ -87,8 +87,8 @@ private:
 	void setupUi();
 	void setupConnections();
 
-	void *layoutBeamlineContent();
-	void *layoutDetectorContent();
+	void layoutBeamlineContent();
+	void layoutDetectorContent();
 	QPushButton *createPushButton(QString text);
 };
 


### PR DESCRIPTION
https://github.com/acquaman/acquaman/issues/678

Original: 
    when stop moving button clicked, the message shows `Reason: An undocumented failure happened`

New fix:
   the error message shows `Reason: The move was manually interrupted or stopped.`