### PR TITLE
Pull Request for Issue1439: Add some sort of display for k-space regions to know see the actual energy

### DIFF
--- a/source/ui/dataman/AMEXAFSScanAxisView.cpp
+++ b/source/ui/dataman/AMEXAFSScanAxisView.cpp
@@ -85,6 +85,9 @@ AMEXAFSScanAxisElementView::AMEXAFSScanAxisElementView(AMScanAxisEXAFSRegion *re
 	maximumTimeLabel->setVisible(region_->inKSpace());
 	maximumTime_->setVisible(region_->inKSpace());
 
+	if (region_->inKSpace())
+		updateKSpaceToolTip();
+
 	QHBoxLayout *elementViewLayout = new QHBoxLayout;
 	elementViewLayout->addWidget(new QLabel("Start"), 0, Qt::AlignCenter);
 	elementViewLayout->addWidget(start_);
@@ -147,8 +150,11 @@ void AMEXAFSScanAxisElementView::setMaximumTimeSpinBox(const AMNumber &value)
 
 void AMEXAFSScanAxisElementView::onStartPositionUpdated()
 {
-	if (region_->inKSpace())
+	if (region_->inKSpace()){
+
 		region_->setRegionStart(AMEnergyToKSpaceCalculator::k(region_->edgeEnergy(), start_->value()+double(region_->edgeEnergy())));
+		updateKSpaceToolTip();
+	}
 
 	else
 		region_->setRegionStart(start_->value() + double(region_->edgeEnergy()));
@@ -163,8 +169,11 @@ void AMEXAFSScanAxisElementView::onDeltaPositionUpdated()
 
 void AMEXAFSScanAxisElementView::onEndPositionUpdated()
 {
-	if (region_->inKSpace())
+	if (region_->inKSpace()){
+
 		region_->setRegionEnd(end_->value());
+		updateKSpaceToolTip();
+	}
 
 	else
 		region_->setRegionEnd(end_->value() + double(region_->edgeEnergy()));
@@ -191,6 +200,16 @@ void AMEXAFSScanAxisElementView::setEdgeEnergy(const AMNumber &energy)
 		region_->setRegionStart(start_->value() + double(energy));
 		region_->setRegionEnd(end_->value() + double(energy));
 	}
+
+	else
+		updateKSpaceToolTip();
+}
+
+void AMEXAFSScanAxisElementView::updateKSpaceToolTip()
+{
+	setToolTip(QString("Energy Range: %1 to %2 eV")
+			   .arg(double(AMEnergyToKSpaceCalculator::energy(region_->edgeEnergy(), region_->regionStart())))
+			   .arg(double(AMEnergyToKSpaceCalculator::energy(region_->edgeEnergy(), region_->regionEnd()))));
 }
 
 // AMEXAFSScanAxisView

--- a/source/ui/dataman/AMEXAFSScanAxisView.h
+++ b/source/ui/dataman/AMEXAFSScanAxisView.h
@@ -79,6 +79,8 @@ protected slots:
 	void onMaximumTimeUpdated();
 
 protected:
+	/// Helper method that sets the tool tip if we are a k-space region.
+	void updateKSpaceToolTip();
 
 	/// The pointer to the region.
 	AMScanAxisEXAFSRegion *region_;


### PR DESCRIPTION
Added a tooltip for k-space EXAFS region views to display what the k-space region is in energy.