### PR TITLE
Pull Request for Issue1446: VESPERS: Exporter indexing issue for 2D Ascii

### DIFF
--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -272,9 +272,9 @@ void VESPERSAppController::setupExporterOptions()
 	if(vespersDefault->id() > 0)
 		AMAppControllerSupport::registerClass<VESPERSTimedLineScanConfiguration, VESPERSExporter2DAscii, AMExporterOptionGeneralAscii>(vespersDefault->id());
 
-	AMExporterOptionSMAK *vespersSMAKDefault = VESPERS::buildSMAKExporterOption("VESPERS2DSMAKDefault", true, false, false, true);
-	if(vespersSMAKDefault->id() > 0)
-		AMAppControllerSupport::registerClass<VESPERS2DScanConfiguration, VESPERSExporterSMAK, AMExporterOptionSMAK>(vespersSMAKDefault->id());
+//	AMExporterOptionSMAK *vespersSMAKDefault = VESPERS::buildSMAKExporterOption("VESPERS2DSMAKDefault", true, false, false, true);
+//	if(vespersSMAKDefault->id() > 0)
+//		AMAppControllerSupport::registerClass<VESPERS2DScanConfiguration, VESPERSExporterSMAK, AMExporterOptionSMAK>(vespersSMAKDefault->id());
 }
 
 void VESPERSAppController::setupUserInterface()


### PR DESCRIPTION
Commented out the line that adds the SMAK exporter option because the exporter support is sorely lacking.  I've left it commented rather than removing it because it should be added back in once the code isn't so rigid.