### PR TITLE
Pull Request for Issue1540: yPoints inside of SXRMB2DScanActionController doesn't use the same axis for calculation

### DIFF
--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -18,7 +18,7 @@ AMGenericStepScanController::AMGenericStepScanController(AMGenericStepScanConfig
 
 	if (configuration_->scanAxes().size() == 2){
 
-		int yPoints = int(round((double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd()) - double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()))/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()))) + 1;
+		int yPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 		AMControlInfo axisControlInfo2 = configuration_->axisControlInfos().at(1);
 		scan_->rawData()->addScanAxis(AMAxisInfo(axisControlInfo2.name(), yPoints, axisControlInfo2.description()));
 	}

--- a/source/acquaman/SXRMB/SXRMB2DMapScanConfiguration.cpp
+++ b/source/acquaman/SXRMB/SXRMB2DMapScanConfiguration.cpp
@@ -96,8 +96,7 @@ void SXRMB2DMapScanConfiguration::computeTotalTimeImplementation()
 	double time = 0;
 
 	// Get the number of points.
-	time = 	fabs((double(scanAxisAt(0)->regionAt(0)->regionEnd())-double(scanAxisAt(0)->regionAt(0)->regionStart()))/double(scanAxisAt(0)->regionAt(0)->regionStep())+1)
-			*fabs((double(scanAxisAt(1)->regionAt(0)->regionEnd())-double(scanAxisAt(1)->regionAt(0)->regionStart()))/double(scanAxisAt(1)->regionAt(0)->regionStep())+1);
+	time = scanAxisAt(0)->numberOfPoints() + scanAxisAt(1)->numberOfPoints();
 
 	time *= double(scanAxisAt(0)->regionAt(0)->regionTime()) + timeOffset_;
 

--- a/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
@@ -39,7 +39,7 @@ SXRMB2DScanActionController::SXRMB2DScanActionController(SXRMB2DMapScanConfigura
 			AMAppControllerSupport::registerClass<SXRMB2DMapScanConfiguration, AMSMAKExporter, AMExporterOptionSMAK>(sxrmbExportOptions->id());
 	}
 
-	int yPoints = int(round((fabs(double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd()) - double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart())))/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()))) + 1;
+	int yPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 
 	AMControlInfoList list;
 	list.append(SXRMBBeamline::sxrmb()->microprobeSampleStageX()->toInfo());

--- a/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
@@ -60,7 +60,7 @@ VESPERS2DScanActionController::VESPERS2DScanActionController(VESPERS2DScanConfig
 			AMAppControllerSupport::registerClass<VESPERS2DScanConfiguration, VESPERSExporterSMAK, AMExporterOptionSMAK>(vespersDefault->id());
 	}
 
-	int yPoints = int(round((double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd()) - double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()))/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()))) + 1;
+	int yPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 
 	VESPERS::Motors motor = configuration_->motor();
 	AMControlInfoList list;

--- a/source/acquaman/VESPERS/VESPERS2DScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanConfiguration.cpp
@@ -207,8 +207,7 @@ void VESPERS2DScanConfiguration::computeTotalTimeImplementation()
 	double time = 0;
 
 	// Get the number of points.
-	time = 	fabs((double(scanAxisAt(0)->regionAt(0)->regionEnd())-double(scanAxisAt(0)->regionAt(0)->regionStart()))/double(scanAxisAt(0)->regionAt(0)->regionStep())+1)
-			*fabs((double(scanAxisAt(1)->regionAt(0)->regionEnd())-double(scanAxisAt(1)->regionAt(0)->regionStart()))/double(scanAxisAt(1)->regionAt(0)->regionStep())+1);
+	time = 	scanAxisAt(0)->numberOfPoints() + scanAxisAt(1)->numberOfPoints();
 
 	// Factor in the time per point.  There is an extra 6 seconds for CCD images for the Roper and Mar.
 	if (ccdDetector() == VESPERS::Roper)

--- a/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
@@ -25,8 +25,8 @@ VESPERS3DScanActionController::VESPERS3DScanActionController(VESPERS3DScanConfig
 	scan_->setIndexType("fileSystem");
 	scan_->setNotes(buildNotes());
 
-	int yPoints = int(round((double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd()) - double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()))/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()))) + 1;
-	int zPoints = int(round((double(configuration_->scanAxisAt(2)->regionAt(0)->regionEnd()) - double(configuration_->scanAxisAt(2)->regionAt(0)->regionStart()))/double(configuration_->scanAxisAt(2)->regionAt(0)->regionStep()))) + 1;
+	int yPoints = configuration_->scanAxisAt(1)->numberOfPoints();
+	int zPoints = configuration_->scanAxisAt(2)->numberOfPoints();
 
 	// 3D is very limited in motor selection choices.
 	AMControlInfoList list;

