### PR TITLE
Pull Request for Issue1085: REIXS XAS scan naming issue

### DIFF
--- a/source/acquaman/REIXS/REIXSXASScanActionController.cpp
+++ b/source/acquaman/REIXS/REIXSXASScanActionController.cpp
@@ -72,7 +72,7 @@ REIXSXASScanActionController::REIXSXASScanActionController(REIXSXASScanConfigura
 	else {
 		scan_->setName(configuration_->userScanName());
 		if(scan_->name().isEmpty())
-			scan_->setName(QString("%1 %2").arg(configuration_->autoScanName()).arg(rangeString));
+			scan_->setName(QString("Unnamed %1 %2").arg(configuration_->autoScanName()).arg(rangeString));
 		scan_->setSampleId(configuration_->sampleId());
 	}
 

--- a/source/acquaman/REIXS/REIXSXASScanConfiguration.h
+++ b/source/acquaman/REIXS/REIXSXASScanConfiguration.h
@@ -90,7 +90,7 @@ public:
 	}
 	/// The auto-generated scan name. Used when no name is provided.
 	virtual QString autoScanName() const {
-			return QString("Unnamed XAS Scan");
+			return QString("XAS Scan");
 	}
 
 

--- a/source/acquaman/REIXS/REIXSXESScanConfiguration.h
+++ b/source/acquaman/REIXS/REIXSXESScanConfiguration.h
@@ -63,7 +63,7 @@ public:
 	virtual ~REIXSXESScanConfiguration();
 
 	/// The auto-generated scan name. Can be re-implemented to customize for each scan type.
-	virtual QString autoScanName() const { return "XES"; }
+	virtual QString autoScanName() const { return "XES Scan"; }
 
 	/// A human-readable description of this scan configuration. Used by scan action to set the title for the action view.
 	virtual QString description() const;


### PR DESCRIPTION
- Removed the word 'Unnamed' from REIXSXASScanConfiguration::autoScanName() ~ This was presumably this way before intending that it would only be used in cases where a scan name was not set. This isn't currently the case in REIXSXASScanActionController.
- Added the word 'Unnamed' to the REIXSXASScanActionController constructor, in which it initializes the scan and sets its name, for the specific case when we know for certain that the scan name is empty.
- Altered the string returned by REIXSXESScanConfiguration::autoScanName() from 'XES' to 'XES Scan' so both scans are of the same format.

#1085 