### PR TITLE
Pull Request for Issue1420: SMAK exporter exports all data even if last row is incomplete

### DIFF
--- a/source/dataman/export/AMSMAKExporter.cpp
+++ b/source/dataman/export/AMSMAKExporter.cpp
@@ -76,6 +76,13 @@ bool AMSMAKExporter::prepareDataSources()
 			for (int i = 0; i < xRange && xIndex_ == -1; i++)
 				if (int(fillerData.at(i)) == -1)
 					xIndex_ = i;
+
+			if (xIndex_ != xRange){
+
+				// This makes it so that we don't export the last row if it is incomplete.
+				yRange_--;
+				xIndex_ = -1;
+			}
 		}
 	}
 


### PR DESCRIPTION
Logic to not export the last row when exporting SMAK if it is incomplete.