### PR TITLE
Pull Request for Issue1435DbUpgrade

### DIFF
--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -140,23 +140,3 @@ SOURCES += \
     source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp \
     source/ui/BioXAS/BioXASXASScanConfigurationView.cpp \
     source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -71,7 +71,8 @@ HEADERS += \
     source/ui/BioXAS/BioXASXASScanConfigurationEnergyEditor.h \
     source/ui/BioXAS/BioXASXASScanConfigurationEdgeEditor.h \
     source/ui/BioXAS/BioXASXASScanConfigurationEditor.h \
-    source/ui/BioXAS/BioXASXASScanConfigurationView.h
+    source/ui/BioXAS/BioXASXASScanConfigurationView.h \
+    source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
 
 SOURCES += \
 	source/acquaman/BioXAS/BioXASXRFScanConfiguration.cpp \
@@ -137,7 +138,10 @@ SOURCES += \
     source/ui/BioXAS/BioXASXASScanConfigurationEnergyEditor.cpp \
     source/ui/BioXAS/BioXASXASScanConfigurationEdgeEditor.cpp \
     source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp \
-    source/ui/BioXAS/BioXASXASScanConfigurationView.cpp
+    source/ui/BioXAS/BioXASXASScanConfigurationView.cpp \
+    source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+
+
 
 
 

