### PR TITLE
Pull Request for Issue1421: Adding setpoint as option for AMBasicControlDetectorEmulator

### DIFF
--- a/source/beamline/AMBasicControlDetectorEmulator.cpp
+++ b/source/beamline/AMBasicControlDetectorEmulator.cpp
@@ -34,6 +34,8 @@ AMBasicControlDetectorEmulator::AMBasicControlDetectorEmulator(const QString &na
 
 	readMethod_ = readMethod;
 
+	controlProperty_ = Control::Value;
+
 	setIsVisible(false);
 	setHiddenFromUsers(true);
 
@@ -57,13 +59,22 @@ AMBasicControlDetectorEmulator::AMBasicControlDetectorEmulator(const QString &na
 
 AMNumber AMBasicControlDetectorEmulator::reading(const AMnDIndex &indexes) const
 {
-	if(!isConnected())
+	if (!isConnected())
 		return AMNumber(AMNumber::Null);
+
 	// We want an "invalid" AMnDIndex for this 0D detector
-	if(indexes.isValid())
+	if (indexes.isValid())
 		return AMNumber(AMNumber::DimensionError);
 
-	return control_->value();
+	AMNumber result = AMNumber(AMNumber::Null);
+
+	if (controlProperty_ == Control::Value)
+		result = control_->value();
+
+	else if (controlProperty_ == Control::Setpoint)
+		result = control_->setpoint();
+
+	return result;
 }
 
 AMNumber AMBasicControlDetectorEmulator::singleReading() const{
@@ -72,14 +83,32 @@ AMNumber AMBasicControlDetectorEmulator::singleReading() const{
 
 bool AMBasicControlDetectorEmulator::data(double *outputValues) const
 {
-	outputValues[0] = control_->value();
-	return true;
+	bool result = false;
+
+	if (controlProperty_ == Control::Value) {
+		outputValues[0] = control_->value();
+		result = true;
+
+	} else if (controlProperty_ == Control::Setpoint) {
+		outputValues[0] = control_->setpoint();
+		result = true;
+	}
+
+	return false;
 }
 
 AMAction3* AMBasicControlDetectorEmulator::createTriggerAction(AMDetectorDefinitions::ReadMode readMode){
 	if(readMethod() != AMDetectorDefinitions::RequestRead)
 		return 0;
 	return AMDetector::createTriggerAction(readMode);
+}
+
+void AMBasicControlDetectorEmulator::setControlProperty(Control::Property newProperty)
+{
+	if (controlProperty_ != newProperty) {
+		controlProperty_ = newProperty;
+		emit controlPropertyChanged(controlProperty_);
+	}
 }
 
 void AMBasicControlDetectorEmulator::onControlsConnected(bool connected){

--- a/source/beamline/AMBasicControlDetectorEmulator.h
+++ b/source/beamline/AMBasicControlDetectorEmulator.h
@@ -29,6 +29,9 @@ class AMBasicControlDetectorEmulator : public AMDetector
 {
 Q_OBJECT
 public:
+	/// Enum that identifies the different control properties that the emulator can monitor.
+	class Control { public: enum Property { Value = 0, Setpoint }; };
+
 	/// Constructor takes a name and description as well as a pointer to the control you wish to acquire
 	AMBasicControlDetectorEmulator(const QString &name, const QString &description, AMControl *control, AMControl *statusControl, double statusAcquiringValue, double statusNotAcquiringValue, AMDetectorDefinitions::ReadMethod readMethod,  QObject *parent = 0);
 	/// Destructor.
@@ -86,6 +89,13 @@ public:
 	/// Returns a AM1DProcessVariableDataSource suitable for viewing
 	virtual AMDataSource* dataSource() const { return 0; }
 
+	/// Returns the control property that the emulator is monitoring.
+	Control::Property controlProperty() const { return controlProperty_; }
+
+signals:
+	/// Notifier that the control property that the emulator is monitoring has changed.
+	void controlPropertyChanged(Control::Property newProperty);
+
 public slots:
 	/// Does nothing and returns false
 	virtual bool setAcquisitionTime(double seconds) { Q_UNUSED(seconds); return false; }
@@ -95,6 +105,9 @@ public slots:
 
 	/// Controls do not support clearing
 	virtual bool clear() { return false; }
+
+	/// Sets the control property that the emulator is monitoring.
+	void setControlProperty(Control::Property newProperty);
 
 protected slots:
 	/// Determines if the detector is connected to ALL controls and process variables.
@@ -131,6 +144,9 @@ protected:
 
 	double statusAcquiringValue_;
 	double statusNotAcquiringValue_;
+
+	/// Holds the control property that the emulator is monitoring.
+	Control::Property controlProperty_;
 };
 
 #endif // AMBASICCONTROLDETECTOREMULATOR_H

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -758,6 +758,7 @@ void BioXASSideBeamline::setupComponents()
 void BioXASSideBeamline::setupControlsAsDetectors()
 {
 	energySetpointDetector_ = new AMBasicControlDetectorEmulator("EnergySetpoint", "EnergySetpoint", new AMReadOnlyPVControl("EnergySetpoint", "BL1607-5-I22:Energy:EV", this), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+	energySetpointDetector_->setControlProperty(AMBasicControlDetectorEmulator::Control::Setpoint);
 	energySetpointDetector_->setHiddenFromUsers(false);
 	energySetpointDetector_->setIsVisible(true);
 


### PR DESCRIPTION
Added enum to the AMBasicControlDetectorEmulator class that identifies the control value or setpoint as options for the emulator to monitor, with getter and setter for the new member variable. Set to value in the constructor. Set the option to setpoint for the energySetpointDetector in BioXASSideBeamline.