### PR TITLE
Pull Request for Issue1273: Add the Xspress3 detector into XAS scans

### DIFF
--- a/source/acquaman/BioXAS/BioXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.h
@@ -32,6 +32,8 @@ public:
 	double energy() const { return dbObject_->energy(); }
 	/// Returns the edge.
 	QString edge() const { return dbObject_->edge(); }
+	/// Returns whether the scan is using an XRF detector or not.
+	bool usingXRFDetector() const { return dbObject_->usingXRFDetector(); }
 	/// Returns the list of regions of interest.
 	QList<AMRegionOfInterest *> regionsOfInterest() const { return dbObject_->regionsOfInterest(); }
 
@@ -49,6 +51,8 @@ public:
 	void setEnergy(double newEnergy) { dbObject_->setEnergy(newEnergy); }
 	/// Sets the edge.
 	void setEdge(const QString &newEdge) { dbObject_->setEdge(newEdge); }
+	/// Sets whether the configuration is using an XRF detector.
+	void setUsingXRFDetector(bool hasXRF) { dbObject_->setUsingXRFDetector(hasXRF); }
 	/// Adds a region of interest to the list.
 	void addRegionOfInterest(AMRegionOfInterest *region) { dbObject_->addRegionOfInterest(region); }
 	/// Removes a region of interest from the list.

--- a/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.cpp
+++ b/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.cpp
@@ -5,6 +5,7 @@ BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(QObject *parent
 {
 	energy_ = 0.0;
 	edge_ = "";
+	usingXRFDetector_ = true;
 }
 
 BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(const BioXASScanConfigurationDbObject &original)
@@ -12,6 +13,7 @@ BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(const BioXASSca
 {
 	energy_ = original.energy();
 	edge_ = original.edge();
+	usingXRFDetector_ = original.usingXRFDetector();
 
 	foreach (AMRegionOfInterest *region, original.regionsOfInterest())
 		addRegionOfInterest(region->createCopy());
@@ -38,6 +40,16 @@ void BioXASScanConfigurationDbObject::setEdge(const QString &newEdge)
 
 		edge_ = newEdge;
 		emit edgeChanged(edge_);
+		setModified(true);
+	}
+}
+
+void BioXASScanConfigurationDbObject::setUsingXRFDetector(bool hasXRF)
+{
+	if (usingXRFDetector_ != hasXRF){
+
+		usingXRFDetector_ = hasXRF;
+		emit usingXRFDetectorChanged(usingXRFDetector_);
 		setModified(true);
 	}
 }

--- a/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.h
+++ b/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.h
@@ -11,6 +11,7 @@ class BioXASScanConfigurationDbObject : public AMDbObject
 
 	Q_PROPERTY(double energy READ energy WRITE setEnergy)
 	Q_PROPERTY(QString edge READ edge WRITE setEdge)
+	Q_PROPERTY(bool usingXRFDetector READ usingXRFDetector WRITE setUsingXRFDetector)
 	Q_PROPERTY(AMDbObjectList regionsOfInterest READ dbReadRegionsOfInterest WRITE dbLoadRegionsOfInterest)
 
 	Q_CLASSINFO("AMDbObject_Attributes", "description=BioXAS Scan Configuration Database Object")
@@ -27,6 +28,8 @@ public:
 	double energy() const { return energy_; }
 	/// Returns the edge.
 	QString edge() const { return edge_; }
+	/// Returns whether the scan is using an XRF detector.
+	bool usingXRFDetector() const { return usingXRFDetector_; }
 	/// Returns the regions of interest.
 	QList<AMRegionOfInterest *> regionsOfInterest() const { return regionsOfInterest_; }
 
@@ -35,12 +38,16 @@ signals:
 	void energyChanged(double);
 	/// Notifier that the edge has changed.
 	void edgeChanged(const QString &);
+	/// Notifier that whether the scan is using an XRF detector or not has changed.
+	void usingXRFDetectorChanged(bool);
 
 public slots:
 	/// Sets the energy.
 	void setEnergy(double newEnergy);
 	/// Sets the edge.
 	void setEdge(const QString &newEdge);
+	/// Sets whether the configuration is using an XRF detector or not.
+	void setUsingXRFDetector(bool hasXRF);
 	/// Adds a region of interest to the list.
 	void addRegionOfInterest(AMRegionOfInterest *region);
 	/// Removes a region of interest from the list.
@@ -56,6 +63,8 @@ protected:
 	double energy_;
 	/// The edge associated with this scan.
 	QString edge_;
+	/// Flag noting whether an XRF detector is being used.
+	bool usingXRFDetector_;
 	/// The list of the regions of interest.
 	QList<AMRegionOfInterest *> regionsOfInterest_;
 };