--- a/compositeCommon/AMCommon.pri
+++ b/compositeCommon/AMCommon.pri
@@ -11,6 +11,7 @@ macx {
 
 	contains(USERNAME, helfrij){
 		CONFIG -= mobility
+		CONFIG -= app_bundle
 	}
 
 	QMAKE_CXXFLAGS_X86_64 *= "-mmacosx-version-min=10.7"

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -3,6 +3,8 @@
 #include "beamline/BioXAS/BioXASBeamline.h"
 #include "beamline/CLS/CLSStorageRing.h"
 
+#include "dataman/BioXAS/BioXASDbUpgrade1Pt1.h"
+
 #include <QDebug>
 
 BioXASAppController::BioXASAppController(QObject *parent) :
@@ -12,6 +14,11 @@ BioXASAppController::BioXASAppController(QObject *parent) :
 
 	userConfiguration_ = new BioXASUserConfiguration(this);
 	setDefaultUseLocalStorage(true);
+
+	// Database upgrades.
+
+	AMDbUpgrade *bioxas1pt1 = new BioXASDbUpgrade1Pt1("user", this);
+	appendDatabaseUpgrade(bioxas1pt1);
 
 	// Initialize member variables.
 

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -17,8 +17,10 @@ BioXASAppController::BioXASAppController(QObject *parent) :
 
 	// Database upgrades.
 
-	AMDbUpgrade *bioxas1pt1 = new BioXASDbUpgrade1Pt1("user", this);
-	appendDatabaseUpgrade(bioxas1pt1);
+	AMDbUpgrade *bioxas1pt1UserDb = new BioXASDbUpgrade1Pt1("user", this);
+	appendDatabaseUpgrade(bioxas1pt1UserDb);
+	AMDbUpgrade *bioxas1pt1ActionsDb = new BioXASDbUpgrade1Pt1("actions", this);
+	appendDatabaseUpgrade(bioxas1pt1ActionsDb);
 
 	// Initialize member variables.
 

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -434,7 +434,7 @@ AMScanConfigurationViewHolder3* BioXASAppController::createScanConfigurationView
 
 			AMGenericStepScanConfiguration *stepScanConfiguration = qobject_cast<AMGenericStepScanConfiguration*>(configuration);
 			if (stepScanConfiguration) {
-				connect( stepScanConfiguration, SIGNAL(totalTimeChanged()), view, SLOT(updateOverallScanTime(double)) );
+				connect( stepScanConfiguration, SIGNAL(totalTimeChanged(double)), view, SLOT(updateOverallScanTime(double)) );
 				view->updateOverallScanTime(stepScanConfiguration->totalTime());
 			}
 		}

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -181,7 +181,7 @@ void BioXASMainBeamline::setupComponents()
 	connect( endstationTable_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// Scaler
-	scaler_ = new CLSSIS3820Scaler("BL1607-5-I21:mcs", this);
+	scaler_ = new CLSSIS3820Scaler("MCS1607-701", this);
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
 	scalerDwellTime_ = new AMReadOnlyPVControl("ScalerDwellTime", "BL1607-5-I21:mcs:delay", this, "Scaler dwell time");

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -216,7 +216,7 @@ void BioXASSideBeamline::setupComponents()
 	cryostatStage_ = new BioXASSideCryostatStage(this);
 
 	// Scaler.
-	scaler_ = new CLSSIS3820Scaler("BL1607-5-I22:mcs", this);
+	scaler_ = new CLSSIS3820Scaler("MCS1607-601", this);
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
 	scalerDwellTime_ = new AMReadOnlyPVControl("ScalerDwellTime", "BL1607-5-I22:mcs:delay", this, "Scaler dwell time");

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -61,6 +61,8 @@ void IDEASBeamline::setupSampleStage()
 
 void IDEASBeamline::setupMotorGroup()
 {
+	motorGroup_ = new AMMotorGroup(this);
+
 	// Set up sample platform motor object:
 	AMMotorGroupObject* samplePlatformObject = new AMMotorGroupObject("Sample Platform", this);
 

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
@@ -34,7 +34,7 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 	// Remove usingXRFDetector column from BioXASScanConfigurationDbObject_table. It is no longer used.
 
 	if (databaseToUpgrade_->tableExists("BioXASScanConfigurationDbObject_table")) {
-		if (databaseToUpgrade_->columnExists("usingXRFDetector")) {
+		if (databaseToUpgrade_->columnExists("BioXASXASScanConfigurationDbObject_table", "usingXRFDetector")) {
 			if (!AMDbUpgradeSupport::removeColumn(databaseToUpgrade_, "BioXASScanConfigurationDbObject_table", "usingXRFDetector")) {
 				AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_REMOVE_COLUMN, "Could not remove the usingXRFDetector column from BioXASScanConfigurationDbObject_table.");
 				databaseToUpgrade_->rollbackTransaction();
@@ -94,7 +94,7 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 
 			if (newId == 0) {
 				databaseToUpgrade_->rollbackTransaction();
-				AMErrorMon::alert(this, BIOXASUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not populate BioXASXASScanConfiguration_table with old configurations from BioXASSideXASScanConfiguration_table.");
+				AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not populate BioXASXASScanConfiguration_table with old configurations from BioXASSideXASScanConfiguration_table.");
 				return false;
 			}
 		}
@@ -138,7 +138,7 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 
 			if (newId == 0) {
 				databaseToUpgrade_->rollbackTransaction();
-				AMErrorMon::alert(this, BIOXASUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not populate BioXASXASScanConfiguration_table with old configurations from BioXASMainXASScanConfiguration_table.");
+				AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not populate BioXASXASScanConfiguration_table with old configurations from BioXASMainXASScanConfiguration_table.");
 				return false;
 			}
 		}

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
@@ -48,10 +48,10 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 	// Create and populate BioXASXASScanConfiguration_table, if it doesn't already exist.
 
 	if (!databaseToUpgrade_->tableExists("BioXASXASScanConfiguration_table")) {
-		QStringList names = QStringList() << "AMDbObjectType" << "thumbnailCount" << "thumbnailFirstId" << "name" << "detectorConfigurations" << "axisControlInfos" << "configurationDbObject" << "header";
-		QStringList types = QStringList() << "TEXT" << "INTEGER" << "INTEGER" << "TEXT" << "TEXT" << "TEXT" << "TEXT" << "TEXT";
+		QStringList dbObjectNames = QStringList() << "AMDbObjectType" << "thumbnailCount" << "thumbnailFirstId" << "name" << "detectorConfigurations" << "axisControlInfos" << "configurationDbObject" << "header";
+		QStringList dbObjectTypes = QStringList() << "TEXT" << "INTEGER" << "INTEGER" << "TEXT" << "TEXT" << "TEXT" << "TEXT" << "TEXT";
 
-		if (!databaseToUpgrade_->ensureTable("BioXASXASScanConfiguration", names, types)) {
+		if (!AMDbUpgradeSupport::addTable(databaseToUpgrade_, "BioXASXASScanConfiguration", dbObjectNames, dbObjectTypes, true, "BioXAS XAS Scan Configuration", "BioXASXASScanConfiguration;AMGenericStepScanConfiguration;AMStepScanConfiguration;AMScanConfiguration;AMDbObject;QObject")) {
 			databaseToUpgrade_->rollbackTransaction();
 			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE, "Could not create BioXASXASScanConfiguration_table.");
 			return false;
@@ -85,7 +85,7 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 															   << "configurationDbObject"
 															   << "header",
 															   QVariantList()
-															   << QVariant()
+															   << "BioXASXASScanConfiguration"
 															   << names.at(idIndex)
 															   << detectors.at(idIndex)
 															   << axisControls.at(idIndex)
@@ -143,42 +143,6 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 					return false;
 				}
 			}
-		}
-	}
-
-	// Add BioXASXASScanConfiguration_table to AMDbObjectTypes_table and associated tables, if appropriate entries do not already exist.
-
-	QVariantList objectTypes = databaseToUpgrade_->retrieve("AMDbObjectTypes_table", "AMDbObjectType");
-	if (!objectTypes.contains(QVariant("BioXASXASScanConfiguration"))) {
-
-		QStringList objectTypeNames = QStringList() << "AMDbObjectType" << "tableName" << "description" << "version" << "inheritance";
-		QVariantList objectTypeValues = QVariantList() << "BioXASXASScanConfiguration" << "BioXASXASScanConfiguration_table" << "BioXAS XAS Scan Configuration" << 1 << "BioXASXASScanConfiguration;AMGenericStepScanConfiguration;AMStepScanConfiguration;AMScanConfiguration;AMDbObject;QObject";
-
-		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_table", objectTypeNames, objectTypeValues)) {
-			databaseToUpgrade_->rollbackTransaction();
-			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_table.");
-			return false;
-		}
-
-		QStringList names = QStringList() << "AMDbObjectType" << "thumbnailCount" << "thumbnailFirstId" << "name" << "detectorConfigurations" << "axisControlInfos" << "configurationDbObject" << "header";
-		QStringList types = QStringList() << "TEXT" << "INTEGER" << "INTEGER" << "TEXT" << "TEXT" << "TEXT" << "TEXT" << "TEXT";
-
-		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_allColumns", names, types)) {
-			databaseToUpgrade_->rollbackTransaction();
-			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_allColumns.");
-			return false;
-		}
-
-		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_visibleColumns", names, types)) {
-			databaseToUpgrade_->rollbackTransaction();
-			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_visibleColumns.");
-			return false;
-		}
-
-		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_loadColumns", names, types)) {
-			databaseToUpgrade_->rollbackTransaction();
-			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_loadColumns.");
-			return false;
 		}
 	}
 

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
@@ -148,6 +148,8 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 
 	// Upgrade complete.
 
