### PR TITLE
Pull Request for Issue 1531: MotorGroup not initializing correctly for unconnected controls

### DIFF
--- a/source/beamline/AMMotorGroup.cpp
+++ b/source/beamline/AMMotorGroup.cpp
@@ -254,20 +254,20 @@ bool AMMotorGroupAxis::canRotate() const
 
 AMControl * AMMotorGroupAxis::translationMotor() const
 {
-	if(!canTranslate()) {
+	if(translationalMotion_) {
+		return translationalMotion_->motor();
+	} else {
 		return 0;
 	}
-
-	return translationalMotion_->motor();
 }
 
 AMControl * AMMotorGroupAxis::rotationMotor() const
 {
-	if(!canRotate()) {
+	if(rotationalMotion_) {
+		return rotationalMotion_->motor();
+	} else {
 		return 0;
 	}
-
-	return rotationalMotion_->motor();
 }
 
 AMAction3 * AMMotorGroupAxis::createTranslateMoveAction(double position)

--- a/source/beamline/AMMotorGroup.cpp
+++ b/source/beamline/AMMotorGroup.cpp
@@ -164,7 +164,7 @@ double AMMotorGroupAxis::currentRotationPosition() const
 QString AMMotorGroupAxis::translationPositionUnits() const
 {
 	if(translationalMotion_ && translationalMotion_->motor()) {
-		return translationalMotion_->motor()->units();
+		return translationalMotion_->positionUnits();
 	} else {
 		return QString();
 	}
@@ -173,7 +173,7 @@ QString AMMotorGroupAxis::translationPositionUnits() const
 QString AMMotorGroupAxis::rotationPositionUnits() const
 {
 	if(rotationalMotion_ && rotationalMotion_->motor()) {
-		return rotationalMotion_->motor()->units();
+		return rotationalMotion_->positionUnits();
 	} else {
 		return QString();
 	}

--- a/source/ui/AMMotorGroupView.cpp
+++ b/source/ui/AMMotorGroupView.cpp
@@ -581,7 +581,7 @@ void AMMotorGroupObjectView::setupData()
 	jogSize_->setDecimals(3);
 	jogSize_->setFixedWidth(110);
 
-	bool canMoveGrouping = motorGroupObject_->hasHorizontalAxis() && motorGroupObject_->horizontalAxis()->canRotate();
+	bool canMoveGrouping = motorGroupObject_->hasHorizontalAxis() && motorGroupObject_->horizontalAxis()->rotationMotor();
 	horizontalRotationIncrement_->setVisible(canMoveGrouping);
 	horizontalRotationDecrement_->setVisible(canMoveGrouping);
 	horizontalRotationValue_->setVisible(canMoveGrouping);
@@ -594,7 +594,7 @@ void AMMotorGroupObjectView::setupData()
 
 	}
 
-	canMoveGrouping = motorGroupObject_->hasHorizontalAxis() && motorGroupObject_->horizontalAxis()->canTranslate();
+	canMoveGrouping = motorGroupObject_->hasHorizontalAxis() && motorGroupObject_->horizontalAxis()->translationMotor();
 	horizontalTranslationIncrement_->setVisible(canMoveGrouping);
 	horizontalTranslationDecrement_->setVisible(canMoveGrouping);
 	horizontalTranslationValue_->setVisible(canMoveGrouping);
@@ -606,7 +606,7 @@ void AMMotorGroupObjectView::setupData()
 		horizontalTranslationLabel_->setText(motorGroupObject_->horizontalAxis()->translationName());
 	}
 
-	canMoveGrouping = motorGroupObject_->hasVerticalAxis() && motorGroupObject_->verticalAxis()->canRotate();
+	canMoveGrouping = motorGroupObject_->hasVerticalAxis() && motorGroupObject_->verticalAxis()->rotationMotor();
 	verticalRotationIncrement_->setVisible(canMoveGrouping);
 	verticalRotationDecrement_->setVisible(canMoveGrouping);
 	verticalRotationValue_->setVisible(canMoveGrouping);
@@ -618,7 +618,7 @@ void AMMotorGroupObjectView::setupData()
 		verticalRotationLabel_->setText(motorGroupObject_->verticalAxis()->rotationName());
 	}
 
-	canMoveGrouping = motorGroupObject_->hasVerticalAxis() && motorGroupObject_->verticalAxis()->canTranslate();
+	canMoveGrouping = motorGroupObject_->hasVerticalAxis() && motorGroupObject_->verticalAxis()->translationMotor();
 	verticalTranslationIncrement_->setVisible(canMoveGrouping);
 	verticalTranslationDecrement_->setVisible(canMoveGrouping);
 	verticalTranslationValue_->setVisible(canMoveGrouping);
@@ -630,7 +630,7 @@ void AMMotorGroupObjectView::setupData()
 		verticalTranslationLabel_->setText(motorGroupObject_->verticalAxis()->translationName());
 	}
 
-	canMoveGrouping = motorGroupObject_->hasNormalAxis() && motorGroupObject_->normalAxis()->canRotate();
+	canMoveGrouping = motorGroupObject_->hasNormalAxis() && motorGroupObject_->normalAxis()->rotationMotor();
 	normalRotationIncrement_->setVisible(canMoveGrouping);
 	normalRotationDecrement_->setVisible(canMoveGrouping);
 	normalRotationValue_->setVisible(canMoveGrouping);
@@ -642,7 +642,7 @@ void AMMotorGroupObjectView::setupData()
 		normalRotationLabel_->setText(motorGroupObject_->normalAxis()->rotationName());
 	}
 
-	canMoveGrouping = motorGroupObject_->hasNormalAxis() && motorGroupObject_->normalAxis()->canTranslate();
+	canMoveGrouping = motorGroupObject_->hasNormalAxis() && motorGroupObject_->normalAxis()->translationMotor();
 	normalTranslationIncrement_->setVisible(canMoveGrouping);
 	normalTranslationDecrement_->setVisible(canMoveGrouping);
 	normalTranslationValue_->setVisible(canMoveGrouping);


### PR DESCRIPTION
Fixed the getters to return references to the motor even if it wasn't connected yet, and fixed some issues with the manually set position units not being obtained correctly.

Made the motor group view show the controls that weren't yet connected.

Estimate: 2