--- a/source/acquaman/BioXAS/BioXASSideXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanConfiguration.cpp
@@ -120,62 +120,14 @@ QString BioXASSideXASScanConfiguration::headerText() const
 	header.append(regionsOfInterestHeaderString(regionsOfInterest()) % "\n");
 	header.append("\n");
 	header.append("Regions Scanned\n");
-
-	foreach (AMScanAxisRegion *region, scanAxisAt(0)->regions().toList()){
-
-		AMScanAxisEXAFSRegion *exafsRegion = qobject_cast<AMScanAxisEXAFSRegion *>(region);
-
-		if (exafsRegion->inKSpace() && (exafsRegion->maximumTime().isValid() || exafsRegion->maximumTime() == exafsRegion->regionTime()))
-			header.append(QString("Start: %1 eV\tDelta: %2 k\tEnd: %3 k\tTime: %4 s\n")
-						.arg(double(AMEnergyToKSpaceCalculator::energy(energy(), exafsRegion->regionStart())))
-						.arg(double(exafsRegion->regionStep()))
-						.arg(double(exafsRegion->regionEnd()))
-						.arg(double(exafsRegion->regionTime())));
-
-		else if (exafsRegion->inKSpace() && exafsRegion->maximumTime().isValid())
-			header.append(QString("Start: %1 eV\tDelta: %2 k\tEnd: %3 k\tStart time: %4 s\tMaximum time (used with variable integration time): %5 s\n")
-					  .arg(double(AMEnergyToKSpaceCalculator::energy(energy(), exafsRegion->regionStart())))
-					  .arg(double(exafsRegion->regionStep()))
-					  .arg(double(exafsRegion->regionEnd()))
-					  .arg(double(exafsRegion->regionTime()))
-					  .arg(double(exafsRegion->maximumTime())));
-
-		else
-			header.append(QString("Start: %1 eV\tDelta: %2 eV\tEnd: %3 eV\tTime: %4 s\n")
-					  .arg(double(exafsRegion->regionStart()))
-					  .arg(double(exafsRegion->regionStep()))
-					  .arg(double(exafsRegion->regionEnd()))
-					  .arg(double(exafsRegion->regionTime())));
-	}
+	header.append(scanAxisAt(0)->toString());
 
 	return header;
 }
 
 void BioXASSideXASScanConfiguration::computeTotalTimeImplementation()
 {
-	double time = 0;
-
-	// Some region stuff.
-	foreach (AMScanAxisRegion *region, scanAxisAt(0)->regions().toList()){
-
-		AMScanAxisEXAFSRegion *exafsRegion = qobject_cast<AMScanAxisEXAFSRegion *>(region);
-		int numberOfPoints = int((double(exafsRegion->regionEnd()) - double(exafsRegion->regionStart()))/double(exafsRegion->regionStep()) + 1);
-
-		if (exafsRegion->inKSpace() && exafsRegion->maximumTime().isValid()){
-
-			QVector<double> regionTimes = QVector<double>(numberOfPoints);
-			AMVariableIntegrationTime calculator(exafsRegion->equation(), exafsRegion->regionTime(), exafsRegion->maximumTime(), exafsRegion->regionStart(), exafsRegion->regionStep(), exafsRegion->regionEnd(), exafsRegion->a2());
-			calculator.variableTime(regionTimes.data());
-
-			for (int i = 0; i < numberOfPoints; i++)
-				time += regionTimes.at(i);
-		}
-
-		else
-			time += (double(exafsRegion->regionTime())+timeOffset_)*numberOfPoints;
-	}
-
-	totalTime_ = time;
+	totalTime_ = scanAxisAt(0)->timePerAxis();
 	setExpectedDuration(totalTime_);
 	emit totalTimeChanged(totalTime_);
 }

--- a/source/acquaman/BioXAS/BioXASSideXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanConfiguration.cpp
@@ -120,7 +120,7 @@ QString BioXASSideXASScanConfiguration::headerText() const
 	header.append(regionsOfInterestHeaderString(regionsOfInterest()) % "\n");
 	header.append("\n");
 	header.append("Regions Scanned\n");
-	header.append(scanAxisAt(0)->toString());
+	header.append(scanAxisAt(0)->toString("eV"));
 
 	return header;
 }

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -230,6 +230,7 @@ void BioXASSideAppController::setupUserInterface()
 	// Create the four element detector view.
 	BioXASFourElementVortexDetectorView *fourElementDetectorView = new BioXASFourElementVortexDetectorView(BioXASSideBeamline::bioXAS()->fourElementVortexDetector());
 	fourElementDetectorView->buildDetectorView();