+	AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_UPGRADE_COMPLETED_SUCCESSFULLY, "Database upgrade completed successfully!");
+
 	databaseToUpgrade_->commitTransaction();
 
 	return true;

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
@@ -1,0 +1,202 @@
+#include "BioXASDbUpgrade1Pt1.h"
+#include "util/AMErrorMonitor.h"
+
+BioXASDbUpgrade1Pt1::BioXASDbUpgrade1Pt1(const QString &databaseNameToUpgrade, QObject *parent) :
+	AMDbUpgrade(databaseNameToUpgrade, parent)
+{
+
+}
+
+BioXASDbUpgrade1Pt1::~BioXASDbUpgrade1Pt1()
+{
+
+}
+
+QStringList BioXASDbUpgrade1Pt1::upgradeFromTags() const
+{
+	return QStringList();
+}
+
+bool BioXASDbUpgrade1Pt1::upgradeNecessary() const
+{
+	bool usingXRFDetector = databaseToUpgrade_->tableExists("BioXASScanConfigurationDbObject_table") && databaseToUpgrade_->columnExists("BioXASScanConfigurationDbObject_table", "usingXRFDetector");
+	bool sideConfiguration = !databaseToUpgrade_->tableExists("BioXASXASScanConfiguration_table") && databaseToUpgrade_->tableExists("BioXASSideXASScanConfiguration_table");
+	bool mainConfiguration = !databaseToUpgrade_->tableExists("BioXASXASScanConfiguration_table") && databaseToUpgrade_->tableExists("BioXASMainXASScanConfiguration_table");
+
+	bool upgradeNeeded = (usingXRFDetector || sideConfiguration || mainConfiguration);
+	return upgradeNeeded;
+}
+
+bool BioXASDbUpgrade1Pt1::upgradeImplementation()
+{
+	databaseToUpgrade_->startTransaction();
+
+	// Remove usingXRFDetector column from BioXASScanConfigurationDbObject_table. It is no longer used.
+
+	if (databaseToUpgrade_->tableExists("BioXASScanConfigurationDbObject_table")) {
+		if (databaseToUpgrade_->columnExists("usingXRFDetector")) {
+			if (!AMDbUpgradeSupport::removeColumn(databaseToUpgrade_, "BioXASScanConfigurationDbObject_table", "usingXRFDetector")) {
+				AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_REMOVE_COLUMN, "Could not remove the usingXRFDetector column from BioXASScanConfigurationDbObject_table.");
+				databaseToUpgrade_->rollbackTransaction();
+				return false;
+			}
+		}
+	}
+
+	// Create BioXASXASScanConfiguration_table, if it doesn't already exist.
+
+	if (!databaseToUpgrade_->tableExists("BioXASXASScanConfiguration_table")) {
+		QStringList names = QStringList() << "AMDbObjectType" << "thumbnailCount" << "thumbnailFirstId" << "name" << "detectorConfigurations" << "axisControlInfos" << "configurationDbObject" << "header";
+		QStringList types = QStringList() << "TEXT" << "INTEGER" << "INTEGER" << "TEXT" << "TEXT" << "TEXT" << "TEXT" << "TEXT";
+
+		if (!databaseToUpgrade_->ensureTable("BioXASXASScanConfiguration", names, types)) {
+			databaseToUpgrade_->rollbackTransaction();
+			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE, "Could not create BioXASXASScanConfiguration_table.");
+			return false;
+		}
+	}
+
+	// Populate BioXASXASScanConfiguration_table with items from BioXASSideXASScanConfiguration_table, if it exists.
+
+	if (databaseToUpgrade_->tableExists("BioXASSideXASScanConfiguration_table")) {
+
+		QVariantList ids = databaseToUpgrade_->retrieve("BioXASSideXASScanConfiguration_table", "id");
+		QVariantList names = databaseToUpgrade_->retrieve("BioXASSideXASScanConfiguration_table", "name");
+		QVariantList detectors = databaseToUpgrade_->retrieve("BioXASSideXASScanConfiguration_table", "detectorConfigurations");
+		QVariantList axisControls = databaseToUpgrade_->retrieve("BioXASSideXASScanConfiguration_table", "axisControlInfos");
+		QVariantList dbObjects = databaseToUpgrade_->retrieve("BioXASSideXASScanConfiguration_table", "configurationDbObject");
+		QVariantList headers = databaseToUpgrade_->retrieve("BioXASSideXASScanConfiguration_table", "header");
+
+		QList<int> updateIds;
+
+		foreach (QVariant id, ids) {
+			updateIds << id.toString().split(";").last().toInt();
+		}
+
+		foreach (int idIndex, updateIds) {
+
+			int newId = databaseToUpgrade_->insertOrUpdate(0, "BioXASXASScanConfiguration_table",
+														   QStringList()
+														   << "id"
+														   << "name"
+														   << "detectorConfigurations"
+														   << "axisControlInfos"
+														   << "configurationDbObject"
+														   << "header",
+														   QVariantList()
+														   << QVariant()
+														   << names.at(idIndex)
+														   << detectors.at(idIndex)
+														   << axisControls.at(idIndex)
+														   << dbObjects.at(idIndex)
+														   << headers.at(idIndex)
+														   );
+
+			if (newId == 0) {
+				databaseToUpgrade_->rollbackTransaction();
+				AMErrorMon::alert(this, BIOXASUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not populate BioXASXASScanConfiguration_table with old configurations from BioXASSideXASScanConfiguration_table.");
+				return false;
+			}
+		}
+	}
+
+	// Populate BioXASXASScanConfiguration_table with items from BioXASMainXASScanConfiguration_table, if it exists.
+
+	if (databaseToUpgrade_->tableExists("BioXASMainXASScanConfiguration_table")) {
+
+		QVariantList ids = databaseToUpgrade_->retrieve("BioXASMainXASScanConfiguration_table", "id");
+		QVariantList names = databaseToUpgrade_->retrieve("BioXASMainXASScanConfiguration_table", "name");
+		QVariantList detectors = databaseToUpgrade_->retrieve("BioXASMainXASScanConfiguration_table", "detectorConfigurations");
+		QVariantList axisControls = databaseToUpgrade_->retrieve("BioXASMainXASScanConfiguration_table", "axisControlInfos");
+		QVariantList dbObjects = databaseToUpgrade_->retrieve("BioXASMainXASScanConfiguration_table", "configurationDbObject");
+		QVariantList headers = databaseToUpgrade_->retrieve("BioXASMainXASScanConfiguration_table", "header");
+
+		QList<int> updateIds;
+
+		foreach (QVariant id, ids) {
+			updateIds << id.toString().split(";").last().toInt();
+		}
+
+		foreach (int idIndex, updateIds) {
+
+			int newId = databaseToUpgrade_->insertOrUpdate(0, "BioXASXASScanConfiguration_table",
+														   QStringList()
+														   << "id"
+														   << "name"
+														   << "detectorConfigurations"
+														   << "axisControlInfos"
+														   << "configurationDbObject"
+														   << "header",
+														   QVariantList()
+														   << "BioXASXASScanConfiguration"
+														   << names.at(idIndex)
+														   << detectors.at(idIndex)
+														   << axisControls.at(idIndex)
+														   << dbObjects.at(idIndex)
+														   << headers.at(idIndex)
+														   );
+
+			if (newId == 0) {
+				databaseToUpgrade_->rollbackTransaction();
+				AMErrorMon::alert(this, BIOXASUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not populate BioXASXASScanConfiguration_table with old configurations from BioXASMainXASScanConfiguration_table.");
+				return false;
+			}
+		}
+	}
+
+	// Add BioXASXASScanConfiguration_table to AMDbObjectTypes_table.
+
+	QVariantList objectTypes = databaseToUpgrade_->retrieve("AMDbObjectTypes_table", "AMDbObjectType");
+	if (!objectTypes.contains(QVariant("BioXASXASScanConfiguration"))) {
+
+		QStringList dboColumnNames = QStringList() << "AMDbObjectType" << "tableName" << "description" << "version" << "inheritance";
+		QVariantList dboValues = QVariantList() << "BioXASXASScanConfiguration" << "BioXASXASScanConfiguration_table" << "BioXAS XAS Scan Configuration" << 1 << "BioXASXASScanConfiguration;AMGenericStepScanConfiguration;AMStepScanConfiguration;AMScanConfiguration;AMDbObject;QObject";
+
+		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_table", dboColumnNames, dboValues)) {
+			databaseToUpgrade_->rollbackTransaction();
+			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_table.");
+			return false;
+		}
+
+		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_allColumns", dboColumnNames, dboValues)) {
+			databaseToUpgrade_->rollbackTransaction();
+			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_allColumns.");
+			return false;
+		}
+
+		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_visibleColumns", dboColumnNames, dboValues)) {
+			databaseToUpgrade_->rollbackTransaction();
+			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_visibleColumns.");
+			return false;
+		}
+
+		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_loadColumns", dboColumnNames, dboValues)) {
+			databaseToUpgrade_->rollbackTransaction();
+			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_loadColumns.");
+		}
+	}
+
+	databaseToUpgrade_->commitTransaction();
+
+	return true;
+}
+
+AMDbUpgrade* BioXASDbUpgrade1Pt1::createCopy() const
+{
+	AMDbUpgrade *copy = new BioXASDbUpgrade1Pt1(databaseNameToUpgrade());
+
+	if (databaseToUpgrade())
+		copy->loadDatabaseFromName();
+
+	return copy;
+}
+
+QString BioXASDbUpgrade1Pt1::upgradeToTag() const
+{
+	return "BioXASDbUpgrade1.1";
+}
+
+QString BioXASDbUpgrade1Pt1::description() const
+{
+	return "Upgrades database to account for new BioXASXASScanConfiguration, which functionally replaces existing BioXASSideXASScanConfiguration and BioXASMainXASScanConfiguration.";
+}

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
@@ -178,6 +178,7 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 		if (databaseToUpgrade_->insertOrUpdate(0, "AMDbObjectTypes_loadColumns", names, types)) {
 			databaseToUpgrade_->rollbackTransaction();
 			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, "Could not add BioXASXASScanConfiguration entry to AMDbObjectType_loadColumns.");
