### PR TITLE
Pull Request for Issue1447: Problematic region control connect state

### DIFF
--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
@@ -39,10 +39,11 @@ BioXASSSRLMonochromatorEnergyControl::~BioXASSSRLMonochromatorEnergyControl()
 
 bool BioXASSSRLMonochromatorEnergyControl::canMeasure() const
 {
-	bool result = false;
-
-	if (isConnected())
-		result = ( bragg_->canMeasure() && braggSetPosition_->canMeasure() && region_->canMeasure() && m1MirrorPitch_->canMeasure() );
+	bool result = (
+				bragg_ && bragg_->canMeasure() &&
+				region_ && region_->canMeasure() &&
+				m1MirrorPitch_ && m1MirrorPitch_->canMeasure()
+				);
 
 	return result;
 }

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.cpp
@@ -53,7 +53,7 @@ bool BioXASSSRLMonochromatorRegionControl::canMeasure() const
 {
 	bool result = false;
 
-	if (isConnected()) {
+	if (regionAStatus_ && regionBStatus_) {
 		result = (
 				regionAStatus_->canMeasure() &&
 				regionBStatus_->canMeasure()

--- a/source/ui/beamline/AMExtendedControlEditor.cpp
+++ b/source/ui/beamline/AMExtendedControlEditor.cpp
@@ -339,7 +339,7 @@ void AMExtendedControlEditor::updateReadOnlyStatus()
 
 void AMExtendedControlEditor::onConnectedChanged()
 {
-	if (control_ && control_->isConnected()) {
+	if (control_ && control_->canMeasure()) {
 
 		onValueChanged(control_->value());
 		onUnitsChanged(control_->units());


### PR DESCRIPTION
This solution is some minor tweaks to the region control, energy control, and AMExtendedControlEditor. For the controls, I've removed the requirement that they be connected to be measurable--they really only need access to the pvs that directly contribute to their value. For the editor, I've made it so the control value is displayed if the control exists and is measurable; the 'not connected' display is shown otherwise.