+	fourElementDetectorView->setEnergyRange(3000, 28000);
 	fourElementDetectorView->addEmissionLineNameFilter(QRegExp("1"));
 	fourElementDetectorView->addPileUpPeakNameFilter(QRegExp("(K.1|L.1|Ma1)"));
 

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -305,7 +305,7 @@ void BioXASSideAppController::onCurrentScanActionFinishedImplementation(AMScanAc
 
 void BioXASSideAppController::onUserConfigurationLoadedFromDb()
 {
-	AMXRFDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
+	AMXRFDetector *detector = BioXASSideBeamline::bioXAS()->fourElementVortexDetector();
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 

--- a/source/beamline/AMXspress3XRFDetector.cpp
+++ b/source/beamline/AMXspress3XRFDetector.cpp
@@ -37,6 +37,11 @@ AMXspress3XRFDetector::~AMXspress3XRFDetector()
 bool AMXspress3XRFDetector::initializeImplementation()
 {
 	AMAction3 *initializeAction = createInitializationAction();
+
+	connect(initializeAction, SIGNAL(failed()), initializeAction, SLOT(scheduleForDeletion()));
+	connect(initializeAction, SIGNAL(cancelled()), initializeAction, SLOT(scheduleForDeletion()));
+	connect(initializeAction, SIGNAL(succeeded()), initializeAction, SLOT(scheduleForDeletion()));
+
 	initializeAction->start();
 
 	return true;
@@ -209,10 +214,6 @@ AMAction3 * AMXspress3XRFDetector::createInitializationAction()
 	initializeAction->addSubAction(AMActionSupport::buildControlMoveAction(eraseControl_, 0.0));
 	initializeAction->addSubAction(AMActionSupport::buildControlMoveAction(updateControl_, 0.0));
 	initializeAction->addSubAction(AMActionSupport::buildControlMoveAction(initializationControl_, 1.0));
-
-	connect(initializeAction, SIGNAL(failed()), initializeAction, SLOT(scheduleForDeletion()));
-	connect(initializeAction, SIGNAL(cancelled()), initializeAction, SLOT(scheduleForDeletion()));
-	connect(initializeAction, SIGNAL(succeeded()), initializeAction, SLOT(scheduleForDeletion()));
 
 	connect(initializeAction, SIGNAL(failed()), this, SLOT(setInitializationRequired()));
 	connect(initializeAction, SIGNAL(cancelled()), this, SLOT(setInitializationRequired()));

--- a/source/beamline/AMXspress3XRFDetector.h
+++ b/source/beamline/AMXspress3XRFDetector.h
@@ -56,6 +56,14 @@ public:
 
 	/// Returns the threshold (only returns the first element one).
 	int threshold() const { return int(thresholdControls_.at(0)->value()); }
+
+	/// Returns an action that will initialize this detector.
+	AMAction3 *createInitializationAction();
+	/// Returns an action that sets the frames per acquisition.
+	AMAction3 *createFramesPerAcquisitionAction(int number);
+	/// Returns an action that disarms the detector.
+	AMAction3 *createDisarmAction();
+
 signals:
 	/// Notifier that the status message has changed.
 	void statusMessageChanged(const QString &);

--- a/source/dataman/AMScanAxis.cpp
+++ b/source/dataman/AMScanAxis.cpp
@@ -314,3 +314,33 @@ void AMScanAxis::dbLoadRegions(const AMDbObjectList &newAxisRegions)
 			regions_.append(region);
 	}
 }
+
+int AMScanAxis::numberOfPoints() const
+{
+	int points = 0;
+
+	foreach (AMScanAxisRegion *region, regions_.toList())
+		points += region->numberOfPoints();
+
+	return points;
+}
+
+double AMScanAxis::timePerAxis() const
+{
+	double time = 0;
+
+	foreach (AMScanAxisRegion *region, regions_.toList())
+		time += region->timePerRegion();
+
+	return time;
+}
+
+QString AMScanAxis::toString(const QString &units) const
+{
+	QString string = "";
+
+	foreach (AMScanAxisRegion *region, regions_.toList())
+		string.append(region->toString(units));
+
+	return string;
+}

--- a/source/dataman/AMScanAxis.h
+++ b/source/dataman/AMScanAxis.h
@@ -76,6 +76,13 @@ public:
 	/// Returns the end of the axis. That is, the end of the final region. If this type of axis doesn't have a end, then an AMNumber with state of AMNumber::Null will be returned.
 	AMNumber axisEnd() const;
 
+	/// Returns the number of points from all regions.  Can be reimplemented if region is more sophisticated.
+	virtual int numberOfPoints() const;
+	/// Returns the amount of time from all regions.
+	virtual double timePerAxis() const;
+	/// Returns a string containing the information in a standard way.
+	virtual QString toString(const QString &units = "") const;
+
 signals:
 	/// Notifier that a scan axis region has been added to the axis.  Passes a pointer to the new region.
 	void regionAdded(AMScanAxisRegion *);

--- a/source/dataman/AMScanAxisEXAFSRegion.cpp
+++ b/source/dataman/AMScanAxisEXAFSRegion.cpp
@@ -116,3 +116,54 @@ void AMScanAxisEXAFSRegion::switchSpace()
 		setRegionEnd(AMEnergyToKSpaceCalculator::energy(edgeEnergy_, regionEnd_));
 	}
 }
