### PR TITLE
Pull Request for Issue1550: Adding Exit Slit Position to SGM Beamline

### DIFF
--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -65,6 +65,11 @@ AMControl * SGMBeamline::exitSlitGap() const
 	return exitSlitGap_;
 }
 
+AMControl * SGMBeamline::exitSlitPosition() const
+{
+	return exitSlitPosition_;
+}
+
 AMControl * SGMBeamline::grating() const
 {
 	return grating_;
@@ -125,6 +130,11 @@ void SGMBeamline::setupBeamlineComponents()
 	exitSlitGap_ = new AMPVwStatusControl("exitSlitGap", "PSL16114I1004:Y:mm:fbk", "BL1611-ID-1:AddOns:ExitSlitGap:Y:mm", "BL1611-ID-1:AddOns:ExitSlitGap:Y:status", "SMTR16114I1017:stop", this, 0.5);
 	exitSlitGap_->setDescription("Exit Slit Gap");
 
+	// Exit Slit Position
+	exitSlitPosition_ = new AMPVwStatusControl("exitSlitPosition", "PSL16114I1003:Y:mm:fbk", "PSL16114I1003:Y:mm:encsp", "SMTR16114I1003:status", "SMTR16114I1003:stop", this, 0.1, 2.0, new AMControlStatusCheckerDefault(1));
+	exitSlitPosition_->setDescription("Exit Slit Position");
+	exitSlitPosition_->setContextKnownDescription("Exit Slit");
+
 	// Grating
 	grating_ = new AMPVwStatusControl("grating", "BL1611-ID-1:AddOns:grating", "BL1611-ID-1:AddOns:grating", "SMTR16114I1016:state", "SMTR16114I1016:emergStop", this, 0.1, 2.0, new AMControlStatusCheckerStopped(0));
 	grating_->setDescription("Grating Selection");
@@ -181,12 +191,14 @@ void SGMBeamline::setupBeamlineComponents()
 
 	connect(energy_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(exitSlitGap_ ,SIGNAL(connected(bool)),this, SLOT(onConnectionStateChanged(bool)));
+	connect(exitSlitPosition_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(grating_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(ssaManipulatorX_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(ssaManipulatorY_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(ssaManipulatorZ_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(ssaManipulatorRot_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(onConnectionStateChanged(bool)));
+
 
 	// Ensure that the inital cached connected state is valid, and emit an initial
 	// connected signal:
@@ -257,6 +269,7 @@ void SGMBeamline::setupExposedControls()
 {
 	addExposedControl(energy_);
 	addExposedControl(exitSlitGap_);
+	addExposedControl(exitSlitPosition_);
 	addExposedControl(ssaManipulatorX_);
 	addExposedControl(ssaManipulatorY_);
 	addExposedControl(ssaManipulatorZ_);

--- a/source/beamline/SGM/SGMBeamline.h
+++ b/source/beamline/SGM/SGMBeamline.h
@@ -64,6 +64,11 @@ public:
 	AMControl* exitSlitGap() const;
 
 	/*!
+	  * The exit slit position control.
+	  */
+	AMControl* exitSlitPosition() const;
+
+	/*!
 	  * The grating control.
 	  */
 	AMControl* grating() const;
@@ -147,6 +152,7 @@ protected:
 
 	AMControl *energy_;
 	AMControl *exitSlitGap_;
+	AMControl *exitSlitPosition_;
 	AMControl *grating_;
 
 	AMMotorGroup *sampleManipulatorsMotorGroup_;

--- a/source/ui/SGM/SGMPersistentView.cpp
+++ b/source/ui/SGM/SGMPersistentView.cpp
@@ -19,7 +19,8 @@ SGMPersistentView::SGMPersistentView(QWidget *parent) :
 void SGMPersistentView::setupUi()
 {
 	energyControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->energy());
-	exitSlitControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->exitSlitGap());
+	exitSlitGapControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->exitSlitGap());
+	exitSlitPositionControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->exitSlitPosition());
 	gratingSelectionControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->grating());
 
 	hexapodVelocityControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->hexapod()->systemVelocity());
@@ -36,7 +37,8 @@ void SGMPersistentView::setupUi()
 	QVBoxLayout* controlsGroupLayout = new QVBoxLayout();
 
 	controlsGroupLayout->addWidget(energyControlEditor_);
-	controlsGroupLayout->addWidget(exitSlitControlEditor_);
+	controlsGroupLayout->addWidget(exitSlitGapControlEditor_);
+	controlsGroupLayout->addWidget(exitSlitPositionControlEditor_);
 	controlsGroupLayout->addWidget(gratingSelectionControlEditor_);
 	controlsGroupLayout->addWidget(hexapodVelocityControlEditor_);
 	controlsGroupLayout->addWidget(manipulatorsMotorGroupView);

--- a/source/ui/SGM/SGMPersistentView.h
+++ b/source/ui/SGM/SGMPersistentView.h
@@ -37,7 +37,8 @@ protected:
 	void setupUi();
 
 	AMExtendedControlEditor* energyControlEditor_;
-	AMExtendedControlEditor* exitSlitControlEditor_;
+	AMExtendedControlEditor* exitSlitGapControlEditor_;
+	AMExtendedControlEditor* exitSlitPositionControlEditor_;
 	AMExtendedControlEditor* gratingSelectionControlEditor_;
 	AMExtendedControlEditor* hexapodVelocityControlEditor_;
 	SGMHexapodTrajectoryView* hexapodTrajectoryView_;


### PR DESCRIPTION
- Added PVwStatusControl for the Exit Slit Position to the SGM Beamline class (plus getter)
- Added the Exit Slit Position control to the list of exposed controls
- Added an AMExtendedControlEditor for the Exit Slit Position to the SGMPersistentView

Estimate: 1