### PR TITLE
Pull Request for Issue1443: Add option to use step-based energy control in XAS scans

### DIFF
--- a/source/acquaman/BioXAS/BioXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.cpp
@@ -3,6 +3,8 @@
 BioXASScanConfiguration::BioXASScanConfiguration()
 {
 	dbObject_ = new BioXASScanConfigurationDbObject;
+
+	usingEncoderEnergy_ = true;
 	timeOffset_ = 0.0;
 	totalTime_ = 0.0;
 }
@@ -10,6 +12,8 @@ BioXASScanConfiguration::BioXASScanConfiguration()
 BioXASScanConfiguration::BioXASScanConfiguration(const BioXASScanConfiguration &original)
 {
 	dbObject_ = new BioXASScanConfigurationDbObject(*original.dbObject());
+
+	usingEncoderEnergy_ = original.usingEncoderEnergy();
 	timeOffset_ = original.timeOffset();
 	totalTime_ = original.totalTime();
 }
@@ -17,6 +21,13 @@ BioXASScanConfiguration::BioXASScanConfiguration(const BioXASScanConfiguration &
 BioXASScanConfiguration::~BioXASScanConfiguration()
 {
 
+}
+
+void BioXASScanConfiguration::setUsingEncoderEnergy(bool usingEncoder)
+{
+	if (usingEncoderEnergy_ != usingEncoder) {
+		usingEncoderEnergy_ = usingEncoder;
+	}
 }
 
 void BioXASScanConfiguration::dbWriteScanConfigurationDbObject(AMDbObject *object)

--- a/source/acquaman/BioXAS/BioXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.h
@@ -34,6 +34,8 @@ public:
 	QString edge() const { return dbObject_->edge(); }
 	/// Returns whether the scan is using an XRF detector or not.
 	bool usingXRFDetector() const { return dbObject_->usingXRFDetector(); }
+	/// Returns whether the scan is using an encoder-based energy control (or step-based).
+	bool usingEncoderEnergy() const { return usingEncoderEnergy_; }
 	/// Returns the list of regions of interest.
 	QList<AMRegionOfInterest *> regionsOfInterest() const { return dbObject_->regionsOfInterest(); }
 
@@ -53,6 +55,8 @@ public:
 	void setEdge(const QString &newEdge) { dbObject_->setEdge(newEdge); }
 	/// Sets whether the configuration is using an XRF detector.
 	void setUsingXRFDetector(bool hasXRF) { dbObject_->setUsingXRFDetector(hasXRF); }
+	/// Sets whether the configuration is using the encoder-based energy control (or step-based).
+	void setUsingEncoderEnergy(bool usingEncoder);
 	/// Adds a region of interest to the list.
 	void addRegionOfInterest(AMRegionOfInterest *region) { dbObject_->addRegionOfInterest(region); }
 	/// Removes a region of interest from the list.
@@ -85,6 +89,8 @@ protected:
 	/// The database object we're encapsulating.
 	BioXASScanConfigurationDbObject *dbObject_;
 
+	/// Flag indicating whether the energy control used is encoder-based (or step-based).
+	bool usingEncoderEnergy_;
 	/// Holds the total time in seconds that the scan is estimated to take.
 	double totalTime_;
 	/// Holds the offset per point of extra time when doing a scan.

--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -63,7 +63,7 @@ BioXASSideXASScanActionController::BioXASSideXASScanActionController(BioXASSideX
 		controlInfo = BioXASSideBeamline::bioXAS()->mono()->stepEnergyControl()->toInfo();
 
 	AMControlInfoList list;
-	list.append(BioXASSideBeamline::bioXAS()->mono()->encoderEnergyControl()->toInfo());
+	list.append(controlInfo);
 	configuration_->setAxisControlInfos(list);
 
 	useFeedback_ = true;

--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -121,7 +121,16 @@ QString BioXASSideXASScanActionController::beamlineSettings()
 	QString notes;
 
 	notes.append(QString("SR1 Current:\t%1 mA\n").arg(CLSStorageRing::sr1()->ringCurrent()));
-	notes.append(QString("Energy used: %1").arg(configuration_->axisControlInfos().at(0).name()));
+
+	// Note which energy control is being used.
+
+	QString controlType;
+	if (configuration_->usingEncoderEnergy())
+		controlType = QString("encoder-based");
+	else
+		controlType = QString("step-based");
+
+	notes.append(QString("Energy option:\t%1\n").arg(controlType));
 
 	return notes;
 }

--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -56,6 +56,12 @@ BioXASSideXASScanActionController::BioXASSideXASScanActionController(BioXASSideX
 	if (bioXASDefaultXAS->id() > 0)
 		AMAppControllerSupport::registerClass<BioXASSideXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(bioXASDefaultXAS->id());
 
+	AMControlInfo controlInfo;
+	if (configuration_->usingEncoderEnergy())
+		controlInfo = BioXASSideBeamline::bioXAS()->mono()->encoderEnergyControl()->toInfo();
+	else
+		controlInfo = BioXASSideBeamline::bioXAS()->mono()->stepEnergyControl()->toInfo();
+
 	AMControlInfoList list;
 	list.append(BioXASSideBeamline::bioXAS()->mono()->encoderEnergyControl()->toInfo());
 	configuration_->setAxisControlInfos(list);
@@ -115,6 +121,7 @@ QString BioXASSideXASScanActionController::beamlineSettings()
 	QString notes;
 
 	notes.append(QString("SR1 Current:\t%1 mA\n").arg(CLSStorageRing::sr1()->ringCurrent()));
+	notes.append(QString("Energy used: %1").arg(configuration_->axisControlInfos().at(0).name()));
 
 	return notes;
 }

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
@@ -47,6 +47,10 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 	connect(configuration_->dbObject(), SIGNAL(usingXRFDetectorChanged(bool)), usingXRFDetectorCheckBox_, SLOT(setChecked(bool)));
 	connect(usingXRFDetectorCheckBox_, SIGNAL(toggled(bool)), configuration_->dbObject(), SLOT(setUsingXRFDetector(bool)));
 
+	usingEncoderEnergyCheckBox_ = new QCheckBox("Use encoder-based energy");
+	usingEncoderEnergyCheckBox_->setChecked(configuration_->usingEncoderEnergy());
+	connect( usingEncoderEnergyCheckBox_, SIGNAL(toggled(bool)), this, SLOT(onUsingEncoderEnergyCheckBoxToggled()) );
+
 	autoRegionButton_ = new QPushButton("Auto Set XANES Regions");
 	connect(autoRegionButton_, SIGNAL(clicked()), this, SLOT(setupDefaultXANESScanRegions()));
 
@@ -102,21 +106,34 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 	energyAndRegionLayout->addLayout(energyLayout);
 	energyAndRegionLayout->addWidget(regionsView_);
 
-	QHBoxLayout *regionsLayout = new QHBoxLayout;
-	regionsLayout->addLayout(energyAndRegionLayout);
-	regionsLayout->addWidget(usingXRFDetectorCheckBox_, 0, Qt::AlignBottom);
+//	QHBoxLayout *regionsLayout = new QHBoxLayout;
+//	regionsLayout->addLayout(energyAndRegionLayout);
+//	regionsLayout->addWidget(usingXRFDetectorCheckBox_, 0, Qt::AlignBottom);
+//	regionsLayout->addWidget(usingEncoderEnergyCheckBox_, 0
 
 //	QLabel *settingsLabel = new QLabel("Scan Settings:");
 //	settingsLabel->setFont(QFont("Lucida Grande", 12, QFont::Bold));
 
-	QHBoxLayout *regionsHL = new QHBoxLayout();
-	regionsHL->addStretch();
-	regionsHL->addWidget(autoRegionButton_);
-	regionsHL->addWidget(pseudoXAFSButton_);
+//	QHBoxLayout *regionsHL = new QHBoxLayout();
+//	regionsHL->addStretch();
+//	regionsHL->addWidget(autoRegionButton_);
+//	regionsHL->addWidget(pseudoXAFSButton_);
+
+	QVBoxLayout *optionsLayout = new QVBoxLayout();
+	optionsLayout->addWidget(usingXRFDetectorCheckBox_);
+	optionsLayout->addWidget(usingEncoderEnergyCheckBox_);
+
+	QVBoxLayout *regionButtonsLayout = new QVBoxLayout();
+	regionButtonsLayout->addWidget(autoRegionButton_);
+	regionButtonsLayout->addWidget(pseudoXAFSButton_);
+
+	QHBoxLayout *miscLayout = new QHBoxLayout();
+	miscLayout->addLayout(regionButtonsLayout);
+	miscLayout->addLayout(optionsLayout);
 
 	QVBoxLayout *mainVL = new QVBoxLayout();
-	mainVL->addLayout(regionsLayout);
-	mainVL->addLayout(regionsHL);
+	mainVL->addLayout(energyAndRegionLayout);
+	mainVL->addLayout(miscLayout);
 
 	mainVL->setContentsMargins(20,0,0,20);
 	mainVL->setSpacing(1);
@@ -252,4 +269,9 @@ void BioXASSideXASScanConfigurationView::onEdgeChanged()
 
 	if (energy_->value() != configuration_->energy())
 		energy_->setValue(configuration_->energy());
+}
+
+void BioXASSideXASScanConfigurationView::onUsingEncoderEnergyCheckBoxToggled()
+{
+	configuration_->setUsingEncoderEnergy(usingEncoderEnergyCheckBox_->isChecked());
 }

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
@@ -106,26 +106,15 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 	energyAndRegionLayout->addLayout(energyLayout);
 	energyAndRegionLayout->addWidget(regionsView_);
 