+
+double AMScanAxisEXAFSRegion::timePerRegion() const
+{
+	double time = 0;
+
+	if (inKSpace() && maximumTime().isValid()){
+
+		int points = numberOfPoints();
+		QVector<double> regionTimes = QVector<double>(points);
+		AMVariableIntegrationTime calculator(equation(), regionTime(), maximumTime(), regionStart(), regionStep(), regionEnd(), a2());
+		calculator.variableTime(regionTimes.data());
+
+		for (int i = 0; i < points; i++)
+			time += regionTimes.at(i);
+	}
+
+	else
+		time = AMScanAxisRegion::timePerRegion();
+
+	return time;
+}
+
+QString AMScanAxisEXAFSRegion::toString(const QString &units) const
+{
+	Q_UNUSED(units);
+	QString string = "";
+
+	if (inKSpace() && (maximumTime().isValid() || maximumTime() == regionTime()))
+		string.append(QString("Start: %1 eV\tDelta: %2 k\tEnd: %3 k\tTime: %4 s\n")
+					  .arg(double(AMEnergyToKSpaceCalculator::energy(edgeEnergy(), regionStart())))
+					  .arg(double(regionStep()))
+					  .arg(double(regionEnd()))
+					  .arg(double(regionTime())));
+
+	else if (inKSpace() && maximumTime().isValid())
+		string.append(QString("Start: %1 eV\tDelta: %2 k\tEnd: %3 k\tStart time: %4 s\tMaximum time (used with variable integration time): %5 s\n")
+					  .arg(double(AMEnergyToKSpaceCalculator::energy(edgeEnergy(), regionStart())))
+					  .arg(double(regionStep()))
+					  .arg(double(regionEnd()))
+					  .arg(double(regionTime()))
+					  .arg(double(maximumTime())));
+
+	else
+		string.append(QString("Start: %1 eV\tDelta: %2 eV\tEnd: %3 eV\tTime: %4 s\n")
+					  .arg(double(regionStart()))
+					  .arg(double(regionStep()))
+					  .arg(double(regionEnd()))
+					  .arg(double(regionTime())));
+
+	return string;
+}

--- a/source/dataman/AMScanAxisEXAFSRegion.h
+++ b/source/dataman/AMScanAxisEXAFSRegion.h
@@ -58,6 +58,11 @@ public:
 	/// Method that creates an exact copy of the current object.  Caller is responisible for memory.
 	virtual AMScanAxisRegion *createCopy() const;
 
+	/// Returns the amount of time the region would take using the parameters it has.
+	virtual double timePerRegion() const;
+	/// Returns a string containing the information in a standard way.
+	virtual QString toString(const QString &units = "") const;
+
 	/// Returns whether this region is in k-space.
 	bool inKSpace() const { return inKSpace_; }
 	/// Returns the edge energy associated with this region.

--- a/source/dataman/AMScanAxisRegion.cpp
+++ b/source/dataman/AMScanAxisRegion.cpp
@@ -108,3 +108,18 @@ int AMScanAxisRegion::numberOfPoints() const
 {
 	return int((double(regionEnd()) - double(regionStart()))/double(regionStep()) + 1);
 }
+
+double AMScanAxisRegion::timePerRegion() const
+{
+	return numberOfPoints()*double(regionTime());
+}
+
+QString AMScanAxisRegion::toString(const QString &units) const
+{
+	return QString("Start:\t%1 %4\tStep: %2 %4End:\t%3 %4\tTime: %5 s\n")
+			.arg(double(regionStart()))
+			.arg(double(regionStep()))
+			.arg(double(regionEnd()))
+			.arg(units)
+			.arg(double(regionTime()));
+}

