### PR TITLE
Pull Request for Issue1467: Fixed issues in REIXSXESSpectrometerControlEditor

### DIFF
--- a/source/ui/REIXS/REIXSXESSpectrometerControlEditor.cpp
+++ b/source/ui/REIXS/REIXSXESSpectrometerControlEditor.cpp
@@ -332,7 +332,7 @@ void REIXSXESSpectrometerControlEditor::setupUi()
 	formLayout->setWidget(6, QFormLayout::LabelRole, labelTiltOffset);
 	formLayout->setWidget(6, QFormLayout::FieldRole, tiltOffsetBox_);
 
-	QLabel* energyRangeLabel_ = new QLabel("361 eV - 438 eV (78eV)");
+	energyRangeLabel_ = new QLabel("361 eV - 438 eV (78eV)");
 	formLayout->setWidget(7, QFormLayout::FieldRole, energyRangeLabel_);
 
 	stopButton_ = new QPushButton(QIcon(":/Close.png"), "Stop!");

--- a/source/ui/REIXS/REIXSXESSpectrometerControlEditor.cpp
+++ b/source/ui/REIXS/REIXSXESSpectrometerControlEditor.cpp
@@ -367,7 +367,7 @@ void REIXSXESSpectrometerControlEditor::setupConnections()
 	connect(spectrometer_, SIGNAL(moveFailed(int)), this, SLOT(onSpectrometerMoveFailed(int)));
 	connect(spectrometer_->gratingMask(), SIGNAL(valueChanged(double)), this, SLOT(updateMaskPosition()));
 	connect(spectrometer_->gratingMask(), SIGNAL(connected(bool)), this, SLOT(updateMaskPosition()));
-
+	connect(maskComboBox_, SIGNAL(currentIndexChanged(QString)), this, SLOT(on_maskComboBox_currentIndexChanged(QString)));
 	connect(energyBox_, SIGNAL(valueChanged(double)), this, SLOT(updateCurrentEnergyStatus()));
 	connect(gratingSelectorBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onGratingComboBoxActivated(int)));
 


### PR DESCRIPTION
Issue #1467 
- Altered the setupUi() function which was redeclaring the energyRangleLabel_, causing multiple definitions.
- Wired up the mask combo box's index changed signal to on_maskComboBox_currentIndexChanged in the setupConnections() function