### PR TITLE
Pull Request for Issue1517: Generic scan config view not showing correct start and end values

### DIFF
--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
@@ -106,8 +106,15 @@ AMGenericStepScanConfigurationView::AMGenericStepScanConfigurationView(AMGeneric
 
 	positionsBox->setLayout(positionLayout);
 
-	onAxisControlChoice1Changed();
-	onAxisControlChoice2Changed();
+	// Set initial spinbox values in cases where we don't yet have axes:
+	if(configuration_->scanAxes().count() == 0) {
+		// Set defaults for axis 1 and 2
+		onAxisControlChoice1Changed();
+		onAxisControlChoice2Changed();
+	} else if(configuration_->scanAxes().count() == 1) {
+		// Set defaults just for axis 2
+		onAxisControlChoice2Changed();
+	}
 
 	QScrollArea *detectorScrollArea = new QScrollArea;
 	QGroupBox *detectorGroupBox = new QGroupBox("Detectors");


### PR DESCRIPTION
Added a check in the constructor of AMGenericStepScanConfigurationView which checks if a valid value already exists for each axis, and only sets defaults if they don't

Estimate: 1