### PR TITLE
Pull Request for Issue1479: Remove encoder-based energy/bragg options

### DIFF
--- a/source/acquaman/BioXAS/BioXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.cpp
@@ -4,7 +4,6 @@ BioXASScanConfiguration::BioXASScanConfiguration()
 {
 	dbObject_ = new BioXASScanConfigurationDbObject;
 
-	usingEncoderEnergy_ = true;
 	timeOffset_ = 0.0;
 	totalTime_ = 0.0;
 }
@@ -13,7 +12,6 @@ BioXASScanConfiguration::BioXASScanConfiguration(const BioXASScanConfiguration &
 {
 	dbObject_ = new BioXASScanConfigurationDbObject(*original.dbObject());
 
-	usingEncoderEnergy_ = original.usingEncoderEnergy();
 	timeOffset_ = original.timeOffset();
 	totalTime_ = original.totalTime();
 }
@@ -21,13 +19,6 @@ BioXASScanConfiguration::BioXASScanConfiguration(const BioXASScanConfiguration &
 BioXASScanConfiguration::~BioXASScanConfiguration()
 {
 
-}
-
-void BioXASScanConfiguration::setUsingEncoderEnergy(bool usingEncoder)
-{
-	if (usingEncoderEnergy_ != usingEncoder) {
-		usingEncoderEnergy_ = usingEncoder;
-	}
 }
 
 void BioXASScanConfiguration::dbWriteScanConfigurationDbObject(AMDbObject *object)

--- a/source/acquaman/BioXAS/BioXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.h
@@ -34,8 +34,6 @@ public:
 	QString edge() const { return dbObject_->edge(); }
 	/// Returns whether the scan is using an XRF detector or not.
 	bool usingXRFDetector() const { return dbObject_->usingXRFDetector(); }
-	/// Returns whether the scan is using an encoder-based energy control (or step-based).
-	bool usingEncoderEnergy() const { return usingEncoderEnergy_; }
 	/// Returns the list of regions of interest.
 	QList<AMRegionOfInterest *> regionsOfInterest() const { return dbObject_->regionsOfInterest(); }
 
@@ -55,8 +53,6 @@ public:
 	void setEdge(const QString &newEdge) { dbObject_->setEdge(newEdge); }
 	/// Sets whether the configuration is using an XRF detector.
 	void setUsingXRFDetector(bool hasXRF) { dbObject_->setUsingXRFDetector(hasXRF); }
-	/// Sets whether the configuration is using the encoder-based energy control (or step-based).
-	void setUsingEncoderEnergy(bool usingEncoder);
 	/// Adds a region of interest to the list.
 	void addRegionOfInterest(AMRegionOfInterest *region) { dbObject_->addRegionOfInterest(region); }
 	/// Removes a region of interest from the list.
@@ -89,8 +85,6 @@ protected:
 	/// The database object we're encapsulating.
 	BioXASScanConfigurationDbObject *dbObject_;
 
-	/// Flag indicating whether the energy control used is encoder-based (or step-based).
-	bool usingEncoderEnergy_;
 	/// Holds the total time in seconds that the scan is estimated to take.
 	double totalTime_;
 	/// Holds the offset per point of extra time when doing a scan.

--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -56,14 +56,8 @@ BioXASSideXASScanActionController::BioXASSideXASScanActionController(BioXASSideX
 	if (bioXASDefaultXAS->id() > 0)
 		AMAppControllerSupport::registerClass<BioXASSideXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(bioXASDefaultXAS->id());
 
-	AMControlInfo controlInfo;
-	if (configuration_->usingEncoderEnergy())
-		controlInfo = BioXASSideBeamline::bioXAS()->mono()->encoderEnergyControl()->toInfo();
-	else
-		controlInfo = BioXASSideBeamline::bioXAS()->mono()->stepEnergyControl()->toInfo();
-
 	AMControlInfoList list;
-	list.append(controlInfo);
+	list.append(BioXASSideBeamline::bioXAS()->mono()->energyControl()->toInfo());
 	configuration_->setAxisControlInfos(list);
 
 	useFeedback_ = true;
@@ -120,17 +114,9 @@ QString BioXASSideXASScanActionController::beamlineSettings()
 {
 	QString notes;
 
+	// Note storage ring current.
+
 	notes.append(QString("SR1 Current:\t%1 mA\n").arg(CLSStorageRing::sr1()->ringCurrent()));
-
-	// Note which energy control is being used.
-
-	QString controlType;
-	if (configuration_->usingEncoderEnergy())
-		controlType = QString("encoder-based");
-	else
-		controlType = QString("step-based");
-
-	notes.append(QString("Energy option:\t%1\n").arg(controlType));
 
 	return notes;
 }

--- a/source/beamline/BioXAS/BioXASMainMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASMainMonochromator.cpp
@@ -45,7 +45,7 @@ BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	region_->setPaddleStatusControl(paddleStatus_);
 	region_->setKeyStatusControl(keyStatus_);
 	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(stepBragg_);
+	region_->setBraggControl(braggControl());
 	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
 	region_->setCrystalChangeControl(crystalChange_);
 	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);

--- a/source/beamline/BioXAS/BioXASMainMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASMainMonochromator.cpp
@@ -12,7 +12,7 @@ BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	paddleStatus_ = new AMReadOnlyPVControl(QString("PaddleStatus"), QString("BL1607-5-I21:Mono:PaddleExtracted"), this);
 	keyStatus_ = new AMReadOnlyPVControl(QString("KeyStatus"), QString("BL1607-5-I21:Mono:KeyStatus"), this);
 	brakeStatus_ = new AMReadOnlyPVControl(QString("BrakeStatus"), QString("BL1607-5-I21:Mono:BrakeOff"), this);
-	bragg_ = new AMPVwStatusControl("Bragg", "SMTR1607-5-I21-12:deg:fbk", "SMTR1607-5-I21-12:deg", "SMTR1607-5-I21-12:status", "SMTR1607-5-I21-12:stop", this, 0.05);
+	encoderBragg_ = new AMPVwStatusControl("Bragg", "SMTR1607-5-I21-12:deg:fbk", "SMTR1607-5-I21-12:deg", "SMTR1607-5-I21-12:status", "SMTR1607-5-I21-12:stop", this, 0.05);
 	stepBragg_ = new AMPVwStatusControl("StepBragg", "SMTR1607-5-I21-12:deg:sp", "SMTR1607-5-I21-12:deg", "SMTR1607-5-I21-12:status", "SMTR1607-5-I21-12:stop", this, 0.05);
 	braggAtCrystalChangePositionStatus_ = new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I21:Mono:XtalChangePos", this);
 	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I21-22:mm:fbk", "SMTR1607-5-I21-22:mm", "SMTR1607-5-I21-22:status", "SMTR1607-5-I21-22:stop", this);
@@ -45,7 +45,7 @@ BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	region_->setPaddleStatusControl(paddleStatus_);
 	region_->setKeyStatusControl(keyStatus_);
 	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(bragg_);
+	region_->setBraggControl(stepBragg_);
 	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
 	region_->setCrystalChangeControl(crystalChange_);
 	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);
@@ -56,7 +56,7 @@ BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	// Create energy control.
 
 	encoderEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name_+"EncoderEnergyControl", this);