--- a/source/acquaman/VESPERS/VESPERS3DScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanConfiguration.cpp
@@ -191,9 +191,7 @@ void  VESPERS3DScanConfiguration::computeTotalTimeImplementation()
 	double time = 0;
 
 	// Get the number of points.
-	time = 	fabs((double(scanAxisAt(0)->regionAt(0)->regionEnd())-double(scanAxisAt(0)->regionAt(0)->regionStart()))/double(scanAxisAt(0)->regionAt(0)->regionStep())+1)
-			*fabs((double(scanAxisAt(1)->regionAt(0)->regionEnd())-double(scanAxisAt(1)->regionAt(0)->regionStart()))/double(scanAxisAt(1)->regionAt(0)->regionStep())+1)
-			*fabs((double(scanAxisAt(2)->regionAt(0)->regionEnd())-double(scanAxisAt(2)->regionAt(0)->regionStart()))/double(scanAxisAt(2)->regionAt(0)->regionStep())+1);
+	time = 	scanAxisAt(0)->numberOfPoints() + scanAxisAt(1)->numberOfPoints() + scanAxisAt(2)->numberOfPoints();
 
 	// Factor in the time per point.  There is an extra 6 seconds for CCD images for the Roper and Mar.
 	if (ccdDetector() == VESPERS::Roper)

--- a/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
@@ -12,7 +12,7 @@ VESPERSTimedLineScanActionController::VESPERSTimedLineScanActionController(VESPE
 {
 	timedConfiguration_ = configuration;
 
-	int yPoints = int(round((double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd()) - double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()))/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep())));
+	int yPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 	scan_->rawData()->addScanAxis(AMAxisInfo("Time", yPoints, "Time", "s"));
 
 	VESPERS::FluorescenceDetectors xrfDetector = configuration_->fluorescenceDetector();

--- a/source/ui/SXRMB/SXRMB2DMapScanConfigurationView.cpp
+++ b/source/ui/SXRMB/SXRMB2DMapScanConfigurationView.cpp
@@ -378,17 +378,8 @@ void SXRMB2DMapScanConfigurationView::updateMapInfo()
 	double hSize = fabs(double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(0)->regionAt(0)->regionStart()));
 	double vSize = fabs(double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()));
 
-	int hPoints = int((hSize)/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()));
-	if ((hSize - (hPoints + 0.01)*double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep())) < 0)
-		hPoints += 1;
-	else
-		hPoints += 2;
-
-	int vPoints = int((vSize)/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()));
-	if ((vSize - (vPoints + 0.01)*double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep())) < 0)
-		vPoints += 1;
-	else
-		vPoints += 2;
+	int hPoints = configuration_->scanAxisAt(0)->numberOfPoints();
+	int vPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 
 	mapInfo_->setText(QString("Map Size: %1 %2 x %3 %2\t Points: %4 x %5")
 			  .arg(QString::number(hSize*1000, 'f', 1))

--- a/source/ui/SXRMB/SXRMB2DOxidationMapScanConfigurationView.cpp
+++ b/source/ui/SXRMB/SXRMB2DOxidationMapScanConfigurationView.cpp
@@ -334,17 +334,8 @@ void SXRMB2DOxidationMapScanConfigurationView::updateMapInfo()
 	double hSize = fabs(double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(0)->regionAt(0)->regionStart()));
 	double vSize = fabs(double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()));
 
-	int hPoints = int((hSize)/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()));
-	if ((hSize - (hPoints + 0.01)*double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep())) < 0)
-		hPoints += 1;
-	else
-		hPoints += 2;
-
-	int vPoints = int((vSize)/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()));
-	if ((vSize - (vPoints + 0.01)*double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep())) < 0)
-		vPoints += 1;
-	else
-		vPoints += 2;
+	int hPoints = configuration_->scanAxisAt(0)->numberOfPoints();
+	int vPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 
 	mapInfo_->setText(QString("Map Size: %1 %2 x %3 %2\t Points: %4 x %5")
 			  .arg(QString::number(hSize*1000, 'f', 1))

--- a/source/ui/VESPERS/VESPERS2DScanConfigurationView.cpp
+++ b/source/ui/VESPERS/VESPERS2DScanConfigurationView.cpp
@@ -534,17 +534,8 @@ void VESPERS2DScanConfigurationView::updateMapInfo()
 	double hSize = fabs(double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(0)->regionAt(0)->regionStart()));
 	double vSize = fabs(double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()));
 