-//	QHBoxLayout *regionsLayout = new QHBoxLayout;
-//	regionsLayout->addLayout(energyAndRegionLayout);
-//	regionsLayout->addWidget(usingXRFDetectorCheckBox_, 0, Qt::AlignBottom);
-//	regionsLayout->addWidget(usingEncoderEnergyCheckBox_, 0
-
-//	QLabel *settingsLabel = new QLabel("Scan Settings:");
-//	settingsLabel->setFont(QFont("Lucida Grande", 12, QFont::Bold));
-
-//	QHBoxLayout *regionsHL = new QHBoxLayout();
-//	regionsHL->addStretch();
-//	regionsHL->addWidget(autoRegionButton_);
-//	regionsHL->addWidget(pseudoXAFSButton_);
-
 	QVBoxLayout *optionsLayout = new QVBoxLayout();
 	optionsLayout->addWidget(usingXRFDetectorCheckBox_);
 	optionsLayout->addWidget(usingEncoderEnergyCheckBox_);
+	optionsLayout->addStretch();
 
 	QVBoxLayout *regionButtonsLayout = new QVBoxLayout();
 	regionButtonsLayout->addWidget(autoRegionButton_);
 	regionButtonsLayout->addWidget(pseudoXAFSButton_);
+	regionButtonsLayout->addStretch();
 
 	QHBoxLayout *miscLayout = new QHBoxLayout();
 	miscLayout->addLayout(regionButtonsLayout);

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
@@ -129,6 +129,7 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 
 	QHBoxLayout *miscLayout = new QHBoxLayout();
 	miscLayout->addLayout(regionButtonsLayout);