-	encoderEnergy_->setBraggControl(bragg_);
+	encoderEnergy_->setBraggControl(encoderBragg_);
 	encoderEnergy_->setBraggSetPositionControl(braggSetPosition_);
 	encoderEnergy_->setRegionControl(region_);
 	encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
@@ -76,7 +76,7 @@ BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	connect( paddleStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( keyStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( brakeStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( bragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	connect( encoderBragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( stepBragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( braggAtCrystalChangePositionStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -16,7 +16,7 @@ BioXASSSRLMonochromator::BioXASSSRLMonochromator(const QString &name, QObject *p
 	paddleStatus_ = 0;
 	keyStatus_ = 0;
 	brakeStatus_ = 0;
-	bragg_ = 0;
+	encoderBragg_ = 0;
 	stepBragg_ = 0;
 	braggAtCrystalChangePositionStatus_ = 0;
 	crystalChange_ = 0;
@@ -60,7 +60,7 @@ bool BioXASSSRLMonochromator::isConnected() const
 		paddleStatus_ && paddleStatus_->isConnected() &&
 		keyStatus_ && keyStatus_->isConnected() &&
 		brakeStatus_ && brakeStatus_->isConnected() &&
-		bragg_ && bragg_->isConnected() &&
+		encoderBragg_ && encoderBragg_->isConnected() &&
 		stepBragg_ && stepBragg_->isConnected() &&
 		braggAtCrystalChangePositionStatus_ && braggAtCrystalChangePositionStatus_->isConnected() &&
 		crystalChange_ && crystalChange_->isConnected() &&

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.h
@@ -39,7 +39,7 @@ public:
 	virtual bool isConnected() const;
 
 	/// Returns the energy control (the encoder-based, by default).
-	virtual BioXASSSRLMonochromatorEnergyControl* energyControl() const { return encoderEnergy_; }
+	virtual BioXASSSRLMonochromatorEnergyControl* energyControl() const { return stepEnergy_; }
 	/// Returns the bragg encoder-based energy control.
 	BioXASSSRLMonochromatorEnergyControl* encoderEnergyControl() const { return encoderEnergy_; }
 	/// Returns the bragg step-based energy control.
@@ -62,9 +62,11 @@ public:
 	/// Returns the brake status control.
 	AMControl* brakeStatusControl() const { return brakeStatus_; }
 	/// Returns the bragg control.
-	AMControl* braggControl() const { return bragg_; }
+	AMControl* braggControl() const { return stepBragg_; }
 	/// Returns the step-based bragg position control.
 	AMControl* stepBraggControl() const { return stepBragg_; }
+	/// Returns the encoder-based bragg position control.
+	AMControl* encoderBraggControl() const { return encoderBragg_; }
 	/// Returns the bragg motor at crystal change position status control.
 	AMControl* braggAtCrystalChangePositionStatusControl() const { return braggAtCrystalChangePositionStatus_; }
 	/// Returns the crystal change control.
@@ -135,7 +137,7 @@ protected:
 	/// The key status control.
 	AMControl *keyStatus_;
 	/// The bragg motor control.
-	AMControl *bragg_;
+	AMControl *encoderBragg_;
 	/// The step-based bragg motor position.
 	AMControl *stepBragg_;
 	/// The bragg motor at crystal change position status control.

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -45,7 +45,7 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	region_->setPaddleStatusControl(paddleStatus_);
 	region_->setKeyStatusControl(keyStatus_);
 	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(stepBragg_);
+	region_->setBraggControl(braggControl());
 	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
 	region_->setCrystalChangeControl(crystalChange_);
 	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -12,7 +12,7 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	paddleStatus_ = new AMReadOnlyPVControl("PaddleStatus", "BL1607-5-I22:Mono:PaddleExtracted", this);
 	keyStatus_ = new AMReadOnlyPVControl("KeyStatus", "BL1607-5-I22:Mono:KeyStatus", this);
 	brakeStatus_ = new AMReadOnlyPVControl("BrakeStatus", "BL1607-5-I22:Mono:BrakeOff", this);
-	bragg_ = new AMPVwStatusControl("Bragg", "SMTR1607-5-I22-12:deg:fbk", "SMTR1607-5-I22-12:deg", "SMTR1607-5-I22-12:status", "SMTR1607-5-I22-12:stop", this, 0.05);
+	encoderBragg_ = new AMPVwStatusControl("Bragg", "SMTR1607-5-I22-12:deg:fbk", "SMTR1607-5-I22-12:deg", "SMTR1607-5-I22-12:status", "SMTR1607-5-I22-12:stop", this, 0.05);
 	stepBragg_ = new AMPVwStatusControl("StepBragg", "SMTR1607-5-I22-12:deg:sp", "SMTR1607-5-I22-12:deg", "SMTR1607-5-I22-12:status", "SMTR1607-5-I22-12:stop", this, 0.05);
 	braggAtCrystalChangePositionStatus_ = new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I22:Mono:XtalChangePos", this);
 	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I22-22:mm:fbk", "SMTR1607-5-I22-22:mm", "SMTR1607-5-I22-22:status", "SMTR1607-5-I22-22:stop", this);
@@ -45,7 +45,7 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	region_->setPaddleStatusControl(paddleStatus_);
 	region_->setKeyStatusControl(keyStatus_);
 	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(bragg_);
+	region_->setBraggControl(stepBragg_);
 	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
 	region_->setCrystalChangeControl(crystalChange_);
 	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);
@@ -56,7 +56,7 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	// Create energy control.
 
 	encoderEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name_+"EncoderEnergyControl", this);
-	encoderEnergy_->setBraggControl(bragg_);
+	encoderEnergy_->setBraggControl(encoderBragg_);
 	encoderEnergy_->setBraggSetPositionControl(braggSetPosition_);
 	encoderEnergy_->setRegionControl(region_);
 	encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
@@ -76,7 +76,7 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	connect( paddleStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( keyStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( brakeStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( bragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	connect( encoderBragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( stepBragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( braggAtCrystalChangePositionStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -11,24 +11,16 @@ BioXASPersistentView::BioXASPersistentView(BioXASSSRLMonochromator *mono, CLSSIS
 {
 	// Create UI elements.
 
-	encoderEnergyEditor_ = new AMExtendedControlEditor(0);
-	encoderEnergyEditor_->setTitle("Mono Energy (encoder)");
-	encoderEnergyEditor_->setControlFormat('f', 2);
-
-	stepEnergyEditor_ = new AMExtendedControlEditor(0);
-	stepEnergyEditor_->setTitle("Mono Energy (step)");
-	stepEnergyEditor_->setControlFormat('f', 2);
+	energyEditor_ = new AMExtendedControlEditor(0);
+	energyEditor_->setTitle("Mono Energy");
+	energyEditor_->setControlFormat('f', 2);
 
 	regionEditor_ = new BioXASSSRLMonochromatorRegionControlEditor(0);
 	regionEditor_->setTitle("Mono Crystal Region");
 
-	encoderBraggEditor_ = new AMExtendedControlEditor(0);
-	encoderBraggEditor_->setTitle("Mono Goniometer Angle (encoder)");
-	encoderBraggEditor_->setControlFormat('f', 2);
-
-	stepBraggEditor_ = new AMExtendedControlEditor(0);
-	stepBraggEditor_->setTitle("Mono Goniometer Angle (step)");
-	stepBraggEditor_->setControlFormat('f', 2);
+	braggEditor_ = new AMExtendedControlEditor(0);
+	braggEditor_->setTitle("Mono Goniometer Angle");
+	braggEditor_->setControlFormat('f', 2);
 
 	// Create the scaler channel views.
 
@@ -45,11 +37,9 @@ BioXASPersistentView::BioXASPersistentView(BioXASSSRLMonochromator *mono, CLSSIS
 
 	QVBoxLayout *layout = new QVBoxLayout();
 	layout->setMargin(0);
-	layout->addWidget(encoderEnergyEditor_);
-	layout->addWidget(stepEnergyEditor_);
+	layout->addWidget(energyEditor_);
 	layout->addWidget(regionEditor_);
-	layout->addWidget(encoderBraggEditor_);
-	layout->addWidget(stepBraggEditor_);
+	layout->addWidget(braggEditor_);
 	layout->addWidget(channelsBox_);
 
 	setLayout(layout);
@@ -73,21 +63,17 @@ void BioXASPersistentView::setMono(BioXASSSRLMonochromator *newMono)
 	if (mono_ != newMono) {
 
 		if (mono_) {
-			encoderEnergyEditor_->setControl(0);
-			stepEnergyEditor_->setControl(0);
+			energyEditor_->setControl(0);
 			regionEditor_->setControl(0);
-			encoderBraggEditor_->setControl(0);
-			stepBraggEditor_->setControl(0);
+			braggEditor_->setControl(0);
 		}
 
 		mono_ = newMono;
 
 		if (mono_) {
-			encoderEnergyEditor_->setControl(mono_->encoderEnergyControl());
-			stepEnergyEditor_->setControl(mono_->stepEnergyControl());
+			energyEditor_->setControl(mono_->energyControl());
 			regionEditor_->setControl(mono_->regionControl());
-			encoderBraggEditor_->setControl(mono_->braggControl());
-			stepBraggEditor_->setControl(mono_->stepBraggControl());
+			braggEditor_->setControl(mono_->braggControl());
 		}
 
 		emit monoChanged(mono_);

--- a/source/ui/BioXAS/BioXASPersistentView.h
+++ b/source/ui/BioXAS/BioXASPersistentView.h
@@ -45,16 +45,12 @@ protected:
 	/// The scaler being viewed.
 	CLSSIS3820Scaler *scaler_;
 
-	/// Display that edits the encoder-based energy.
-	AMExtendedControlEditor *encoderEnergyEditor_;
 	/// Display that edits the step-based energy.
-	AMExtendedControlEditor *stepEnergyEditor_;
+	AMExtendedControlEditor *energyEditor_;
 	/// Editor that selects the mono region.
 	BioXASSSRLMonochromatorRegionControlEditor *regionEditor_;
-	/// Display that edits the bragg encoder-based position.
-	AMExtendedControlEditor *encoderBraggEditor_;
 	/// Display that edits the bragg step-based position.
-	AMExtendedControlEditor *stepBraggEditor_;
+	AMExtendedControlEditor *braggEditor_;
 	/// The scaler channel views for the i0, iT, and i2 channels.
 	QGroupBox *channelsBox_;
 };

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -10,21 +10,6 @@ BioXASSSRLMonochromatorConfigurationView::BioXASSSRLMonochromatorConfigurationVi
 
 	// Create UI elements.
 
-	regionEditor_ = new BioXASSSRLMonochromatorRegionControlEditor(0);
-	regionEditor_->setTitle("Region");
-
-	energyEditor_ = new AMExtendedControlEditor(0);
-	energyEditor_->setTitle("Energy (encoder)");
-	energyEditor_->setControlFormat('f', 2);
-
-	calibrateEnergyButton_ = new QPushButton("Calibrate");
-
-	braggEditor_ = new AMExtendedControlEditor(0);
-	braggEditor_->setTitle("Goniometer angle (encoder)");
-	braggEditor_->setControlFormat('f', 2);
-
-	calibrateBraggButton_ = new QPushButton("Calibrate");
-
 	upperSlitEditor_ = new AMExtendedControlEditor(0);
 	upperSlitEditor_->setTitle("Upper slit blade");
 	upperSlitEditor_->setControlFormat('f', 3);
@@ -32,6 +17,14 @@ BioXASSSRLMonochromatorConfigurationView::BioXASSSRLMonochromatorConfigurationVi
 	lowerSlitEditor_ = new AMExtendedControlEditor(0);
 	lowerSlitEditor_->setTitle("Lower slit blade");
 	lowerSlitEditor_->setControlFormat('f', 3);
+
+	heightEditor_ = new AMExtendedControlEditor(0);
+	heightEditor_->setTitle("Height");
+	heightEditor_->setControlFormat('f', 3);
+
+	lateralEditor_ = new AMExtendedControlEditor(0);
+	lateralEditor_->setTitle("Lateral");
+	lateralEditor_->setControlFormat('f', 3);
 
 	paddleEditor_ = new AMExtendedControlEditor(0);
 	paddleEditor_->setTitle("Paddle");
@@ -48,43 +41,90 @@ BioXASSSRLMonochromatorConfigurationView::BioXASSSRLMonochromatorConfigurationVi
 	crystal2RollEditor_ = new AMExtendedControlEditor(0);
 	crystal2RollEditor_->setTitle("Crystal 2 Roll");
 
+	regionEditor_ = new BioXASSSRLMonochromatorRegionControlEditor(0);
+	regionEditor_->setTitle("Region");
+
 	regionStatusWidget_ = new BioXASSSRLMonochromatorRegionControlView(0);
+
+	stepEnergyEditor_ = new AMExtendedControlEditor(0);
+	stepEnergyEditor_->setTitle("Energy (step)");
+	stepEnergyEditor_->setControlFormat('f', 2);
+
+	encoderEnergyEditor_ = new AMExtendedControlEditor(0, 0, true);
+	encoderEnergyEditor_->setTitle("Energy (encoder)");
+	encoderEnergyEditor_->setControlFormat('f', 2);
+
+	stepBraggEditor_ = new AMExtendedControlEditor(0);
+	stepBraggEditor_->setTitle("Goniometer (step)");
+	stepBraggEditor_->setControlFormat('f', 2);
+
+	encoderBraggEditor_ = new AMExtendedControlEditor(0, 0, true);
+	encoderBraggEditor_->setTitle("Goniometer (encoder)");
+	encoderBraggEditor_->setControlFormat('f', 2);
+
+	m1PitchEditor_ = new AMExtendedControlEditor(0);
+	m1PitchEditor_->setTitle("M1 Mirror Pitch");
+	m1PitchEditor_->setControlFormat('f', 2);
 
 	braggConfigWidget_ = new BioXASSSRLMonochromatorBraggConfigurationView(0);
 
 	// Create and set layouts.
+	// Motors view
 
-	QHBoxLayout *energyLayout = new QHBoxLayout();
-	energyLayout->setMargin(0);
-	energyLayout->addWidget(energyEditor_);
-	energyLayout->addWidget(calibrateEnergyButton_);
+	QVBoxLayout *motorsViewLayout = new QVBoxLayout();
+	motorsViewLayout->addWidget(upperSlitEditor_);
+	motorsViewLayout->addWidget(lowerSlitEditor_);
+	motorsViewLayout->addWidget(heightEditor_);
+	motorsViewLayout->addWidget(lateralEditor_);
+	motorsViewLayout->addWidget(paddleEditor_);
+	motorsViewLayout->addWidget(crystal1PitchEditor_);
+	motorsViewLayout->addWidget(crystal1RollEditor_);
+	motorsViewLayout->addWidget(crystal2PitchEditor_);
+	motorsViewLayout->addWidget(crystal2RollEditor_);
 
-	QHBoxLayout *braggLayout = new QHBoxLayout();
-	braggLayout->setMargin(0);
-	braggLayout->addWidget(braggEditor_);
-	braggLayout->addWidget(calibrateBraggButton_);
+	QGroupBox *motorsView = new QGroupBox("Motors");
+	motorsView->setLayout(motorsViewLayout);
+	motorsView->setMinimumWidth(VIEW_WIDTH_MIN);
 
-	QVBoxLayout *controlsViewLayout = new QVBoxLayout();
-	controlsViewLayout->addWidget(regionEditor_);
-	controlsViewLayout->addLayout(energyLayout);
-	controlsViewLayout->addLayout(braggLayout);
-	controlsViewLayout->addWidget(upperSlitEditor_);
-	controlsViewLayout->addWidget(lowerSlitEditor_);
-	controlsViewLayout->addWidget(paddleEditor_);
-	controlsViewLayout->addWidget(crystal1PitchEditor_);
-	controlsViewLayout->addWidget(crystal1RollEditor_);
-	controlsViewLayout->addWidget(crystal2PitchEditor_);
-	controlsViewLayout->addWidget(crystal2RollEditor_);
-
-	QGroupBox *controlsView = new QGroupBox("Controls");
-	controlsView->setLayout(controlsViewLayout);
+	// Region view
 
 	QVBoxLayout *regionStatusViewLayout = new QVBoxLayout();
 	regionStatusViewLayout->setMargin(0);
 	regionStatusViewLayout->addWidget(regionStatusWidget_);
 
-	QGroupBox *regionStatusView = new QGroupBox("Region status");
+	QGroupBox *regionStatusView = new QGroupBox("Status");
 	regionStatusView->setLayout(regionStatusViewLayout);
+
+	QVBoxLayout *regionViewLayout = new QVBoxLayout();
+	regionViewLayout->addWidget(regionEditor_);
+	regionViewLayout->addWidget(regionStatusView);
+
+	QGroupBox *regionView = new QGroupBox("Region");
+	regionView->setLayout(regionViewLayout);
+	regionView->setMinimumWidth(VIEW_WIDTH_MIN);
+
+	// Energy view
+
+	QGridLayout *energyGridLayout = new QGridLayout();
+	energyGridLayout->addWidget(stepEnergyEditor_, 0, 0);
+	energyGridLayout->addWidget(encoderEnergyEditor_, 0, 1);
+	energyGridLayout->addWidget(stepBraggEditor_, 1, 0);
+	energyGridLayout->addWidget(encoderBraggEditor_, 1, 1);
+
+	QHBoxLayout *energyM1Layout = new QHBoxLayout();
+	energyM1Layout->addStretch();
+	energyM1Layout->addWidget(m1PitchEditor_);
+	energyM1Layout->addStretch();
+
+	QVBoxLayout *energyViewLayout = new QVBoxLayout();
+	energyViewLayout->addLayout(energyGridLayout);
+	energyViewLayout->addLayout(energyM1Layout);
+
+	QGroupBox *energyView = new QGroupBox("Energy");
+	energyView->setLayout(energyViewLayout);
+	energyView->setMinimumWidth(VIEW_WIDTH_MIN);
+
+	// Bragg config view
 
 	QVBoxLayout *braggConfigViewLayout = new QVBoxLayout();
 	braggConfigViewLayout->setMargin(0);
@@ -93,25 +133,27 @@ BioXASSSRLMonochromatorConfigurationView::BioXASSSRLMonochromatorConfigurationVi
 	QGroupBox *braggConfigView = new QGroupBox("Goniometer configuration");
 	braggConfigView->setLayout(braggConfigViewLayout);
 
+	// Main layouts
+
 	QVBoxLayout *leftLayout = new QVBoxLayout();
-	leftLayout->addWidget(controlsView);
+	leftLayout->addWidget(motorsView);
 	leftLayout->addStretch();
 
+	QVBoxLayout *centerLayout = new QVBoxLayout();
+	centerLayout->addWidget(regionView);
+	centerLayout->addStretch();
+
 	QVBoxLayout *rightLayout = new QVBoxLayout();
-	rightLayout->addWidget(regionStatusView);
+	rightLayout->addWidget(energyView);
 	rightLayout->addWidget(braggConfigView);
 	rightLayout->addStretch();
 
 	QHBoxLayout *layout = new QHBoxLayout();
 	layout->addLayout(leftLayout);
+	layout->addLayout(centerLayout);
 	layout->addLayout(rightLayout);
 
 	setLayout(layout);
-
-	// Make connections
-
-	connect( calibrateEnergyButton_, SIGNAL(clicked()), this, SLOT(onCalibrateEnergyButtonClicked()) );
-	connect( calibrateBraggButton_, SIGNAL(clicked()), this, SLOT(onCalibrateBraggButtonClicked()) );
 
 	// Current settings
 
@@ -131,18 +173,25 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 
 			// Clear UI elements.
 
-			regionEditor_->setControl(0);
-			energyEditor_->setControl(0);
-			braggEditor_->setControl(0);
 			upperSlitEditor_->setControl(0);
 			lowerSlitEditor_->setControl(0);
+			heightEditor_->setControl(0);
+			lateralEditor_->setControl(0);
 			paddleEditor_->setControl(0);
 			crystal1PitchEditor_->setControl(0);
 			crystal1RollEditor_->setControl(0);
 			crystal2PitchEditor_->setControl(0);
 			crystal2RollEditor_->setControl(0);
 
+			regionEditor_->setControl(0);
 			regionStatusWidget_->setRegionControl(0);
+
+			stepEnergyEditor_->setControl(0);
+			encoderEnergyEditor_->setControl(0);
+			stepBraggEditor_->setControl(0);
+			encoderBraggEditor_->setControl(0);
+			m1PitchEditor_->setControl(0);
+
 			braggConfigWidget_->setBraggMotor(0);
 		}
 
@@ -152,46 +201,29 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 
 			// Update UI elements.
 
-			regionEditor_->setControl(mono_->regionControl());
-			energyEditor_->setControl(mono_->energyControl());
-			braggEditor_->setControl(mono_->braggMotor());
 			upperSlitEditor_->setControl(mono_->upperSlitControl());
 			lowerSlitEditor_->setControl(mono_->lowerSlitControl());
+			heightEditor_->setControl(mono_->verticalMotor());
+			lateralEditor_->setControl(mono_->lateralMotor());
 			paddleEditor_->setControl(mono_->paddleControl());
 			crystal1PitchEditor_->setControl(mono_->crystal1PitchMotor());
 			crystal1RollEditor_->setControl(mono_->crystal1RollMotor());
 			crystal2PitchEditor_->setControl(mono_->crystal2PitchMotor());
 			crystal2RollEditor_->setControl(mono_->crystal2RollMotor());
 
+			regionEditor_->setControl(mono_->regionControl());
 			regionStatusWidget_->setRegionControl(mono_->regionControl());
+
+			stepEnergyEditor_->setControl(mono_->stepEnergyControl());
+			encoderEnergyEditor_->setControl(mono_->encoderEnergyControl());
+			stepBraggEditor_->setControl(mono_->stepBraggControl());
+			encoderBraggEditor_->setControl(mono_->braggControl());
+			m1PitchEditor_->setControl(mono_->m1MirrorPitchControl());
+
 			braggConfigWidget_->setBraggMotor(mono_->braggMotor());
 		}
 
 		emit monoChanged(mono_);
-	}
-}
-
-void BioXASSSRLMonochromatorConfigurationView::onCalibrateEnergyButtonClicked()
-{
-	if (mono_) {
-		bool inputOK = false;
-		double newEnergy = QInputDialog::getDouble(this, "Energy Calibration", "Enter calibrated energy:", mono_->encoderEnergyControl()->value(), ENERGY_MIN, ENERGY_MAX, 1, &inputOK);
-
-		if (inputOK) {
-			mono_->encoderEnergyControl()->setEnergy(newEnergy);
-		}
-	}
-}
-
-void BioXASSSRLMonochromatorConfigurationView::onCalibrateBraggButtonClicked()
-{
-	if (mono_) {
-		bool inputOK = false;
-		double newPosition = QInputDialog::getDouble(this, "Bragg Position Calibration", "Enter calibrated position:", mono_->braggMotor()->value(), BRAGG_POSITION_MIN, BRAGG_POSITION_MAX, 1, &inputOK);
-
-		if (inputOK) {
-			mono_->calibrateBraggPosition(newPosition);
-		}
 	}
 }
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h
@@ -44,6 +44,12 @@ public slots:
 	/// Sets the mono being viewed.
 	void setMono(BioXASSSRLMonochromator *newMono);
 
+protected slots:
+	/// Creates and displays a basic calibration screen for the energy.
+	void onCalibrateEnergyButtonClicked();
+	/// Creates and displays a basic calibration screen for the goniometer.
+	void onCalibrateGoniometerButtonClicked();
+
 protected:
 	/// The mono being viewed.
 	BioXASSSRLMonochromator *mono_;
@@ -67,11 +73,6 @@ protected:
 	/// The crystal 2 roll editor.
 	AMExtendedControlEditor *crystal2RollEditor_;
 
-	/// The region editor.
-	BioXASSSRLMonochromatorRegionControlEditor *regionEditor_;
-	/// The region status display.
-	BioXASSSRLMonochromatorRegionControlView *regionStatusWidget_;
-
 	/// The step-based energy editor.
 	AMExtendedControlEditor *stepEnergyEditor_;
 	/// The encoder-based energy editor.
@@ -82,6 +83,16 @@ protected:
 	AMExtendedControlEditor *encoderBraggEditor_;
 	/// The m1 mirror pitch editor.
 	AMExtendedControlEditor *m1PitchEditor_;
+
+	/// The calibrate energy button.
+	QPushButton *calibrateEnergyButton_;
+	/// The calibrate goniometer button.
+	QPushButton *calibrateGoniometerButton_;
+
+	/// The region editor.
+	BioXASSSRLMonochromatorRegionControlEditor *regionEditor_;
+	/// The region status display.
+	BioXASSSRLMonochromatorRegionControlView *regionStatusWidget_;
 
 	/// The bragg configuration view.
 	BioXASSSRLMonochromatorBraggConfigurationView *braggConfigWidget_;

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h
@@ -19,6 +19,7 @@
 #define BRAGG_POSITION_MAX 1000000
 #define SETTLING_TIME_MIN 0
 #define SETTLING_TIME_MAX 100
+#define VIEW_WIDTH_MIN 300
 
 class BioXASSSRLMonochromatorBraggConfigurationView;
 
@@ -43,30 +44,18 @@ public slots:
 	/// Sets the mono being viewed.
 	void setMono(BioXASSSRLMonochromator *newMono);
 
-protected slots:
-	/// Displays a dialog for the user to set the calibrated energy.
-	void onCalibrateEnergyButtonClicked();
-	/// Displays a dialog for the user to set the calibrated bragg position.
-	void onCalibrateBraggButtonClicked();
-
 protected:
 	/// The mono being viewed.
 	BioXASSSRLMonochromator *mono_;
 
-	/// The region editor.
-	BioXASSSRLMonochromatorRegionControlEditor *regionEditor_;
-	/// The energy editor.
-	AMExtendedControlEditor *energyEditor_;
-	/// The calibrate energy button.
-	QPushButton *calibrateEnergyButton_;
-	/// The bragg motor position editor.
-	AMExtendedControlEditor *braggEditor_;
-	/// The calibrate bragg button.
-	QPushButton *calibrateBraggButton_;
 	/// The upper slit blade editor.
 	AMExtendedControlEditor *upperSlitEditor_;
 	/// The lower slit blade editor.
 	AMExtendedControlEditor *lowerSlitEditor_;
+	/// The height editor.
+	AMExtendedControlEditor *heightEditor_;
+	/// The lateral editor.
+	AMExtendedControlEditor *lateralEditor_;
 	/// The paddle editor.
 	AMExtendedControlEditor *paddleEditor_;
 	/// The crystal 1 pitch editor.
@@ -78,8 +67,22 @@ protected:
 	/// The crystal 2 roll editor.
 	AMExtendedControlEditor *crystal2RollEditor_;
 
+	/// The region editor.
+	BioXASSSRLMonochromatorRegionControlEditor *regionEditor_;
 	/// The region status display.
 	BioXASSSRLMonochromatorRegionControlView *regionStatusWidget_;
+
+	/// The step-based energy editor.
+	AMExtendedControlEditor *stepEnergyEditor_;
+	/// The encoder-based energy editor.
+	AMExtendedControlEditor *encoderEnergyEditor_;
+	/// The step-based bragg editor.
+	AMExtendedControlEditor *stepBraggEditor_;
+	/// The encoder-based bragg editor.
+	AMExtendedControlEditor *encoderBraggEditor_;
+	/// The m1 mirror pitch editor.
+	AMExtendedControlEditor *m1PitchEditor_;
+
 	/// The bragg configuration view.
 	BioXASSSRLMonochromatorBraggConfigurationView *braggConfigWidget_;
 };

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.cpp
@@ -47,10 +47,6 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 	connect(configuration_->dbObject(), SIGNAL(usingXRFDetectorChanged(bool)), usingXRFDetectorCheckBox_, SLOT(setChecked(bool)));
 	connect(usingXRFDetectorCheckBox_, SIGNAL(toggled(bool)), configuration_->dbObject(), SLOT(setUsingXRFDetector(bool)));
 
-	usingEncoderEnergyCheckBox_ = new QCheckBox("Use encoder-based energy");
-	usingEncoderEnergyCheckBox_->setChecked(configuration_->usingEncoderEnergy());
-	connect( usingEncoderEnergyCheckBox_, SIGNAL(toggled(bool)), this, SLOT(onUsingEncoderEnergyCheckBoxToggled()) );
-
 	autoRegionButton_ = new QPushButton("Auto Set XANES Regions");
 	connect(autoRegionButton_, SIGNAL(clicked()), this, SLOT(setupDefaultXANESScanRegions()));
 
@@ -108,7 +104,6 @@ BioXASSideXASScanConfigurationView::BioXASSideXASScanConfigurationView(BioXASSid
 
 	QVBoxLayout *optionsLayout = new QVBoxLayout();
 	optionsLayout->addWidget(usingXRFDetectorCheckBox_);
-	optionsLayout->addWidget(usingEncoderEnergyCheckBox_);
 	optionsLayout->addStretch();
 
 	QVBoxLayout *regionButtonsLayout = new QVBoxLayout();
@@ -259,9 +254,4 @@ void BioXASSideXASScanConfigurationView::onEdgeChanged()
 
 	if (energy_->value() != configuration_->energy())
 		energy_->setValue(configuration_->energy());
-}
-
-void BioXASSideXASScanConfigurationView::onUsingEncoderEnergyCheckBoxToggled()
-{
-	configuration_->setUsingEncoderEnergy(usingEncoderEnergyCheckBox_->isChecked());
 }

--- a/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
+++ b/source/ui/BioXAS/BioXASSideXASScanConfigurationView.h
@@ -69,9 +69,6 @@ protected slots:
 	/// Handles setting the proper information if the edge is changed.
 	void onEdgeChanged();
 
-	/// Handles setting the configuration flag for whether the encoder-based energy control is used.
-	void onUsingEncoderEnergyCheckBoxToggled();
-
 protected:
 	/// The scan configuration being viewed.
 	BioXASSideXASScanConfiguration *configuration_;
@@ -95,8 +92,6 @@ protected:
 	QLabel *scanEnergyRange_;
 	/// Check box for using the XRF detector.
 	QCheckBox *usingXRFDetectorCheckBox_;
-	/// Check box for using the encoder-based energy control (or step-based).
-	QCheckBox *usingEncoderEnergyCheckBox_;
 };
 
 #endif // BIOXASXASSCANCONFIGURATIONVIEW_H


### PR DESCRIPTION
In BioXASPersistentView:
- [x] Removed the 'encoder-based' editors
- [x] Renamed the 'step-based' editors. 

For XAS scans, removed the option to use the encoder-based energy:
- [x] in BioXASScanConfiguration
- [x] in BioXASSideXASScanConfiguration
- [x] in BioXASSideXASScanConfigurationView
- [x] in BioXASSideXASScanActionController

In the SSRLMono classes:
- [x] Renamed bragg controls to better reflect whether the control is step-based or encoder-based.
- [x] Changed the bragg control and energy control getters in the mono classes to return the step-based bragg and energy controls.

In the SSRLMono config view:
- [x] Add two new controls (height and lateral)
- [x] Include both the step-based and encoder-based energy and bragg control editors