### PR TITLE
Pull Request for Issue1514: Open up other databases in read-only mode

### DIFF
--- a/source/analysis/AM1DCalibrationABEditor.cpp
+++ b/source/analysis/AM1DCalibrationABEditor.cpp
@@ -245,7 +245,7 @@ void AM1DCalibrationABEditor::applyToAllSources()
 void AM1DCalibrationABEditor::onApplyToScansButtonClicked()
 {
 	if(!chooseScanDialog_) {
-		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose scans...", "Choose the scans you want to apply these analysis parameters to.", true, this);
+		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose scans...", "Choose the scans you want to apply these analysis parameters to.", this);
 		chooseScanDialog_->setAttribute(Qt::WA_DeleteOnClose, false);
 	}
 	connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(onApplyToOtherScansChosen()));

--- a/source/analysis/REIXS/REIXSXESImageABEditor.cpp
+++ b/source/analysis/REIXS/REIXSXESImageABEditor.cpp
@@ -950,7 +950,7 @@ void REIXSXESImageABEditorShiftModel::yValues(unsigned indexStart, unsigned inde
 void REIXSXESImageABEditor::onApplyToOtherScansMenuClicked()
 {
 	if(!chooseScanDialog_) {
-		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose scans...", "Choose the scans you want to apply these analysis parameters to.", true, this);
+		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose scans...", "Choose the scans you want to apply these analysis parameters to.", this);
 		/*
 		chooseScanDialog_->dataView_->setOrganizeMode(AMDataViews::OrganizeScanTypes);
 		*/

--- a/source/analysis/REIXS/REIXSXESImageInterpolationABEditor.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationABEditor.cpp
@@ -1293,7 +1293,7 @@ void REIXSXESImageInterpolationABEditor::onApplyToOtherScansMenuClicked()
 	if (confirm == QMessageBox::Yes)
 	{
 		if(!chooseScanDialog_) {
-			chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose scans...", "Choose the scans you want to apply these analysis parameters to.", true, this);
+			chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose scans...", "Choose the scans you want to apply these analysis parameters to.", this);
 			chooseScanDialog_->setAttribute(Qt::WA_DeleteOnClose, false);
 		}
 		connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(onApplyToOtherScansChosen()));

--- a/source/application/AMAppController.cpp
+++ b/source/application/AMAppController.cpp
@@ -121,7 +121,7 @@ bool AMAppController::startup(){
 
 void AMAppController::shutdown()
 {
-	AMDatamanAppController::shutdown();	
+	AMDatamanAppControllerForActions3::shutdown();
 	AMStorageRing::releaseStorageRing();
 	AMProcessVariableSupport::shutdownChannelAccess();
 }

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -1828,38 +1828,42 @@ bool AMDatamanAppController::anyOpenScansModified() const
 void AMDatamanAppController::onOpenOtherDatabaseClicked()
 {
 	QString otherFileName = QFileDialog::getOpenFileName(0, "Open other database...", ".", "*.db");
-	QStringList otherFileNameList = otherFileName.split("/");
-	QString otherDatabaseName = otherFileNameList.at(otherFileNameList.indexOf("userData")-1).toLower();
 
-	AMDatabase *otherDatabase = AMDatabase::createDatabase(otherDatabaseName, otherFileName, true);
-	otherOpenDatabases_ << otherDatabase;
-	AMScanDataView *newScanDataView = new AMScanDataView(otherDatabase);
+	if (!otherFileName.isEmpty()){
 
-	// Make a dataview widget and add it under two links/headings: "Runs" and "Experiments". See AMMainWindowModel for more information.
-	////////////////////////////////////
+		QStringList otherFileNameList = otherFileName.split("/");
+		QString otherDatabaseName = otherFileNameList.at(otherFileNameList.indexOf("userData")-1).toLower();
 
-	newScanDataView->setWindowTitle(otherDatabaseName);
+		AMDatabase *otherDatabase = AMDatabase::createDatabase(otherDatabaseName, otherFileName, true);
+		otherOpenDatabases_ << otherDatabase;
+		AMScanDataView *newScanDataView = new AMScanDataView(otherDatabase);
 
-	QStandardItem* dataViewItem = new QStandardItem();
-	dataViewItem->setData(qVariantFromValue((QWidget*)newScanDataView), AM::WidgetRole);
-	dataViewItem->setFlags(Qt::ItemIsEnabled);	// enabled, but should not be selectable
-	QFont font = QFont("Lucida Grande", 10, QFont::Bold);
-	font.setCapitalization(QFont::AllUppercase);
-	dataViewItem->setFont(font);
-	dataViewItem->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
-	dataViewItem->setData(true, AMWindowPaneModel::DockStateRole);
+		// Make a dataview widget and add it under two links/headings: "Runs" and "Experiments". See AMMainWindowModel for more information.
+		////////////////////////////////////
 
-	mw_->windowPaneModel()->appendRow(dataViewItem);
+		newScanDataView->setWindowTitle(otherDatabaseName);
 
-	QStandardItem *runsParentItem = new QStandardItem(QIcon(":/22x22/lock.png"), "Runs");
-	mw_->windowPaneModel()->initAliasItem(runsParentItem, dataViewItem, "Runs", -1);
-	dataViewItem->appendRow(runsParentItem);
+		QStandardItem* dataViewItem = new QStandardItem();
+		dataViewItem->setData(qVariantFromValue((QWidget*)newScanDataView), AM::WidgetRole);
+		dataViewItem->setFlags(Qt::ItemIsEnabled);	// enabled, but should not be selectable
+		QFont font = QFont("Lucida Grande", 10, QFont::Bold);
+		font.setCapitalization(QFont::AllUppercase);
+		dataViewItem->setFont(font);
+		dataViewItem->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
+		dataViewItem->setData(true, AMWindowPaneModel::DockStateRole);
 
-	new AMRunExperimentInsert(otherDatabase, runsParentItem, 0, this);
+		mw_->windowPaneModel()->appendRow(dataViewItem);
 
-	// connect the activated signal from the dataview to our own slot
-	connect(newScanDataView, SIGNAL(selectionActivated(QList<QUrl>)), this, SLOT(onDataViewItemsActivated(QList<QUrl>)));
-	connect(newScanDataView, SIGNAL(selectionActivatedSeparateWindows(QList<QUrl>)), this, SLOT(onDataViewItemsActivatedSeparateWindows(QList<QUrl>)));
-	connect(newScanDataView, SIGNAL(selectionExported(QList<QUrl>)), this, SLOT(onDataViewItemsExported(QList<QUrl>)));
-	connect(newScanDataView, SIGNAL(launchScanConfigurationsFromDb(QList<QUrl>)), this, SLOT(onLaunchScanConfigurationsFromDb(QList<QUrl>)));
+		QStandardItem *runsParentItem = new QStandardItem(QIcon(":/22x22/lock.png"), "Runs");
+		mw_->windowPaneModel()->initAliasItem(runsParentItem, dataViewItem, "Runs", -1);
+		dataViewItem->appendRow(runsParentItem);
+
+		new AMRunExperimentInsert(otherDatabase, runsParentItem, 0, this);
+
+		// connect the activated signal from the dataview to our own slot
+		connect(newScanDataView, SIGNAL(selectionActivated(QList<QUrl>)), this, SLOT(onDataViewItemsActivated(QList<QUrl>)));
+		connect(newScanDataView, SIGNAL(selectionActivatedSeparateWindows(QList<QUrl>)), this, SLOT(onDataViewItemsActivatedSeparateWindows(QList<QUrl>)));
+		connect(newScanDataView, SIGNAL(selectionExported(QList<QUrl>)), this, SLOT(onDataViewItemsExported(QList<QUrl>)));
+		connect(newScanDataView, SIGNAL(launchScanConfigurationsFromDb(QList<QUrl>)), this, SLOT(onLaunchScanConfigurationsFromDb(QList<QUrl>)));
+	}
 }

--- a/source/application/AMDatamanAppController.h
+++ b/source/application/AMDatamanAppController.h
@@ -260,6 +260,9 @@ The Drag is accepted when:
 	/// Helps force quit Acquaman by setting a flag to override the check in the event filter for QEvent::Close
 	void forceQuitAcquaman();
 
+	/// Opens another database in read-only mode so that you can compare data across databases.
+	void onOpenOtherDatabaseClicked();
+
 protected slots:
 
 	/// This slot catches changes in the current widget of the AMMainWindow. \c pane is the new current widget.  Re-implement to catch any widget-specific responses that you need here.
@@ -387,9 +390,10 @@ protected:
 	/// This will be set to true if this is the first time a user has run Acquaman
 	bool isFirstTimeRun_;
 
+	/// Holds the list of extra databases that have been opened since the application has started.
+	QList<AMDatabase *> otherOpenDatabases_;
 	/// Holds the list of database upgrades to do in order (holds these as QMetaObjects so they can be new'd at the correct time)
 	QList<AMDbUpgrade*> databaseUpgrades_;
-
 	/// Holds a list of additional databases to look in for export options (the "user" database will always be searched")
 	QStringList additionalExporterOptionsDatabases_;
 

--- a/source/application/AMDatamanAppControllerForActions3.cpp
+++ b/source/application/AMDatamanAppControllerForActions3.cpp
@@ -187,3 +187,11 @@ bool AMDatamanAppControllerForActions3::startupRegisterDatabases()
 
 	return true;
 }
+
+void AMDatamanAppControllerForActions3::shutdown()
+{
+	AMDatamanAppController::shutdown();
+
+	AMDatabase::deleteDatabase("actions");
+	AMDatabase::deleteDatabase("scanActions");
+}

--- a/source/application/AMDatamanAppControllerForActions3.h
+++ b/source/application/AMDatamanAppControllerForActions3.h
@@ -29,7 +29,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 /// This version of AMDatamanAppController is suitable for apps using the 'actions3' actions framework
 class AMDatamanAppControllerForActions3 : public AMDatamanAppController
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
 	explicit AMDatamanAppControllerForActions3(QObject *parent = 0);
 
@@ -39,6 +39,9 @@ public:
 	virtual bool startupCreateDatabases();
 	/// Re-implemented to register common database classes, and the actions3 database objects.
 	virtual bool startupRegisterDatabases();
+
+	/// destroy all of the windows, widgets, and data objects created by applicationStartup(). Only call this if startup() has ran successfully.  If reimplementing, must call the base-class shutdown() as the last thing it does.
+	virtual void shutdown();
 
 signals:
 

--- a/source/dataman/AMLightweightScanInfo.cpp
+++ b/source/dataman/AMLightweightScanInfo.cpp
@@ -128,8 +128,8 @@ AMDbThumbnail *AMLightweightScanInfo::thumbnailAt(int index) const
 		return 0;
 
 	/// Thumbnails hasn't been loaded yet, load
-	if(!thumbnailsMap_.contains(thumbnailIds_.at(index))) {
-		AMDatabase* db = AMDatabase::database("user");
+	if(!thumbnailsMap_.contains(thumbnailIds_.at(index)) && database_) {
+		AMDatabase* db = database_;
 
 		QSqlQuery query = db->select(AMDbObjectSupport::thumbnailTableName(), "type, title, subtitle, thumbnail", QString("id = %1").arg(thumbnailIds_.at(index)));
 		if(query.exec()) {

--- a/source/dataman/AMLightweightScanInfoCollection.cpp
+++ b/source/dataman/AMLightweightScanInfoCollection.cpp
@@ -22,6 +22,7 @@ QUrl AMLightweightScanInfoCollection::getScanUrl(int id) const
 				.arg(database_->connectionName())
 				.arg(AMDbObjectSupport::s()->tableNameForClass("AMScan"))
 				.arg(id);
+
 	QUrl returnUrl(urlString);
 
 	return returnUrl;

--- a/source/dataman/AMScan.cpp
+++ b/source/dataman/AMScan.cpp
@@ -717,29 +717,35 @@ AMDbThumbnail AMScan::thumbnail(int index) const {
 }
 
 bool AMScan::loadData()
-
 {
 	bool accepts = false;
 	bool success = false;
+	QStringList basePathList = database()->dbAccessString().split("/");
+	basePathList.removeLast();
+	QString basePath = basePathList.join("/");
 
 	// find the available file loaders that claim to work for our fileFormat:
 	QList<AMFileLoaderFactory*> acceptingFileLoaders = AMPluginsManager::s()->availableFileLoaderPlugins().values(fileFormat());
 
 	for(int x = 0; x < acceptingFileLoaders.count(); x++) {
+
 		if((accepts = acceptingFileLoaders.at(x)->accepts(this))){
+
 			AMFileLoaderInterface* fileLoader = acceptingFileLoaders.at(x)->createFileLoader();
-			success = fileLoader->load(this, AMUserSettings::userDataFolder, AMErrorMon::mon());
+			success = fileLoader->load(this, basePath, AMErrorMon::mon());
 			delete fileLoader;
 			break;
 		}
 
 	}
+
 	if(!accepts)
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Alert, AMSCAN_CANNOT_FIND_SUITABLE_PLUGIN_FOR_FILE_FORMAT, QString("Could not find a suitable plugin for loading the file format '%1'.  Check the Acquaman preferences for the correct plugin locations, and contact the Acquaman developers for assistance.").arg(fileFormat())));
 
 	if(success)
 		for(int i=rawDataSources_.count()-1; i>=0; i--)
 			rawDataSources_.at(i)->setDataStore(rawData());
+
 	return success;
 }
 

--- a/source/dataman/VESPERS/VESPERSDatabaseDuplicateEntryObject.cpp
+++ b/source/dataman/VESPERS/VESPERSDatabaseDuplicateEntryObject.cpp
@@ -96,7 +96,7 @@ bool VESPERSDatabaseDuplicateEntryObject::fix()
 
 	query.prepare("SELECT name FROM AMRawDataSource_table WHERE " % duplicateWhereClause);
 
-	if (!AMDatabase::execQuery(query)){
+	if (!database_->execQuery(query)){
 
 		query.finish();
 		return false;

--- a/source/dataman/VESPERS/VESPERSDatabaseDuplicateEntryPatch.cpp
+++ b/source/dataman/VESPERS/VESPERSDatabaseDuplicateEntryPatch.cpp
@@ -40,7 +40,7 @@ bool VESPERSDatabaseDuplicateEntryPatch::start()
 	QSqlQuery query = database->query();
 	query.prepare("SELECT id, measurementId, name FROM AMRawDataSource_table;");
 
-	if (!AMDatabase::execQuery(query)){
+	if (!database->execQuery(query)){
 
 		query.finish();
 		AMErrorMon::alert(this, 0, "Could not read from AMRawDataSource_table");
@@ -79,7 +79,7 @@ bool VESPERSDatabaseDuplicateEntryPatch::start()
 
 	query.prepare("SELECT id1 FROM AMScan_table_rawDataSources WHERE " % duplicateWhereClause);
 
-	if (!AMDatabase::execQuery(query)){
+	if (!database->execQuery(query)){
 
 		query.finish();
 		return false;

--- a/source/dataman/database/AMDatabase.cpp
+++ b/source/dataman/database/AMDatabase.cpp
@@ -46,8 +46,10 @@ AMDatabase::AMDatabase(const QString& connectionName, const QString& dbAccessStr
 	qdbMutex_(QMutex::Recursive)
 {
 
-	if (openAsReadOnly)
+	if (openAsReadOnly){
+
 		isReadOnly_ = true;
+	}
 
 	else {
 
@@ -859,10 +861,9 @@ bool AMDatabase::supportsTransactions() const
 	return qdb().driver()->hasFeature(QSqlDriver::Transactions);
 }
 
-#include <QDebug>
 bool AMDatabase::execQuery(QSqlQuery &query, int timeoutMs)
 {
-	if (isReadOnly() && !query.executedQuery().startsWith("SELECT", Qt::CaseInsensitive)){
+	if (isReadOnly() && !(query.executedQuery().startsWith("SELECT", Qt::CaseInsensitive) || query.executedQuery().startsWith("PRAGMA", Qt::CaseInsensitive))){
 
 		AMErrorMon::debug(this, AMDATABASE_IS_READ_ONLY, QString("This database is read-only and the desired command would modify the contents of the database. Query: %1").arg(query.executedQuery()));
 		return false;

--- a/source/dataman/database/AMDatabase.cpp
+++ b/source/dataman/database/AMDatabase.cpp
@@ -386,8 +386,8 @@ int AMDatabase::deleteRows(const QString& tableName, const QString& whereClause)
  (Note that the const and & arguments are designed to prevent memory copies, so this should be fast.)
  Return value: returns true on success.
 */
-QVariantList AMDatabase::retrieve(int id, const QString& table, const QStringList& colNames) const {
-
+QVariantList AMDatabase::retrieve(int id, const QString& table, const QStringList& colNames)
+{
 	QVariantList values;	// return value
 
 	/// \todo sanitize more than this...
@@ -429,8 +429,8 @@ QVariantList AMDatabase::retrieve(int id, const QString& table, const QStringLis
  (Note that the const and & arguments are designed to prevent memory copies, so this should be fast.)
  Return value: returns the list of values
 */
-QVariantList AMDatabase::retrieve(const QString& table, const QString& colName) const {
-
+QVariantList AMDatabase::retrieve(const QString& table, const QString& colName)
+{
 	QVariantList values;	// return value
 
 	/// \todo sanitize more than this...
@@ -461,8 +461,8 @@ QVariantList AMDatabase::retrieve(const QString& table, const QString& colName) 
 }
 
 
-QVariant AMDatabase::retrieve(int id, const QString& table, const QString& colName) const {
-
+QVariant AMDatabase::retrieve(int id, const QString& table, const QString& colName)
+{
 	/// \todo sanitize more than this...
 	if(table.isEmpty()) {
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Alert, -10, "Could not search the database. (Missing the table name.)"));
@@ -494,7 +494,7 @@ QVariant AMDatabase::retrieve(int id, const QString& table, const QString& colNa
 
 }
 
-QVariant AMDatabase::retrieveMax(const QString &table, const QString &colName, const QString &whereClause) const
+QVariant AMDatabase::retrieveMax(const QString &table, const QString &colName, const QString &whereClause)
 {
 	// Sanitize the options
 	if(table.isEmpty() || colName.isEmpty())
@@ -545,8 +545,8 @@ QVariant AMDatabase::retrieveMax(const QString &table, const QString &colName, c
 }
 
 /// returns a list of all the objecst/rows (by id) that match a given condition. \c whereClause is a string suitable for appending after an SQL "WHERE" statement.
-QList<int> AMDatabase::objectsWhere(const QString& tableName, const QString& whereClause) const {
-
+QList<int> AMDatabase::objectsWhere(const QString& tableName, const QString& whereClause)
+{
 	QList<int> rl;
 
 	/// \todo sanitize more than this...
@@ -575,8 +575,8 @@ QList<int> AMDatabase::objectsWhere(const QString& tableName, const QString& whe
 
 /// Return a list of all the objects/rows (by id) that match 'value' in a certain column.
 /// ex: AMDatabase::db()->objectsMatching("name", "Carbon60"), or AMDatabase::db()->objectsMatching("dateTime", QDateTime::currentDateTime())
-QList<int> AMDatabase::objectsMatching(const QString& tableName, const QString& colName, const QVariant& value) const {
-
+QList<int> AMDatabase::objectsMatching(const QString& tableName, const QString& colName, const QVariant& value)
+{
 	// return value: list of id's that match
 	QList<int> rl;
 
@@ -611,7 +611,8 @@ QList<int> AMDatabase::objectsMatching(const QString& tableName, const QString& 
 
 /// Return a list of all the objects/rows (by id) that contain 'value' in a certain column
 /// ex: AMDatabase::db()->scansContaining("name", "Carbon60") could return Scans with names Carbon60_alpha and bCarbon60_gamma
-QList<int> AMDatabase::objectsContaining(const QString& tableName, const QString& colName, const QVariant& value) const {
+QList<int> AMDatabase::objectsContaining(const QString& tableName, const QString& colName, const QVariant& value)
+{
 
 	QList<int> rl;
 
@@ -858,14 +859,14 @@ bool AMDatabase::supportsTransactions() const
 	return qdb().driver()->hasFeature(QSqlDriver::Transactions);
 }
 
-
+#include <QDebug>
 bool AMDatabase::execQuery(QSqlQuery &query, int timeoutMs)
 {
-//	if (isReadOnly() && !query.isSelect()){
+	if (isReadOnly() && !query.executedQuery().startsWith("SELECT", Qt::CaseInsensitive)){
 
-//		AMErrorMon::debug(this, AMDATABASE_IS_READ_ONLY, "This database is read-only and the desired command would modify the contents of the database.");
-//		return false;
-//	}
+		AMErrorMon::debug(this, AMDATABASE_IS_READ_ONLY, QString("This database is read-only and the desired command would modify the contents of the database. Query: %1").arg(query.executedQuery()));
+		return false;
+	}
 
 	QTime startTime;
 	startTime.start();

--- a/source/dataman/database/AMDatabase.h
+++ b/source/dataman/database/AMDatabase.h
@@ -39,6 +39,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #define AMDATABASE_LOCK_FOR_EXECQUERY_CONTENTION_FAILED -3106
 #define AMDATABASE_MISSING_TABLE_NAME_IN_RETRIEVE -3107
 #define AMDATABASE_RETRIEVE_QUERY_FAILED -3108
+#define AMDATABASE_IS_READ_ONLY -3109
 
 /// This class provides thread-safe, general access to an SQL database.
 /*! Instances of this class are used to query or modify a database; all of the functions are thread-safe and will operate using a per-thread connection to the same underlying database.
@@ -53,17 +54,17 @@ class AMDatabase : public QObject {
 	Q_OBJECT
 
 public:
- 	virtual ~AMDatabase();
+	virtual ~AMDatabase();
 
 	// Multiton accessor functions: getting access to an AMDatabase instance.
 	/////////////////////////////////////
 	/// Create a new database instance with the given \c connectionName and \c dbAccessString.
 	/*! The AMDatabase constructor is private so that we can enforce unique connection names across the program. This is the only way to access it.
-The \c connectionName will be used to retrieve this instance later using AMDatabase::database(). It needs to be unique (program-wide); this function will return 0 if a connection with that name already exists.
-
-The parameters by which to access the database are given in \c dbAccessString. (For the current SQLITE database, dbAccessString is just the path to the database file.)
+		The \c connectionName will be used to retrieve this instance later using AMDatabase::database(). It needs to be unique (program-wide); this function will return 0 if a connection with that name already exists.
+		The parameters by which to access the database are given in \c dbAccessString. (For the current SQLITE database, dbAccessString is just the path to the database file.)
+		\param openAsReadOnly is a defaulted parameter that defaults to false (you typically want the ability to have changes to your database stick).  If set to true, execQuery() will not take place for statements that modify the database.
 */
-	static AMDatabase* createDatabase(const QString& connectionName, const QString& dbAccessString);
+	static AMDatabase* createDatabase(const QString& connectionName, const QString& dbAccessString, bool openAsReadOnly = false);
 	/// Get access to a database based on the \c connectionName. If the connection doesn't exist, returns 0.
 	static AMDatabase* database(const QString& connectionName);
 	/// Delete a database instance that is not longer required.
@@ -233,7 +234,8 @@ protected:
 private:
 	/// Constructor is private.  ConnectionName is a unique connection name (program-wide) for this database. dbAccessString provides the database-engine specific connection details.
 	/*! (For the current SQLITE database, dbAccessString is just the path to the database file.)*/
-	AMDatabase(const QString& connectionName, const QString& dbAccessString);
+	/// \param openAsReadOnly is a defaulted parameter that defaults to false (you typically want the ability to have changes to your database stick).  If set to true, execQuery() will not take place for statements that modify the database.
+	AMDatabase(const QString& connectionName, const QString& dbAccessString, bool openAsReadOnly = false);
 
 	// Instance variables:
 	///////////////////////////

--- a/source/dataman/database/AMDatabase.h
+++ b/source/dataman/database/AMDatabase.h
@@ -95,33 +95,23 @@ public:
 
 
 	/// Contrary to what the docs say, the QSQLiteDriver never re-tries a query that fails when the database was busy/locked. You can use this function instead of QSqlQuery::exec(). Whenever a query fails due to a busy error, it will block up to a maximum timeout of \c timeoutMs ms while re-trying automatically every 5ms.
-	static bool execQuery(QSqlQuery& query, int timeoutMs = 5000);
+	bool execQuery(QSqlQuery& query, int timeoutMs = 5000);
 
 
 	// Instance Functions
 	///////////////////////////
 
 	/// This is the connection name of this database instance.
-	QString connectionName() {
-		return connectionName_;
-	}
+	QString connectionName() const { return connectionName_; }
 
 	/// This is the full path to the database
-	QString dbAccessString() const{
-		return dbAccessString_;
-	}
+	QString dbAccessString() const { return dbAccessString_; }
 
 	/// This returns whether or not this instance can be written to (all valid connections can be read from)
-	bool isReadOnly() const{
-		return isReadOnly_;
-	}
+	bool isReadOnly() const { return isReadOnly_; }
 
 	/// This returns whether or not the database has any tables (if no tables, then it's empty)
-	bool isEmpty() const{
-		if(qdb().tables().count() == 0)
-			return true;
-		return false;
-	}
+	bool isEmpty() const { return (qdb().tables().count() == 0); }
 
 
 	/// Inserting or updating a row in the database.
@@ -156,7 +146,7 @@ public:
 
 		Returns an empty list on failure.
 	*/
-	QVariantList retrieve(int id, const QString& table, const QStringList& colNames) const;
+	QVariantList retrieve(int id, const QString& table, const QStringList& colNames);
 	/// retrieve a column from the database
 	/*! \c table is the database table name
 		\c colName is the name of the column you wish to get all the values for
@@ -165,13 +155,13 @@ public:
 		No id parameter is used, because a value for each id is returned
 		Returns an empty list on failure.
 	*/
-	QVariantList retrieve(const QString& table, const QString& colName) const;
+	QVariantList retrieve(const QString& table, const QString& colName);
 
 	/// Retrieve a single parameter/value for an object.  This is simpler than retrieve() when all you need is a single value.
-	QVariant retrieve(int id, const QString& table, const QString& colName) const;
+	QVariant retrieve(int id, const QString& table, const QString& colName);
 
 	/// Retrieves the maximum value stored in table.colName, with the option to match prior to detemining the max with a where clause.
-	QVariant retrieveMax(const QString& table, const QString& colName, const QString& whereClause = QString()) const;
+	QVariant retrieveMax(const QString& table, const QString& colName, const QString& whereClause = QString());
 
 	/// Checks whether \param tableName exists within the database.
 	bool tableExists(const QString &tableName);
@@ -193,14 +183,14 @@ public:
 
 	/// Return a list of all the objects/rows (by id) that match 'value' in a certain column.
 	/// ex: AMDatabase::db()->objectsMatching("name", "Carbon60"), or AMDatabase::db()->objectsMatching("dateTime", QDateTime::currentDateTime())
-	QList<int> objectsMatching(const QString& tableName, const QString& colName, const QVariant& value) const;
+	QList<int> objectsMatching(const QString& tableName, const QString& colName, const QVariant& value);
 
 	/// Return a list of all the objects/rows (by id) that contain 'value' in a certain column
 	/// ex: AMDatabase::db()->scansContaining("name", "Carbon60") could return Scans with names Carbon60_alpha and bCarbon60_gamma
-	QList<int> objectsContaining(const QString& tableName, const QString& colName, const QVariant& value) const;
+	QList<int> objectsContaining(const QString& tableName, const QString& colName, const QVariant& value);
 
 	/// returns a list of all the objecst/rows (by id) that match a given condition. \c whereClause is a string suitable for appending after an SQL "WHERE" statement. If you want the id of all objects, you can omit the where clause.
-	QList<int> objectsWhere(const QString& tableName, const QString& whereClause = QString()) const;
+	QList<int> objectsWhere(const QString& tableName, const QString& whereClause = QString());
 
 
 	/// Starts an SQL transaction if the implementation supports them. Returns true on success.

--- a/source/dataman/database/AMDbObject.cpp
+++ b/source/dataman/database/AMDbObject.cpp
@@ -184,9 +184,9 @@ bool AMDbObject::storeToDb(AMDatabase* db, bool generateThumbnails) {
 	//////////////////////////////////////////////////
 	for(int i=0; i<myInfo->columnCount; i++) {
 
-        int columnType = myInfo->columnTypes.at(i);
+		int columnType = myInfo->columnTypes.at(i);
 		QByteArray columnNameBA = myInfo->columns.at(i).toAscii();
-        const char* columnName = columnNameBA.constData();
+		const char* columnName = columnNameBA.constData();
 
 		// add column name to key list... UNLESS the type is an AMDbObjectList. In that case, it gets its own table instead of a column.
 		if(columnType != qMetaTypeId<AMDbObjectList>() && columnType != qMetaTypeId<AMConstDbObjectList>())
@@ -909,4 +909,9 @@ AMDbThumbnailsGeneratedEvent::AMDbThumbnailsGeneratedEvent(const QList<AMDbThumb
 {
 }
 
+void AMDbObject::setModified(bool isModified)
+{
+	if(!database()->isReadOnly() && isModified != modified_)
+		emit modifiedChanged(modified_ = isModified);
+}
 

--- a/source/dataman/database/AMDbObject.cpp
+++ b/source/dataman/database/AMDbObject.cpp
@@ -911,7 +911,14 @@ AMDbThumbnailsGeneratedEvent::AMDbThumbnailsGeneratedEvent(const QList<AMDbThumb
 
 void AMDbObject::setModified(bool isModified)
 {
-	if(!database()->isReadOnly() && isModified != modified_)
+	// First one is to allow the db object to be reset after being loaded from the database.
+	if (database() && database()->isReadOnly()){
+
+		if (modified_)
+			emit modifiedChanged(modified_ = false);
+	}
+
+	else if (isModified != modified_)
 		emit modifiedChanged(modified_ = isModified);
 }
 

--- a/source/dataman/database/AMDbObject.h
+++ b/source/dataman/database/AMDbObject.h
@@ -389,10 +389,7 @@ public slots:
 protected:
 
 	/// Subclasses should call this to set or un-set the modified flag.  Handles emission of the modifiedChanged() signal when required.
-	void setModified(bool isModified = true) {
-		if(isModified != modified_)
-			emit modifiedChanged(modified_ = isModified);
-	}
+	void setModified(bool isModified = true);
 
 
 private:

--- a/source/dataman/database/AMDbObjectSupport.cpp
+++ b/source/dataman/database/AMDbObjectSupport.cpp
@@ -552,7 +552,7 @@ bool AMDbObjectSupport::isUpgradeRequiredForClass(AMDatabase* db, const AMDbObje
 
 	QSqlQuery q = db->query();
 	q.prepare("SELECT columnName FROM " % allColumnsTableName() % " WHERE typeId = '" % QString::number(typeIdInDatabase) % "';");
-	if(!AMDatabase::execQuery(q)) {
+	if(!db->execQuery(q)) {
 		q.finish();
 		AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, AMDBOBJECTSUPPORT_ERROR_WHILE_CHECKING_UPGRADE, QString("Database support: There was an error while trying to check if the class '%1' in the database needs an upgrade.").arg(info.className)));
 		return false;
@@ -572,7 +572,7 @@ bool AMDbObjectSupport::isUpgradeRequiredForClass(AMDatabase* db, const AMDbObje
 			QString auxTableName = info.tableName % "_" % info.columns.at(i);
 			// Ok, let's try this way.  This will simply fail if the auxiliary table doesn't exist...
 			q.prepare("SELECT COUNT(1) FROM " % auxTableName % " WHERE 1=0;");	// as high-performance of a query as we can make on that table
-			if(!AMDatabase::execQuery(q)) {
+			if(!db->execQuery(q)) {
 				return true;
 			}
 		}
@@ -595,7 +595,7 @@ bool AMDbObjectSupport::upgradeDatabaseForClass(AMDatabase* db, const AMDbObject
 	QSet<QString> existingColumns;
 	QSqlQuery q = db->query();
 	q.prepare("SELECT columnName FROM " % allColumnsTableName() % " WHERE typeId = '" % QString::number(typeIdInDatabase) % "';");
-	if(!AMDatabase::execQuery(q)) {
+	if(!db->execQuery(q)) {
 		AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, AMDBOBJECTSUPPORT_ERROR_WHILE_ATTEMPTING_UPGRADE, QString("Database support: There was an error while trying to upgrade class '%1' in the database.").arg(info.className)));
 		return false;
 	}
@@ -625,7 +625,7 @@ bool AMDbObjectSupport::upgradeDatabaseForClass(AMDatabase* db, const AMDbObject
 			QString auxTableName = info.tableName % "_" % info.columns.at(i);
 			// Does the table exist?
 			q.prepare("SELECT COUNT(1) FROM " % auxTableName % " WHERE 1=0;");	// as high-performance of a query as we can make on that table
-			if(!AMDatabase::execQuery(q)) {	// fails if table doesn't exist.
+			if(!db->execQuery(q)) {	// fails if table doesn't exist.
 				q.finish();
 				// therefore, we need to create the table:
 				if( !db->ensureTable(auxTableName,
@@ -676,7 +676,7 @@ bool AMDbObjectSupport::upgradeDatabaseForClass(AMDatabase* db, const AMDbObject
 					q.prepare(QString("UPDATE %1 SET %2 = ?;").arg(info.tableName).arg(info.columns.at(i)));
 					q.bindValue(0, QVariant(defaultValue));
 
-					if(!AMDatabase::execQuery(q)) {
+					if(!db->execQuery(q)) {
 						q.finish();
 						AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, AMDBOBJECTSUPPORT_CANNOT_INSERT_DEFAULT_VALUE_FOR_UPGRADE, QString("AMDbObjectSupport: Could not insert default value '%1' for column '%2'").arg(defaultValue).arg(info.columns.at(i))));
 					}

--- a/source/dataman/database/AMDbUpgrade.cpp
+++ b/source/dataman/database/AMDbUpgrade.cpp
@@ -78,7 +78,7 @@ bool AMDbUpgrade::upgradeRequired() const{
 	// Check to make sure each has the upgrade table using the PRAGMA query
 	QSqlQuery q = databaseToUpgrade_->query();
 	q.prepare("PRAGMA table_info(AMDbObjectUpgrades_table)");
-	if(!AMDatabase::execQuery(q)) {
+	if(!databaseToUpgrade_->execQuery(q)) {
 		q.finish();
 		AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -270103, QString("Database support: There was an error while trying to read meta data on the upgrades table.")));
 		return false;
@@ -223,7 +223,7 @@ bool AMDbUpgradeSupport::dbObjectClassBecomes(AMDatabase *databaseToEdit, const 
 				// Query if this table has an index (or indices) defined for it
 				QSqlQuery q1 = userDb->query();
 				q1.prepare("PRAGMA index_list("%originalIndexTableName%")");
-				if(!AMDatabase::execQuery(q1)) {
+				if(!userDb->execQuery(q1)) {
 					q1.finish();
 					AMErrorMon::report(AMErrorReport(0, AMErrorReport::Alert, -291, QString("Database support: There was an error trying to find the index list for %1.").arg(originalIndexTableName)));
 					return false;
@@ -240,7 +240,7 @@ bool AMDbUpgradeSupport::dbObjectClassBecomes(AMDatabase *databaseToEdit, const 
 					QSqlQuery q1A = userDb->query();
 					q1A.prepare(QString("DROP INDEX %1;").arg(indexListResponses.at(x)));
 
-					if(AMDatabase::execQuery(q1A)){
+					if(userDb->execQuery(q1A)){
 						q1A.finish();
 					}
 					else{
@@ -253,7 +253,7 @@ bool AMDbUpgradeSupport::dbObjectClassBecomes(AMDatabase *databaseToEdit, const 
 				// Actually rename the table (we need to do this every time)
 				QSqlQuery q2 = userDb->query();
 				q2.prepare("ALTER table "%originalIndexTableName%" RENAME to "%newIndexTableName);
-				if(!AMDatabase::execQuery(q2)) {
+				if(!userDb->execQuery(q2)) {
 					q2.finish();
 					AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -283, QString("Database support: There was an error while trying to update table %1 to become %2.").arg(originalIndexTableName).arg(newIndexTableName)));
 					return false;
@@ -268,7 +268,7 @@ bool AMDbUpgradeSupport::dbObjectClassBecomes(AMDatabase *databaseToEdit, const 
 					indexName.remove(QRegExp("[\\s\\,\\;]"));// remove whitespace, commas, and semicolons from index name...
 					q2A.prepare(QString("CREATE INDEX %1 ON %2(%3);").arg(indexName, newIndexTableName, columnName));
 
-					if(AMDatabase::execQuery(q2A)){
+					if(userDb->execQuery(q2A)){
 						q2A.finish();
 					}
 					else{
@@ -291,7 +291,7 @@ bool AMDbUpgradeSupport::dbObjectClassBecomes(AMDatabase *databaseToEdit, const 
 		// Finally, rename the table from the original name to the new name
 		QSqlQuery q = userDb->query();
 		q.prepare("ALTER table "%originalTableName%" RENAME to "%newTableName);
-		if(!AMDatabase::execQuery(q)) {
+		if(!userDb->execQuery(q)) {
 			q.finish();
 			AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -273, QString("Database support: There was an error while trying to update table %1 to become %2.").arg(originalClassName).arg(newClassName)));
 			return false;
@@ -324,7 +324,7 @@ bool AMDbUpgradeSupport::dbObjectClassMerge(AMDatabase *databaseToEdit, const QS
 	// Query and record all the column names (except id) from the from table. We need this string list to pass around.
 	QSqlQuery q = userDb->query();
 	q.prepare("PRAGMA table_info("%mergeFromTableName%")");
-	if(!AMDatabase::execQuery(q)) {
+	if(!userDb->execQuery(q)) {
 		q.finish();
 		AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -274, QString("Database support: There was an error while trying to read meta data on table %1.").arg(mergeFromTableName)));
 		return false;
@@ -410,7 +410,7 @@ bool AMDbUpgradeSupport::dbObjectClassMerge(AMDatabase *databaseToEdit, const QS
 	// Actually delete the "from" side class table.
 	q = userDb->query();
 	q.prepare("DROP TABLE "%mergeFromTableName);
-	if(!AMDatabase::execQuery(q)) {
+	if(!userDb->execQuery(q)) {
 		q.finish();
 		AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -280, QString("Database support: There was an error while trying to rollback table %1.").arg(mergeFromTableName)));
 		return false;

--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorView.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorView.cpp
@@ -90,7 +90,7 @@ void IDEASXRFDetailedDetectorView::buildScanSaveViews()
 void IDEASXRFDetailedDetectorView::onSaveScanButtonClicked()
 {
 	if(!chooseScanDialog_) {
-		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", true, this);
+		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", this);
 		chooseScanDialog_->setAttribute(Qt::WA_DeleteOnClose, false);
 		connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(exportScan()));
 	}
@@ -182,18 +182,18 @@ void IDEASXRFDetailedDetectorView::onPeakingTimeBoxChanged(const QString &arg1)
 
 	if (arg1 == "High Rate / Low Res")
 	{
-	    IDEASBeamline::ideas()->ketekPeakingTime()->move(0.300);
-	    IDEASBeamline::ideas()->ketekPreampGain()->move(1.2600);
+		IDEASBeamline::ideas()->ketekPeakingTime()->move(0.300);
+		IDEASBeamline::ideas()->ketekPreampGain()->move(1.2600);
 	}
 	else if (arg1 == "High Res / Low Rate")
 	{
-	    IDEASBeamline::ideas()->ketekPeakingTime()->move(2.00);
-	    IDEASBeamline::ideas()->ketekPreampGain()->move(1.2375);
+		IDEASBeamline::ideas()->ketekPeakingTime()->move(2.00);
+		IDEASBeamline::ideas()->ketekPreampGain()->move(1.2375);
 	}
 	else if (arg1 == "Ultra Res / Slow Rate")
 	{
-	    IDEASBeamline::ideas()->ketekPeakingTime()->move(4.00);
-	    IDEASBeamline::ideas()->ketekPreampGain()->move(1.2375);
+		IDEASBeamline::ideas()->ketekPeakingTime()->move(4.00);
+		IDEASBeamline::ideas()->ketekPreampGain()->move(1.2375);
 
 	}
 }
@@ -201,19 +201,19 @@ void IDEASXRFDetailedDetectorView::onPeakingTimeBoxChanged(const QString &arg1)
 void IDEASXRFDetailedDetectorView::onKETEKPeakingTimeChanged()
 {
 
-    // HACK ugly hard coded magic numbers...   Works for now.
-    peakingTimeBox->blockSignals(true);
+	// HACK ugly hard coded magic numbers...   Works for now.
+	peakingTimeBox->blockSignals(true);
 
-    if (IDEASBeamline::ideas()->ketekPeakingTime()->value() == 0.3)
+	if (IDEASBeamline::ideas()->ketekPeakingTime()->value() == 0.3)
 	peakingTimeBox->setCurrentIndex(1);
-    else if (IDEASBeamline::ideas()->ketekPeakingTime()->value() == 2.0)
+	else if (IDEASBeamline::ideas()->ketekPeakingTime()->value() == 2.0)
 	peakingTimeBox->setCurrentIndex(2);
-    else if (IDEASBeamline::ideas()->ketekPeakingTime()->value() == 4.0)
+	else if (IDEASBeamline::ideas()->ketekPeakingTime()->value() == 4.0)
 	peakingTimeBox->setCurrentIndex(3);
-    else
+	else
 	peakingTimeBox->setCurrentIndex(0);
 
-    peakingTimeBox->blockSignals(false);
+	peakingTimeBox->blockSignals(false);
 
 }
 

--- a/source/ui/REIXS/REIXSRIXSScanConfigurationView.cpp
+++ b/source/ui/REIXS/REIXSRIXSScanConfigurationView.cpp
@@ -291,7 +291,7 @@ REIXSRIXSScanConfigurationView::~REIXSRIXSScanConfigurationView()
 void REIXSRIXSScanConfigurationView::onloadXASDataClicked()
 {
 	if(!chooseScanDialog_) {
-		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Open an existing scan", "Choose existing XAS scan to open.", false, this);
+		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Open an existing scan", "Choose existing XAS scan to open.", this);
 		connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(onloadXASDataChosen()));
 	}
 	chooseScanDialog_->show();

--- a/source/ui/SXRMB/SXRMBXRFDetailedDetectorView.cpp
+++ b/source/ui/SXRMB/SXRMBXRFDetailedDetectorView.cpp
@@ -35,7 +35,7 @@ void SXRMBXRFDetailedDetectorView::onSaveButtonClicked()
 {
 
 	if(!chooseScanDialog_) {
-		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", true, this);
+		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", this);
 		chooseScanDialog_->setAttribute(Qt::WA_DeleteOnClose, false);
 		connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(exportScan()));
 	}

--- a/source/ui/VESPERS/VESPERSXRFDetailedDetectorView.cpp
+++ b/source/ui/VESPERS/VESPERSXRFDetailedDetectorView.cpp
@@ -30,7 +30,7 @@ void VESPERSXRFDetailedDetectorView::onSaveButtonClicked()
 {
 	if(!chooseScanDialog_) {
 
-		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", true, this);
+		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", this);
 		chooseScanDialog_->setAttribute(Qt::WA_DeleteOnClose, false);
 		connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(exportScan()));
 	}

--- a/source/ui/dataman/AM2DScanConfigurationGeneralView.cpp
+++ b/source/ui/dataman/AM2DScanConfigurationGeneralView.cpp
@@ -39,7 +39,7 @@ void AM2DScanConfigurationGeneralView::createView(const QString &databaseName, c
 	if(database){
 		QSqlQuery q = database->query();
 		q.prepare("PRAGMA table_info("%tableName%")");
-		if(!AMDatabase::execQuery(q)) {
+		if(!database->execQuery(q)) {
 			q.finish();
 			AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -275002, QString("2D Scan Configuration Generl View: There was an error while trying to read meta data on table %1.").arg(tableName)));
 		}
@@ -105,7 +105,7 @@ bool AM2DScanConfigurationGeneralView::canView(const QString &databaseName, cons
 	if(database){
 		QSqlQuery q = database->query();
 		q.prepare("PRAGMA table_info("%tableName%")");
-		if(!AMDatabase::execQuery(q)) {
+		if(!database->execQuery(q)) {
 			q.finish();
 			AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -275003, QString("2D Scan Configuration Generl View: There was an error while trying to read meta data on table %1.").arg(tableName)));
 		}

--- a/source/ui/dataman/AMChooseScanDialog.h
+++ b/source/ui/dataman/AMChooseScanDialog.h
@@ -30,6 +30,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QHBoxLayout>
 #include <QMenu>
 #include <QLabel>
+#include <QStackedWidget>
 
 class AMDatabase;
 class AMLightweightScanInfoModel;
@@ -50,8 +51,11 @@ public:
 	  \param multipleSelectionsAllowed Set this true if multiple selections are ok; otherwise, enforces choosing a single scan
 	  \param parent Parent widget for this QDialog
 	  */
+	AMChooseScanDialog(AMDatabase* db, const QString& title, const QString& prompt, QWidget *parent = 0);
+	/// Constructs a dialog box with a list of databases to choose from.
+	AMChooseScanDialog(QList<AMDatabase *> databases, const QString &title, const QString &prompt, QWidget *parent = 0);
+	/// Virtual destructor.
 	virtual ~AMChooseScanDialog();
-	AMChooseScanDialog(AMDatabase* db, const QString& title, const QString& prompt, bool multipleSelectionAllowed = false, QWidget *parent = 0);
 
 	/// Access a list of the selected scans.  They are provided as amd (AcquaMan Database) URLs, in the format amd://databaseConnectionName/tableName/id.  (This is the same format we use throughout the Acquaman framework for drag-and-drop, specifying scans to open in scan editors, etc.)
 	QList<QUrl> getSelectedScans() const;
@@ -73,11 +77,14 @@ protected slots:
 	/// Called when someone double-clicks in the AMDataView.  If anything is selected, this should register as an OK.
 	void onDoubleClick();
 	/// Called when context menu is requested by the tableView_
-	void onContextMenuRequested(const QPoint&menuPosition);
+	void onContextMenuRequested(const QPoint &menuPosition);
 
 protected:
+	/// Method that builds the view.
+	void buildView(const QList<AMDatabase *> &databases, const QString& title, const QString& prompt);
+
+	QStackedWidget *allBrowseScansViews_;
 	QButtonGroup* dialogButtons_;
-	AMBrowseScansView* browseScansView_;
 	QMenu* contextMenu_;
 	QLabel* promptLabel_;
 };

--- a/source/ui/dataman/AMDbObjectGeneralView.cpp
+++ b/source/ui/dataman/AMDbObjectGeneralView.cpp
@@ -45,7 +45,7 @@ void AMDbObjectGeneralView::createView(const QString &databaseName, const QStrin
 	if(database){
 		QSqlQuery q = database->query();
 		q.prepare("PRAGMA table_info("%tableName%")");
-		if(!AMDatabase::execQuery(q)) {
+		if(!database->execQuery(q)) {
 			q.finish();
 			AMErrorMon::report(AMErrorReport(0, AMErrorReport::Debug, -275001, QString("General Object View: There was an error while trying to read meta data on table %1.").arg(tableName)));
 		}

--- a/source/ui/dataman/AMGenericScanEditor.cpp
+++ b/source/ui/dataman/AMGenericScanEditor.cpp
@@ -342,7 +342,9 @@ void AMGenericScanEditor::addScan(AMScan* newScan) {
 
 	connect(newScan, SIGNAL(nameChanged(QString)), this, SLOT(onScanDetailsChanged()));
 	connect(newScan, SIGNAL(numberChanged(int)), this, SLOT(onScanDetailsChanged()));
-	connect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
+
+	if (newScan->scanConfiguration())
+		connect(newScan->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
 
 
 	emit scanAdded(this, newScan);
@@ -393,8 +395,9 @@ void AMGenericScanEditor::onCurrentChanged ( const QModelIndex & selected, const
 		disconnect(currentScan_, SIGNAL(numberChanged(int)), this, SLOT(refreshWindowTitle()));
 		disconnect(currentScan_, SIGNAL(nameChanged(QString)), this, SLOT(refreshWindowTitle()));
 		disconnect(currentScan_, SIGNAL(scanInitialConditionsChanged()), this, SLOT(refreshScanConditions()));
-		disconnect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
 
+		if (currentScan_->scanConfiguration())
+			disconnect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
 	}
 
 	// it becomes now the new scan:
@@ -415,7 +418,9 @@ void AMGenericScanEditor::onCurrentChanged ( const QModelIndex & selected, const
 		connect(currentScan_, SIGNAL(numberChanged(int)), this, SLOT(refreshWindowTitle()));
 		connect(currentScan_, SIGNAL(nameChanged(QString)), this, SLOT(refreshWindowTitle()));
 		connect(currentScan_, SIGNAL(scanInitialConditionsChanged()), this, SLOT(refreshScanConditions()));
-		connect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
+
+		if (currentScan_->scanConfiguration())
+			connect(currentScan_->scanConfiguration(), SIGNAL(configurationChanged()), this, SLOT(refreshScanInfo()));
 
 
 		// \todo When migrating to multiple scan selection, this will need to be changed:
@@ -1226,4 +1231,9 @@ void AMGenericScanEditor::setupUi()
 	notesEdit_->setPlainText(QString());
 
 	setLayout(verticalLayout3_);
+}
+
+void AMGenericScanEditor::refreshScanInfo()
+{
+	updateEditor(currentScan_);
 }

--- a/source/ui/dataman/AMGenericScanEditor.h
+++ b/source/ui/dataman/AMGenericScanEditor.h
@@ -180,6 +180,8 @@ protected slots:
 
 	/// Called when the open scan dialog is accepted with one or more new scans to open.
 	void onChooseScanDialogAccepted();
+	/// Called when the open scan dialog is rejected.
+	void onChooseScanDialogRejected();
 
 
 	/// Call this function to open a set of scans from the database. The scan information is contained inside a list of "amd://..." URLs.  For more information on the format, see dropEvent().   Returns true if the list contains at least one valid scan that was added.

--- a/source/ui/dataman/AMGenericScanEditor.h
+++ b/source/ui/dataman/AMGenericScanEditor.h
@@ -154,7 +154,7 @@ public slots:
 	void refreshWindowTitle();
 
 	/// This helper function refreshes the editor widgets with the values from the current scan
-	void refreshScanInfo(){updateEditor(currentScan_); qDebug()<<"refreshScanInfo() called with" << currentScan_;}
+	void refreshScanInfo();
 
 
 protected slots:

--- a/source/ui/dataman/AMRunExperimentInsert.cpp
+++ b/source/ui/dataman/AMRunExperimentInsert.cpp
@@ -39,22 +39,31 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 AMRunExperimentInsert::AMRunExperimentInsert(AMDatabase* db, QStandardItem* runParent, QStandardItem* experimentParent, QObject *parent) :
 	QObject(parent)
 {
+	experimentItem_ = 0;
+	runItem_ = 0;
 
 	db_ = db;
-
-	newExperimentId_ = -1;
-
-	experimentItem_ = experimentParent;
-	experimentItem_->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-	runItem_ =  runParent;
-	runItem_->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
 	connect(db_, SIGNAL(created(QString,int)), this, SLOT(onDatabaseObjectCreated(QString,int)));
 	connect(db_, SIGNAL(updated(QString,int)), this, SLOT(onDatabaseUpdated(QString,int)));
 	connect(db_, SIGNAL(removed(QString,int)), this, SLOT(onDatabaseUpdated(QString,int)));
 
-	refreshRuns();
-	refreshExperiments();
+	if (experimentParent){
+
+		newExperimentId_ = -1;
+
+		experimentItem_ = experimentParent;
+		experimentItem_->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+		refreshExperiments();
+	}
+
+	if (runParent){
+
+		runItem_ =  runParent;
+		runItem_->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+		refreshRuns();
+	}
+
 }
 
 /// This slot receives updated() signals from the database, and (if a refresh hasn't been scheduled yet), schedules a refresh() for once control returns to the Qt event loop.  This provides a performance boost by potentially only doing one refresh() for multiple sequential database updates.
@@ -62,14 +71,12 @@ void AMRunExperimentInsert::onDatabaseUpdated(const QString& table, int id) {
 
 	Q_UNUSED(id)
 
-	//if(table == "AMRun_table" && !runRefreshScheduled_) {
-	if(table == AMDbObjectSupport::s()->tableNameForClass<AMRun>() && !runRefreshScheduled_) {
+	if (runItem_ && table == AMDbObjectSupport::s()->tableNameForClass<AMRun>() && !runRefreshScheduled_) {
 		runRefreshScheduled_ = true;
 		QTimer::singleShot(0, this, SLOT(refreshRuns()));
 	}
 
-	//if(table == "AMExperiment_table" && !expRefreshScheduled_) {
-	if(table == AMDbObjectSupport::s()->tableNameForClass<AMExperiment>() && !expRefreshScheduled_) {
+	if(experimentItem_ && table == AMDbObjectSupport::s()->tableNameForClass<AMExperiment>() && !expRefreshScheduled_) {
 		expRefreshScheduled_ = true;
 		QTimer::singleShot(0, this, SLOT(refreshExperiments()));
 	}


### PR DESCRIPTION
This allows the opening of other databases inside of an instance of a running application. It also contains a large amount of small changes to AMDatabase and AMDbObject to facilitate general database access and tweaking some classes to introduce a read-only database loading.

@davidChevrier and @iainworkman, could both of you go through this pull request since it has a very large amount of database tweaks?

List of major changes:
- Added another means of using the read-only flag in AMDatabase.
- Removed the static keyword from execQuery().  This required the modification of some const functions.
- Added the ability to load databases inside of AMDatamanAppController.
- Changed AMDatabase and AMDbObject to not save changes to databases opened in read-only mode.
- Fixed a bug in AMLightweightScanInfo where it was calling the user database even though it had a valid database pointer.
- Modified the loadData() method in AMScan to reflect the database it is being loaded from rather than using the AMUserSettings::userDataFolder.
- Added a shutdown method to AMDatamanAppControllerForActions3 to delete the actions and scanActions database.
- Some general code cleanup I saw along the way.