### PR TITLE
Pull Request for Issue 1481: Scaler hangs

### DIFF
--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -147,25 +147,6 @@ AMAction3* BioXASSideXASScanActionController::createInitializationActions()
 	initializationAction->addSubAction(scaler->createStartAction3(true));
 	initializationAction->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 
-//	AMListAction3 *stage1 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 1", "BioXAS Side Initialization Stage 1"), AMListAction3::Parallel);
-//	stage1->addSubAction(scaler->createContinuousEnableAction3(false));
-////	stage1->addSubAction(scaler->createDwellTimeAction3(firstRegionTime));
-
-//	AMListAction3 *stage2 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 2", "BioXAS Side Initialization Stage 2"), AMListAction3::Parallel);
-
-//	stage2->addSubAction(scaler->createStartAction3(false));
-//	stage2->addSubAction(scaler->createScansPerBufferAction3(1));
-//	stage2->addSubAction(scaler->createTotalScansAction3(1));
-
-//	AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 3", "BioXAS Side Initialization Stage 3"), AMListAction3::Parallel);
-//	stage3->addSubAction(scaler->createStartAction3(true));
-//	stage3->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
-
-//	initializationAction->addSubAction(stage1);
-//	initializationAction->addSubAction(stage2);
-//	initializationAction->addSubAction(scaler->createDwellTimeAction3(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
-//	initializationAction->addSubAction(stage3);
-
 	// Set the bragg motor power to PowerOn.
 	initializationAction->addSubAction(BioXASSideBeamline::bioXAS()->mono()->braggMotor()->createPowerAction(CLSMAXvMotor::PowerOn));
 

--- a/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASSideXASScanActionController.cpp
@@ -139,26 +139,32 @@ AMAction3* BioXASSideXASScanActionController::createInitializationActions()
 {
 	AMSequentialListAction3 *initializationAction = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Side Scan Initialization Actions", "BioXAS Side Scan Initialization Actions"));
 	CLSSIS3820Scaler *scaler = BioXASSideBeamline::bioXAS()->scaler();
-	double regionTime = scaler->dwellTime();
 
-	AMListAction3 *stage1 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 1", "BioXAS Side Initialization Stage 1"), AMListAction3::Parallel);
-	stage1->addSubAction(scaler->createContinuousEnableAction3(false));
-//	stage1->addSubAction(scaler->createDwellTimeAction3(firstRegionTime));
+	double regionTime = double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime());
 
-	AMListAction3 *stage2 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 2", "BioXAS Side Initialization Stage 2"), AMListAction3::Parallel);
+	initializationAction->addSubAction(scaler->createContinuousEnableAction3(false));
+	initializationAction->addSubAction(scaler->createDwellTimeAction3(regionTime));
+	initializationAction->addSubAction(scaler->createStartAction3(true));
+	initializationAction->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 
-	stage2->addSubAction(scaler->createStartAction3(false));
-	stage2->addSubAction(scaler->createScansPerBufferAction3(1));
-	stage2->addSubAction(scaler->createTotalScansAction3(1));
+//	AMListAction3 *stage1 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 1", "BioXAS Side Initialization Stage 1"), AMListAction3::Parallel);
+//	stage1->addSubAction(scaler->createContinuousEnableAction3(false));
+////	stage1->addSubAction(scaler->createDwellTimeAction3(firstRegionTime));
 
-	AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 3", "BioXAS Side Initialization Stage 3"), AMListAction3::Parallel);
-	stage3->addSubAction(scaler->createStartAction3(true));
-	stage3->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
+//	AMListAction3 *stage2 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 2", "BioXAS Side Initialization Stage 2"), AMListAction3::Parallel);
 