+			return false;
 		}
 	}
 

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.cpp
@@ -45,7 +45,7 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 		}
 	}
 
-	// Create and populate BioXASXASScanConfiguration_table, if it doesn't already exist.
+	// Create and populate BioXASXASScanConfiguration_table and BioXASXASScanConfiguration_table_scanAxes, if they doesn't already exist.
 
 	if (!databaseToUpgrade_->tableExists("BioXASXASScanConfiguration_table")) {
 		QStringList dbObjectNames = QStringList() << "AMDbObjectType" << "thumbnailCount" << "thumbnailFirstId" << "name" << "detectorConfigurations" << "axisControlInfos" << "configurationDbObject" << "header";
@@ -57,17 +57,36 @@ bool BioXASDbUpgrade1Pt1::upgradeImplementation()
 			return false;
 		}
 
+		QStringList scanAxesNames = QStringList() << "id1" << "table1" << "id2" << "table2";
+		QStringList scanAxesTypes = QStringList() << "INTEGER" << "TEXT" << "INTEGER" << "TEXT";
+
+		if (!databaseToUpgrade_->ensureTable("BioXASXASScanConfiguration_table_scanAxes", scanAxesNames, scanAxesTypes)) {
+			databaseToUpgrade_->rollbackTransaction();
+			AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE, "Could not create BioXASXASScanConfiguration_table_scanAxes.");
+			return false;
+		}
+
 		// Populate BioXASXASScanConfiguration_table with items from BioXASSideXASScanConfiguration_table, if it exists.
 