+	miscLayout->addStretch();
 	miscLayout->addLayout(optionsLayout);
 
 	QVBoxLayout *mainVL = new QVBoxLayout();

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
@@ -69,6 +69,9 @@ protected slots:
 	/// Handles setting the proper information if the edge is changed.
 	void onEdgeChanged();
 
+	/// Handles setting the configuration flag for whether the encoder-based energy control is used.
+	void onUsingEncoderEnergyCheckBoxToggled();
+
 protected:
 	BioXASSideXASScanConfiguration *configuration_;
 
@@ -91,6 +94,8 @@ protected:
 	QLabel *scanEnergyRange_;
 	/// Check box for using the XRF detector.
 	QCheckBox *usingXRFDetectorCheckBox_;
+	/// Check box for using the encoder-based energy control (or step-based).
+	QCheckBox *usingEncoderEnergyCheckBox_;
 };
 
 #endif // BIOXASXASSCANCONFIGURATIONVIEW_H

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
@@ -73,6 +73,7 @@ protected slots:
 	void onUsingEncoderEnergyCheckBoxToggled();
 
 protected:
+	/// The scan configuration being viewed.
 	BioXASSideXASScanConfiguration *configuration_;
 
 	AMTopFrame *topFrame_;


### PR DESCRIPTION
Added bool to the BioXASScanConfiguration class, flag indicating whether to use the encoder-based or step-based energy control. Added checkbox to the Side XAS scan configuration view to show which is currently selected and allow a user to change from the default setting. Modified the Side XAS scan action controller in order to add the appropriate control to the configuration's axis control infos. The scan notes also now indicate which control was used.