-	initializationAction->addSubAction(stage1);
-	initializationAction->addSubAction(stage2);
-	initializationAction->addSubAction(scaler->createDwellTimeAction3(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
-	initializationAction->addSubAction(stage3);
+//	stage2->addSubAction(scaler->createStartAction3(false));
+//	stage2->addSubAction(scaler->createScansPerBufferAction3(1));
+//	stage2->addSubAction(scaler->createTotalScansAction3(1));
+
+//	AMListAction3 *stage3 = new AMListAction3(new AMListActionInfo3("BioXAS Side Initialization Stage 3", "BioXAS Side Initialization Stage 3"), AMListAction3::Parallel);
+//	stage3->addSubAction(scaler->createStartAction3(true));
+//	stage3->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
+
+//	initializationAction->addSubAction(stage1);
+//	initializationAction->addSubAction(stage2);
+//	initializationAction->addSubAction(scaler->createDwellTimeAction3(double(configuration_->scanAxisAt(0)->regionAt(0)->regionTime())));
+//	initializationAction->addSubAction(stage3);
 
 	// Set the bragg motor power to PowerOn.
 	initializationAction->addSubAction(BioXASSideBeamline::bioXAS()->mono()->braggMotor()->createPowerAction(CLSMAXvMotor::PowerOn));

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -121,8 +121,6 @@ QString AMPseudoMotorControl::toString() const
 	return result;
 }
 
-#include <QDebug>
-
 AMControl::FailureExplanation AMPseudoMotorControl::move(double setpoint)
 {
 	// Check that this control is connected and able to move before proceeding.
@@ -151,7 +149,6 @@ AMControl::FailureExplanation AMPseudoMotorControl::move(double setpoint)
 	// Instead report a successful move to setpoint.
 
 	if (withinTolerance(setpoint)) {
-		qDebug() << "Within tolerance.";
 		onMoveStarted(0);
 		onMoveSucceeded(0);
 		return AMControl::NoFailure;

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -121,6 +121,8 @@ QString AMPseudoMotorControl::toString() const
 	return result;
 }
 
+#include <QDebug>
+
 AMControl::FailureExplanation AMPseudoMotorControl::move(double setpoint)
 {
 	// Check that this control is connected and able to move before proceeding.
@@ -149,6 +151,7 @@ AMControl::FailureExplanation AMPseudoMotorControl::move(double setpoint)
 	// Instead report a successful move to setpoint.
 
 	if (withinTolerance(setpoint)) {
+		qDebug() << "Within tolerance.";
 		onMoveStarted(0);
 		onMoveSucceeded(0);
 		return AMControl::NoFailure;

--- a/source/beamline/CLS/CLSSIS3820ScalerModeControl.cpp
+++ b/source/beamline/CLS/CLSSIS3820ScalerModeControl.cpp
@@ -236,8 +236,6 @@ void CLSSIS3820ScalerModeControl::setSingleShotNumberOfScansPerBufferValue(doubl
 		singleShotNumberOfScansPerBufferValue_ = newValue;
 }
 
-#include <QDebug>
-
 AMAction3* CLSSIS3820ScalerModeControl::createMoveAction(double setpoint)
 {
 	// AMPseudoMotorControl handles checking whether we are connected, whether we can move,
@@ -247,14 +245,12 @@ AMAction3* CLSSIS3820ScalerModeControl::createMoveAction(double setpoint)
 
 	switch(int(setpoint)) {
 	case Mode::Continuous:
-//		setSingleShotScanCountValue(scanCountControl_->value());
-//		setSingleShotNumberOfScansPerBufferValue(numberOfScansPerBufferControl_->value());
-
+		setSingleShotScanCountValue(scanCountControl_->value());
+		setSingleShotNumberOfScansPerBufferValue(numberOfScansPerBufferControl_->value());
 		result = createMoveToContinuousModeAction();
 		break;
 
 	case Mode::SingleShot:
-		qDebug() << "Moving to single shot mode...";
 		result = createMoveToSingleShotModeAction();
 		break;
 
@@ -268,6 +264,7 @@ AMAction3* CLSSIS3820ScalerModeControl::createMoveAction(double setpoint)
 AMAction3* CLSSIS3820ScalerModeControl::createMoveToContinuousModeAction()
 {
 	AMListAction3 *result = new AMListAction3(new AMListActionInfo3("ModeChange", "SIS3820 Scaler Mode Change"), AMListAction3::Sequential);
+	result->addSubAction(AMActionSupport::buildControlMoveAction(startScanControl_, Scan::NotScanning));
 	result->addSubAction(AMActionSupport::buildControlMoveAction(scanCountControl_, 0));
 	result->addSubAction(AMActionSupport::buildControlMoveAction(numberOfScansPerBufferControl_, 1));
 	result->addSubAction(AMActionSupport::buildControlMoveAction(startScanControl_, Scan::Scanning));
@@ -278,9 +275,9 @@ AMAction3* CLSSIS3820ScalerModeControl::createMoveToContinuousModeAction()
 AMAction3* CLSSIS3820ScalerModeControl::createMoveToSingleShotModeAction()
 {
 	AMListAction3 *result = new AMListAction3(new AMListActionInfo3("ModeChange", "SIS3820 Scaler Mode Change"), AMListAction3::Sequential);
+	result->addSubAction(AMActionSupport::buildControlMoveAction(startScanControl_, Scan::NotScanning));
 	result->addSubAction(AMActionSupport::buildControlMoveAction(scanCountControl_, singleShotScanCountValue_));
 	result->addSubAction(AMActionSupport::buildControlMoveAction(numberOfScansPerBufferControl_, singleShotNumberOfScansPerBufferValue_));
-	result->addSubAction(AMActionSupport::buildControlMoveAction(startScanControl_, Scan::NotScanning));
 
 	return result;
 }

--- a/source/beamline/CLS/CLSSIS3820ScalerModeControl.cpp
+++ b/source/beamline/CLS/CLSSIS3820ScalerModeControl.cpp
@@ -236,6 +236,8 @@ void CLSSIS3820ScalerModeControl::setSingleShotNumberOfScansPerBufferValue(doubl
 		singleShotNumberOfScansPerBufferValue_ = newValue;
 }
 
+#include <QDebug>
+
 AMAction3* CLSSIS3820ScalerModeControl::createMoveAction(double setpoint)
 {
 	// AMPseudoMotorControl handles checking whether we are connected, whether we can move,
@@ -243,16 +245,21 @@ AMAction3* CLSSIS3820ScalerModeControl::createMoveAction(double setpoint)
 
 	AMAction3 *result = 0;
 
-	int setpointInt = int(setpoint);
-
-	if (setpointInt == Mode::Continuous) {
-		setSingleShotScanCountValue(scanCountControl_->value());
-		setSingleShotNumberOfScansPerBufferValue(numberOfScansPerBufferControl_->value());
+	switch(int(setpoint)) {
+	case Mode::Continuous:
+//		setSingleShotScanCountValue(scanCountControl_->value());
+//		setSingleShotNumberOfScansPerBufferValue(numberOfScansPerBufferControl_->value());
 
 		result = createMoveToContinuousModeAction();
+		break;
 
-	} else if (setpointInt == Mode::SingleShot) {
+	case Mode::SingleShot:
+		qDebug() << "Moving to single shot mode...";
 		result = createMoveToSingleShotModeAction();
+		break;
+
+	default:
+		break;
 	}
 
 	return result;


### PR DESCRIPTION
- Added extra step to set scaler to NotScanning in createMoveToContinuousModeAction().
- Moved existing step to set scaler to NotScanning to first step in createMoveToSingleShotAction()
- Removed some XAS scan initialization steps related to scaler setup--they don't appear to be necessary.