-	int hPoints = int((hSize)/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()));
-	if ((hSize - (hPoints + 0.01)*double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep())) < 0)
-		hPoints += 1;
-	else
-		hPoints += 2;
-
-	int vPoints = int((vSize)/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()));
-	if ((vSize - (vPoints + 0.01)*double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep())) < 0)
-		vPoints += 1;
-	else
-		vPoints += 2;
+	int hPoints = configuration_->scanAxisAt(0)->numberOfPoints();
+	int vPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 
 	mapInfo_->setText(QString("Map Size: %1 %2 x %3 %2\t Points: %4 x %5")
 					  .arg(QString::number(hSize*1000, 'f', 1))

--- a/source/ui/VESPERS/VESPERS3DScanConfigurationView.cpp
+++ b/source/ui/VESPERS/VESPERS3DScanConfigurationView.cpp
@@ -496,23 +496,9 @@ void VESPERS3DScanConfigurationView::updateMapInfo()
 	double vSize = fabs(double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()));
 	double wireSize = fabs(double(configuration_->scanAxisAt(2)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(2)->regionAt(0)->regionStart()));
 
-	int hPoints = int((hSize)/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()));
-	if ((hSize - (hPoints + 0.01)*double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep())) < 0)
-		hPoints += 1;
-	else
-		hPoints += 2;
-
-	int vPoints = int((vSize)/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()));
-	if ((vSize - (vPoints + 0.01)*double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep())) < 0)
-		vPoints += 1;
-	else
-		vPoints += 2;
-
-	int wirePoints = int((wireSize)/double(configuration_->scanAxisAt(2)->regionAt(0)->regionStep()));
-	if ((wireSize - (wirePoints + 0.01)*double(configuration_->scanAxisAt(2)->regionAt(0)->regionStep())) < 0)
-		wirePoints += 1;
-	else
-		wirePoints += 2;
+	int hPoints = configuration_->scanAxisAt(0)->numberOfPoints();
+	int vPoints = configuration_->scanAxisAt(1)->numberOfPoints();
+	int wirePoints = configuration_->scanAxisAt(2)->numberOfPoints();
 
 	mapInfo_->setText(QString("Map Size: %1 %2 x %3 %2 x %6 %2\t Points: %4 x %5 x %7")
 					  .arg(QString::number(hSize*1000, 'f', 1))

--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
@@ -322,13 +322,7 @@ void AMGenericStepScanConfigurationView::updateScanInformation()
 	if (configuration_->scanAxes().size() == 1){
 
 		double size = fabs(double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(0)->regionAt(0)->regionStart()));
-		int points = int((size)/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()));
-
-		if ((size - (points + 0.01)*double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep())) < 0)
-			points += 1;
-
-		else
-			points += 2;
+		int points = configuration_->scanAxisAt(0)->numberOfPoints();
 
 		scanInformation_->setText(QString("Scan Size: %1\t Points: %2")
 						  .arg(QString::number(size, 'f', 1))
@@ -341,17 +335,8 @@ void AMGenericStepScanConfigurationView::updateScanInformation()
 		double hSize = fabs(double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(0)->regionAt(0)->regionStart()));
 		double vSize = fabs(double(configuration_->scanAxisAt(1)->regionAt(0)->regionEnd())-double(configuration_->scanAxisAt(1)->regionAt(0)->regionStart()));
 
-		int hPoints = int((hSize)/double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()));
-		if ((hSize - (hPoints + 0.01)*double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep())) < 0)
-			hPoints += 1;
-		else
-			hPoints += 2;
-
-		int vPoints = int((vSize)/double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep()));
-		if ((vSize - (vPoints + 0.01)*double(configuration_->scanAxisAt(1)->regionAt(0)->regionStep())) < 0)
-			vPoints += 1;
-		else
-			vPoints += 2;
+		int hPoints = configuration_->scanAxisAt(0)->numberOfPoints();
+		int vPoints = configuration_->scanAxisAt(1)->numberOfPoints();
 
 		scanInformation_->setText(QString("Scan Size: %1 x %2 \t Points: %3 x %4")
 						  .arg(QString::number(hSize, 'f', 1))


### PR DESCRIPTION
I not only fixed the typo, but went through the whole framework and made use of the  AMScanAxis::numberOfPoints() method in all the places that made sense to make the code cleaner. 