--- a/source/dataman/AMScanAxisRegion.cpp
+++ b/source/dataman/AMScanAxisRegion.cpp
@@ -103,3 +103,8 @@ void AMScanAxisRegion::setRegionTime(const AMNumber &regionTime)
 		setModified(true);
 	}
 }
+
+int AMScanAxisRegion::numberOfPoints() const
+{
+	return int((double(regionEnd()) - double(regionStart()))/double(regionStep()) + 1);
+}

--- a/source/dataman/AMScanAxisRegion.h
+++ b/source/dataman/AMScanAxisRegion.h
@@ -56,6 +56,9 @@ public:
 	/// Returns the time for the region as an AMNumber (which may be in the state AMNumber::Null)
 	AMNumber regionTime() const;
 
+	/// Returns the number of points in a region.
+	int numberOfPoints() const;
+
 signals:
 	/// Notifier that the start value has changed.
 	void regionStartChanged(const AMNumber &);

--- a/source/dataman/AMScanAxisRegion.h
+++ b/source/dataman/AMScanAxisRegion.h
@@ -56,8 +56,12 @@ public:
 	/// Returns the time for the region as an AMNumber (which may be in the state AMNumber::Null)
 	AMNumber regionTime() const;
 
-	/// Returns the number of points in a region.
-	int numberOfPoints() const;
+	/// Returns the number of points in a region.  Can be reimplemented if region is more sophisticated.
+	virtual int numberOfPoints() const;
+	/// Returns the amount of time the region would take using the parameters it has.
+	virtual double timePerRegion() const;
+	/// Returns a string containing the information in a standard way.
+	virtual QString toString(const QString &units = "") const;
 
 signals:
 	/// Notifier that the start value has changed.

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
@@ -45,6 +45,11 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 
 	regionsView_ = new AMEXAFSScanAxisView("BioXAS-Side Region Configuration", configuration_);
 
+	usingXRFDetectorCheckBox_ = new QCheckBox("Use Four Element");
+	usingXRFDetectorCheckBox_->setChecked(configuration_->usingXRFDetector());
+	connect(configuration_->dbObject(), SIGNAL(usingXRFDetectorChanged(bool)), usingXRFDetectorCheckBox_, SLOT(setChecked(bool)));
+	connect(usingXRFDetectorCheckBox_, SIGNAL(toggled(bool)), configuration_->dbObject(), SLOT(setUsingXRFDetector(bool)));
+
 	autoRegionButton_ = new QPushButton("Auto Set XANES Regions");
 	connect(autoRegionButton_, SIGNAL(clicked()), this, SLOT(setupDefaultXANESScanRegions()));
 
@@ -96,10 +101,17 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 	energyLayout->addWidget(elementChoice_);
 	energyLayout->addWidget(lineChoice_);
 
+	QVBoxLayout *energyAndRegionLayout = new QVBoxLayout;
+	energyAndRegionLayout->addLayout(energyLayout);
+	energyAndRegionLayout->addWidget(regionsView_);
+
+	QHBoxLayout *regionsLayout = new QHBoxLayout;
+	regionsLayout->addLayout(energyAndRegionLayout);
+	regionsLayout->addWidget(usingXRFDetectorCheckBox_, 0, Qt::AlignBottom);
+
 	QVBoxLayout *mainVL = new QVBoxLayout();
 	mainVL->addWidget(topFrame_);
-	mainVL->addLayout(energyLayout);
-	mainVL->addWidget(regionsView_);
+	mainVL->addLayout(regionsLayout);
 
 //	QLabel *settingsLabel = new QLabel("Scan Settings:");
 //	settingsLabel->setFont(QFont("Lucida Grande", 12, QFont::Bold));

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
@@ -89,6 +89,8 @@ protected:
 	QLabel *pointPerScan_;
 	/// Label holding the energy space scan range.
 	QLabel *scanEnergyRange_;
+	/// Check box for using the XRF detector.
+	QCheckBox *usingXRFDetectorCheckBox_;
 };
 
 #endif // BIOXASXASSCANCONFIGURATIONVIEW_H


### PR DESCRIPTION
Got the Xspress3 based four element detector inside the BioXAS side XAS scan controller.  It passes all but the beam test.

This involved a couple final modifications to the Xspress3 acquisition/initialization state machine in AMXspress3XRFDetector.

Some convenience functions came for the ride in AMScanAxis, AMScanAxisRegion, and AMScanAxisEXAFSRegion.