### PR TITLE
#1414 Fixed switching out thumnails in AMScanThumbnailGridView

### DIFF
--- a/source/ui/dataman/AMScanThumbnailGridView.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridView.cpp
@@ -207,7 +207,7 @@ void AMScanThumbnailGridView::onHoverMove(int itemIndex, int positionX, int posi
 		return;
 
 	// get position of x within the content rectangle for itemIndex
-	QModelIndex modelThumbnailImageIndex = model()->index(itemIndex, 1, modelIndexOfItem);
+	QModelIndex modelThumbnailImageIndex = model()->index(0, 1, modelIndexOfItem);
 	QRect thumbnailImageRectangle = visualRect(modelThumbnailImageIndex);
 	QPoint posInsideRect(positionX - thumbnailImageRectangle.x(), positionY - thumbnailImageRectangle.y());
 


### PR DESCRIPTION
Was creating a QModelIndex for a thumbnail using the scan row, not the thumbnail row.