-		if (databaseToUpgrade_->tableExists("BioXASSideXASScanConfiguration_table"))
+		if (databaseToUpgrade_->tableExists("BioXASSideXASScanConfiguration_table")) {
+
 			if (!addConfigurationTableToXASTable("BioXASSideXASScanConfiguration_table"))
 				return false;
 
+			if (!addConfigurationAxesToXASAxesTable("BioXASSideXASScanConfiguration_table", "BioXASSideXASScanConfiguration_table_scanAxes"))
+				return false;
+		}
+
 		// Populate BioXASXASScanConfiguration_table with items from BioXASMainXASScanConfiguration_table, if it exists.
 
-		if (databaseToUpgrade_->tableExists("BioXASMainXASScanConfiguration_table"))
+		if (databaseToUpgrade_->tableExists("BioXASMainXASScanConfiguration_table")) {
+
 			if (!addConfigurationTableToXASTable("BioXASMainXASScanConfiguration_table"))
 				return false;
+
+			if (!addConfigurationAxesToXASAxesTable("BioXASMainXASScanConfiguration_table", "BioXASMainXASScanConfiguration_table_scanAxes"))
+				return false;
+		}
 	}
 
 	// Upgrade complete.
@@ -129,8 +148,7 @@ bool BioXASDbUpgrade1Pt1::addConfigurationTableToXASTable(const QString &configu
 	foreach (QVariant id, ids)
 		updateIds << id.toString().split(";").last().toInt();
 
-	// Add each configuration to BioXASXASScanConfiguration_table, and update corresponding entry in
-	// AMScan_table.
+	// Add each configuration to BioXASXASScanConfiguration_table, and update corresponding entry in AMScan_table.
 
 	for (int idIndex = 0, idIndexCount = updateIds.count(); idIndex < idIndexCount; idIndex++) {
 
@@ -204,7 +222,7 @@ bool BioXASDbUpgrade1Pt1::updateScanTable(int configurationID, const QString &co
 		QString entryTableName = entry.split(";").first();
 
 		if (entryTableName == configurationTableName) {
-			QString newEntry = "BioXASXASScanConfiguration;" + QString::number(configurationID);
+			QString newEntry = QString("BioXASXASScanConfiguration_table;%1").arg(configurationID);
 
 			if (!databaseToUpgrade_->update(updateIds.at(idIndex), "AMScan_table", "scanConfiguration", newEntry)) {
 				databaseToUpgrade_->rollbackTransaction();
@@ -219,6 +237,66 @@ bool BioXASDbUpgrade1Pt1::updateScanTable(int configurationID, const QString &co
 	if (!configurationFound) {
 		AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, QString("Could not update %1 entry in AMScan_table--entry could not be found.").arg(configurationTableName));
 	}
+
+	return true;
+}
+
+bool BioXASDbUpgrade1Pt1::addConfigurationAxesToXASAxesTable(const QString &configurationTableName, const QString &scanAxesTableName)
+{
+	if (!databaseToUpgrade_->tableExists("BioXASXASScanConfiguration_table_scanAxes")) {
+		databaseToUpgrade_->rollbackTransaction();
+		AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_TABLE_DOES_NOT_EXIST, QString("Could not populate BioXASXASScanConfiguration_table_scanAxes with entries from %1--BioXASXASScanConfiguration_table_scanAxes does not exist.").arg(configurationTableName));
+		return false;
+	}
+
+	if (!databaseToUpgrade_->tableExists(scanAxesTableName)) {
+		databaseToUpgrade_->rollbackTransaction();
+		AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_TABLE_DOES_NOT_EXIST, QString("Could not populate BioXASXASScanConfiguration_table_scanAxes with entries from %1--%1 does not exist.").arg(scanAxesTableName));
+		return false;
+	}
+
+	// Identify data from named scan axes table that will be transferred to BioXASXASScanConfiguration_table_scanAxes.
+
+	QVariantList ids = databaseToUpgrade_->retrieve(scanAxesTableName, "id");
+	QVariantList configurationIds = databaseToUpgrade_->retrieve(scanAxesTableName, "id1");
+	QVariantList configurations = databaseToUpgrade_->retrieve(scanAxesTableName, "table1");
+	QVariantList scanAxesIds = databaseToUpgrade_->retrieve(scanAxesTableName, "id2");
+	QVariantList scanAxes = databaseToUpgrade_->retrieve(scanAxesTableName, "table2");
+
+	QList<int> updateIds;
+
+	foreach (QVariant id, ids)
+		updateIds << id.toString().split(";").last().toInt();
+
+	// Iterate through all entries in the named scan axes table, copying over matches to the named configuration table.
+
+	for (int idIndex = 0, idIndexCount = ids.count(); idIndex < idIndexCount; idIndex++) {
+		QString entry = configurations.at(idIndex).toString();
+
+		if (entry == configurationTableName) {
+
+			int newID = databaseToUpgrade_->insertOrUpdate(0, "BioXASXASScanConfiguration_table_scanAxes",
+											   QStringList()
+											   << "id1"
+											   << "table1"
+											   << "id2"
+											   << "table2",
+											   QVariantList()
+											   << configurationIds.at(idIndex)
+											   << "BioXASXASScanConfiguration_table"
+											   << scanAxesIds.at(idIndex)
+											   << scanAxes.at(idIndex)
+											   );
+
+			if (newID == 0) {
+				databaseToUpgrade_->rollbackTransaction();
+				AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE, QString("Could not copy entries from %1 to BioXASXASScanConfiguration_table_scanAxes.").arg(scanAxesTableName));
+				return false;
+			}
+		}
+	}
+
+	AMErrorMon::alert(this, BIOXASDBUPGRADE1PT1_INSERT_OR_UPDATE_SUCCESSFUL, QString("Successfully copied entries from %1 to BioXASXASScanConfiguration_table_scanAxes!").arg(scanAxesTableName));
 
 	return true;
 }

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
@@ -6,6 +6,7 @@
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_REMOVE_COLUMN 234987
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE 234988
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE 234989
+#define BIOXASDBUPGRADE1PT1_UPGRADE_COMPLETED_SUCCESSFULLY 2348990
 
 /// Upgrades database to account for new BioXASXASScanConfiguration, which functionally replaces existing BioXASSideXASScanConfiguration and BioXASMainXASScanConfiguration.
 class BioXASDbUpgrade1Pt1 : public AMDbUpgrade
@@ -21,19 +22,19 @@ public:
 	/// Indicates the dependencies of this upgrade.
 	virtual QStringList upgradeFromTags() const;
 
-	/// Returns true. All modifications to the structure of the database needs to be done.
+	/// Returns true if this upgrade needs to be done.
 	virtual bool upgradeNecessary() const;
 
-	/// Makes all the necessary changes outlined in the class description.
+	/// Returns true if the upgrade is completed successfully, false otherwise. Contains the steps to complete the upgrade.
 	virtual bool upgradeImplementation();
 
-	/// Creates a new copy of this upgrade (caller is responsible for memory).
+	/// Creates a new copy of this upgrade.
 	virtual AMDbUpgrade *createCopy() const;
 
-	/// Returns the upgrade tag for this upgrade.
+	/// Returns the upgrade tag.
 	virtual QString upgradeToTag() const;
 
-	/// Returns the description of the upgrade.
+	/// Returns the description.
 	virtual QString description() const;
 
 };

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
@@ -1,0 +1,41 @@
+#ifndef BIOXASDBUPGRADE1PT1_H
+#define BIOXASDBUPGRADE1PT1_H
+
+#include "dataman/database/AMDbUpgrade.h"
+
+#define BIOXASDBUPGRADE1PT1_COULD_NOT_REMOVE_COLUMN 234987
+#define BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE 234988
+#define BIOXASUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE 234989
+
+/// Upgrades database to account for new BioXASXASScanConfiguration, which functionally replaces existing BioXASSideXASScanConfiguration and BioXASMainXASScanConfiguration.
+class BioXASDbUpgrade1Pt1 : public AMDbUpgrade
+{
+    Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit BioXASDbUpgrade1Pt1(const QString &databaseNameToUpgrade, QObject *parent = 0);
+	/// Destructor.
+	virtual ~BioXASDbUpgrade1Pt1();
+
+	/// Indicates the dependencies of this upgrade.
+	virtual QStringList upgradeFromTags() const;
+
+	/// Returns true. All modifications to the structure of the database needs to be done.
+	virtual bool upgradeNecessary() const;
+
+	/// Makes all the necessary changes outlined in the class description.
+	virtual bool upgradeImplementation();
+
+	/// Creates a new copy of this upgrade (caller is responsible for memory).
+	virtual AMDbUpgrade *createCopy() const;
+
+	/// Returns the upgrade tag for this upgrade.
+	virtual QString upgradeToTag() const;
+
+	/// Returns the description of the upgrade.
+	virtual QString description() const;
+
+};
+
+#endif // BIOXASDBUPGRADE1PT1_H

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
@@ -44,6 +44,9 @@ protected:
 	/// Returns true if successful, false otherwise. Iterates through entries in AMScan_table and updates scanConfiguration entries from the named configuration table to BioXASXASScanConfiguration_table.
 	bool updateScanTable(int configurationID, const QString &configurationTableName);
 
