### PR TITLE
Pull Request for Issue1511: REIXS scaler continuous mode sidebar control not synchronized

### DIFF
--- a/source/ui/REIXS/REIXSSidebar.cpp
+++ b/source/ui/REIXS/REIXSSidebar.cpp
@@ -99,9 +99,16 @@ void REIXSSidebar::onScalerContinuousButtonToggled(bool on)
 	REIXSBeamline::bl()->scaler()->setContinuous(on);
 }
 
-void REIXSSidebar::onScalerContinuousModeChanged(double on)
+void REIXSSidebar::onScalerConnected(bool isConnected)
 {
-	enableScalerContinuousCheckBox_->setChecked(bool(on));
+	if(isConnected && REIXSBeamline::bl()->scaler()->isScanning() && REIXSBeamline::bl()->scaler()->totalScans() == 0) {
+		enableScalerContinuousCheckBox_->setChecked(true);
+	}
+}
+
+void REIXSSidebar::onScalerContinuousModeChanged(bool on)
+{
+	enableScalerContinuousCheckBox_->setChecked(on);
 }
 
 void REIXSSidebar::on_MonoStopButton_clicked()
@@ -140,7 +147,12 @@ void REIXSSidebar::setupConnections()
 
 	connect(beamOnButton_, SIGNAL(clicked()), this, SLOT(onBeamOnButtonClicked()));
 	connect(beamOffButton_, SIGNAL(clicked()), this, SLOT(onBeamOffButtonClicked()));
+
 	connect(enableScalerContinuousCheckBox_, SIGNAL(clicked(bool)), this, SLOT(onScalerContinuousButtonToggled(bool)));
+	connect(REIXSBeamline::bl()->scaler(), SIGNAL(continuousChanged(bool)), this, SLOT(onScalerContinuousModeChanged(bool)));
+	connect(REIXSBeamline::bl()->scaler(), SIGNAL(connectedChanged(bool)), this, SLOT(onScalerConnected(bool)));
+
+
 	connect(MonoStopButton_, SIGNAL(clicked()), this, SLOT(on_MonoStopButton_clicked()));
 
 	connect(REIXSBeamline::bl()->photonSource()->ringCurrent(), SIGNAL(valueChanged(double)), this, SLOT(onRingCurrentChanged(double)));
@@ -220,6 +232,7 @@ void REIXSSidebar::layoutDetectorContent()
 	TFYValue_->setFixedHeight(55);
 	enableScalerContinuousCheckBox_ = new QCheckBox("Enable Real-Time Updates");
 	enableScalerContinuousCheckBox_->setChecked(REIXSBeamline::bl()->scaler()->isContinuous());
+
 
 	QVBoxLayout *detectorPanelLayout = new QVBoxLayout();
 	detectorPanelLayout->addWidget(XESValue_);

--- a/source/ui/REIXS/REIXSSidebar.cpp
+++ b/source/ui/REIXS/REIXSSidebar.cpp
@@ -101,11 +101,6 @@ void REIXSSidebar::onScalerContinuousButtonToggled(bool on)
 
 void REIXSSidebar::onScalerConnected(bool isConnected)
 {
-
-//	qDebug() << "on connection scaler thinks it's:" << REIXSBeamline::bl()->scaler()->isContinuous();
-//	if(isConnected && REIXSBeamline::bl()->scaler()->isScanning() && REIXSBeamline::bl()->scaler()->totalScans() == 0) {
-//		enableScalerContinuousCheckBox_->setChecked(true);
-//	}
 	enableScalerContinuousCheckBox_->setChecked(REIXSBeamline::bl()->scaler()->isContinuous());
 }
 

--- a/source/ui/REIXS/REIXSSidebar.cpp
+++ b/source/ui/REIXS/REIXSSidebar.cpp
@@ -101,9 +101,12 @@ void REIXSSidebar::onScalerContinuousButtonToggled(bool on)
 
 void REIXSSidebar::onScalerConnected(bool isConnected)
 {
-	if(isConnected && REIXSBeamline::bl()->scaler()->isScanning() && REIXSBeamline::bl()->scaler()->totalScans() == 0) {
-		enableScalerContinuousCheckBox_->setChecked(true);
-	}
+
+//	qDebug() << "on connection scaler thinks it's:" << REIXSBeamline::bl()->scaler()->isContinuous();
+//	if(isConnected && REIXSBeamline::bl()->scaler()->isScanning() && REIXSBeamline::bl()->scaler()->totalScans() == 0) {
+//		enableScalerContinuousCheckBox_->setChecked(true);
+//	}
+	enableScalerContinuousCheckBox_->setChecked(REIXSBeamline::bl()->scaler()->isContinuous());
 }
 
 void REIXSSidebar::onScalerContinuousModeChanged(bool on)

--- a/source/ui/REIXS/REIXSSidebar.h
+++ b/source/ui/REIXS/REIXSSidebar.h
@@ -77,8 +77,11 @@ protected slots:
 	/// Monitors REIXSBeamline::bl()->valvesAndShutters()::beamOnChanged() to light up the "beam on" summary LED.
 	void onBeamOnChanged(bool isOn);
 
+	/// When the scaler connects
+	void onScalerConnected(bool isConnected);
+
 	/// When the scaler's continuous mode is changed
-	void onScalerContinuousModeChanged(double on);
+	void onScalerContinuousModeChanged(bool on);
 
 private slots:
 	void on_MonoStopButton_clicked();


### PR DESCRIPTION
MODIFIED: Scaler control connections
Connected onScalerContinuousModeChanged to scaler and fixed it's type
Added onScalerConnected to synchronized control with scaler on startup