+	/// Returns true if successful, false otherwise. Adds entries from named configuration's scan axes table to BioXASXASScanConfiguration_table_scanAxes.
+	bool addConfigurationAxesToXASAxesTable(const QString &configurationTableName, const QString &scanAxesTableName);
+
 };
 
 #endif // BIOXASDBUPGRADE1PT1_H

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
@@ -7,6 +7,8 @@
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE 234988
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE 234989
 #define BIOXASDBUPGRADE1PT1_UPGRADE_COMPLETED_SUCCESSFULLY 2348990
+#define BIOXASDBUPGRADE1PT1_TABLE_DOES_NOT_EXIST 2348991
+#define BIOXASDBUPGRADE1PT1_INSERT_OR_UPDATE_SUCCESSFUL 2348992
 
 /// Upgrades database to account for new BioXASXASScanConfiguration, which functionally replaces existing BioXASSideXASScanConfiguration and BioXASMainXASScanConfiguration.
 class BioXASDbUpgrade1Pt1 : public AMDbUpgrade
@@ -21,10 +23,8 @@ public:
 
 	/// Indicates the dependencies of this upgrade.
 	virtual QStringList upgradeFromTags() const;
-
 	/// Returns true if this upgrade needs to be done.
 	virtual bool upgradeNecessary() const;
-
 	/// Returns true if the upgrade is completed successfully, false otherwise. Contains the steps to complete the upgrade.
 	virtual bool upgradeImplementation();
 
@@ -36,6 +36,10 @@ public:
 
 	/// Returns the description.
 	virtual QString description() const;
+
+protected:
+	/// Returns true if successful, false otherwise. Merges data from the named table into BioXASXASScanConfiguration_table.
+	bool addConfigurationTableToXASTable(const QString &configurationTableName);
 
 };
 

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
@@ -41,6 +41,9 @@ protected:
 	/// Returns true if successful, false otherwise. Merges data from the named table into BioXASXASScanConfiguration_table.
 	bool addConfigurationTableToXASTable(const QString &configurationTableName);
 
+	/// Returns true if successful, false otherwise. Iterates through entries in AMScan_table and updates scanConfiguration entries from the named configuration table to BioXASXASScanConfiguration_table.
+	bool updateScanTable(int configurationID, const QString &configurationTableName);
+
 };
 
 #endif // BIOXASDBUPGRADE1PT1_H

--- a/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
+++ b/source/dataman/BioXAS/BioXASDbUpgrade1Pt1.h
@@ -5,7 +5,7 @@
 
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_REMOVE_COLUMN 234987
 #define BIOXASDBUPGRADE1PT1_COULD_NOT_CREATE_TABLE 234988
-#define BIOXASUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE 234989
+#define BIOXASDBUPGRADE1PT1_COULD_NOT_INSERT_OR_UPDATE_TABLE 234989
 
 /// Upgrades database to account for new BioXASXASScanConfiguration, which functionally replaces existing BioXASSideXASScanConfiguration and BioXASMainXASScanConfiguration.
 class BioXASDbUpgrade1Pt1 : public AMDbUpgrade

--- a/source/ui/beamline/AMExtendedControlEditor.cpp
+++ b/source/ui/beamline/AMExtendedControlEditor.cpp
@@ -136,7 +136,9 @@ bool AMExtendedControlEditor::setControlFormat(const QChar& format, int precisio
 void AMExtendedControlEditor::setPrecision(int precision)
 {
 	precision_ = precision;
-	onValueChanged(control_->value());
+
+	if (control_)
+		onValueChanged(control_->value());
 }
 
 void AMExtendedControlEditor::setRange(double maxValue, double minValue)


### PR DESCRIPTION
Here is the first draft of the database upgrade needed to make sure data in old BioXASSide- and BioXASMainConfigurations are still accessible. These classes are functionally replaced with BioXASXASScanConfiguration in #1435.