### PR TITLE
Pull Request for Issue1552: Add end station translation to SGM Acquaman

### DIFF
--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -304,7 +304,7 @@ void SGMBeamline::setupExposedControls()
 void SGMBeamline::setupExposedDetectors()
 {
 	AMBasicControlDetectorEmulator* endStationPositionDetector =
-			new AMBasicControlDetectorEmulator("ES2Pos", "Position of the End Station", endStationTranslationFeedback_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+			new AMBasicControlDetectorEmulator("EA2Pos", "Position of the End Station 2", endStationTranslationFeedback_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 
 	addExposedDetector(endStationPositionDetector);
 	addExposedDetector(teyDetector_);

--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -151,6 +151,7 @@ void SGMBeamline::setupBeamlineComponents()
 	endStationTranslationSetpont_->setDescription("Step");
 	endStationTranslationFeedback_ = new AMReadOnlyPVControl("endStationFeedback", "ENC16114I1029:raw:cnt:fbk", this);
 	endStationTranslationFeedback_->setDescription("Position");
+	endStationTranslationFeedback_->setTolerance(1e15);
 
 	// Grating
 	grating_ = new AMPVwStatusControl("grating", "BL1611-ID-1:AddOns:grating", "BL1611-ID-1:AddOns:grating", "SMTR16114I1016:state", "SMTR16114I1016:emergStop", this, 0.1, 2.0, new AMControlStatusCheckerStopped(0));
@@ -286,6 +287,7 @@ void SGMBeamline::setupDetectors()
 
 void SGMBeamline::setupExposedControls()
 {
+	addExposedControl(endStationTranslationSetpont_);
 	addExposedControl(energy_);
 	addExposedControl(exitSlitGap_);
 	addExposedControl(exitSlitPosition_);
@@ -306,6 +308,8 @@ void SGMBeamline::setupExposedDetectors()
 	AMBasicControlDetectorEmulator* endStationPositionDetector =
 			new AMBasicControlDetectorEmulator("EA2Pos", "Position of the End Station 2", endStationTranslationFeedback_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 
+	endStationPositionDetector->setIsVisible(true);
+	endStationPositionDetector->setHiddenFromUsers(false);
 	addExposedDetector(endStationPositionDetector);
 	addExposedDetector(teyDetector_);
 	addExposedDetector(tfyDetector_);

--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -27,6 +27,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/AMMotorGroup.h"
 #include "beamline/CLS/CLSAdvancedScalerChannelDetector.h"
 #include "beamline/SGM/SGMHexapod.h"
+#include "beamline/AMBasicControlDetectorEmulator.h"
 
 SGMBeamline* SGMBeamline::sgm() {
 
@@ -302,6 +303,10 @@ void SGMBeamline::setupExposedControls()
 
 void SGMBeamline::setupExposedDetectors()
 {
+	AMBasicControlDetectorEmulator* endStationPositionDetector =
+			new AMBasicControlDetectorEmulator("ES2Pos", "Position of the End Station", endStationTranslationFeedback_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+
+	addExposedDetector(endStationPositionDetector);
 	addExposedDetector(teyDetector_);
 	addExposedDetector(tfyDetector_);
 	addExposedDetector(i0Detector_);

--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -55,6 +55,16 @@ bool SGMBeamline::isConnected() const
 			scaler_->isConnected();
 }
 
+AMControl * SGMBeamline::endStationTranslationSetpoint() const
+{
+	return endStationTranslationSetpont_;
+}
+
+AMControl * SGMBeamline::endStationTranslationFeedback() const
+{
+	return endStationTranslationFeedback_;
+}
+
 AMControl * SGMBeamline::energy() const
 {
 	return energy_;
@@ -135,6 +145,12 @@ void SGMBeamline::setupBeamlineComponents()
 	exitSlitPosition_->setDescription("Exit Slit Position");
 	exitSlitPosition_->setContextKnownDescription("Exit Slit");
 
+	// End Station Translation
+	endStationTranslationSetpont_ = new AMSinglePVControl("endStationStep", "SMTR16114I1038:step", this, 1.0, 2.0);
+	endStationTranslationSetpont_->setDescription("Step");
+	endStationTranslationFeedback_ = new AMReadOnlyPVControl("endStationFeedback", "ENC16114I1029:raw:cnt:fbk", this);
+	endStationTranslationFeedback_->setDescription("Position");
+
 	// Grating
 	grating_ = new AMPVwStatusControl("grating", "BL1611-ID-1:AddOns:grating", "BL1611-ID-1:AddOns:grating", "SMTR16114I1016:state", "SMTR16114I1016:emergStop", this, 0.1, 2.0, new AMControlStatusCheckerStopped(0));
 	grating_->setDescription("Grating Selection");
@@ -192,6 +208,8 @@ void SGMBeamline::setupBeamlineComponents()
 	connect(energy_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(exitSlitGap_ ,SIGNAL(connected(bool)),this, SLOT(onConnectionStateChanged(bool)));
 	connect(exitSlitPosition_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
+	connect(endStationTranslationSetpont_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
+	connect(endStationTranslationFeedback_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(grating_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(ssaManipulatorX_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
 	connect(ssaManipulatorY_, SIGNAL(connected(bool)), this, SLOT(onConnectionStateChanged(bool)));
@@ -305,3 +323,5 @@ SGMBeamline::SGMBeamline()
 	setupExposedControls();
 	setupExposedDetectors();
 }
+
+

--- a/source/beamline/SGM/SGMBeamline.h
+++ b/source/beamline/SGM/SGMBeamline.h
@@ -54,6 +54,16 @@ public:
 	virtual bool isConnected() const;
 
 	/*!
+	  * The end station step setpoint
+	  */
+	AMControl* endStationTranslationSetpoint() const;
+
+	/*!
+	  * The end station translation feedback
+	  */
+	AMControl* endStationTranslationFeedback() const;
+
+	/*!
 	  * The energy control.
 	  */
 	AMControl* energy() const;
@@ -154,6 +164,8 @@ protected:
 	AMControl *exitSlitGap_;
 	AMControl *exitSlitPosition_;
 	AMControl *grating_;
+	AMControl *endStationTranslationSetpont_;
+	AMControl *endStationTranslationFeedback_;
 
 	AMMotorGroup *sampleManipulatorsMotorGroup_;
 

--- a/source/ui/SGM/SGMPersistentView.cpp
+++ b/source/ui/SGM/SGMPersistentView.cpp
@@ -21,6 +21,8 @@ void SGMPersistentView::setupUi()
 	energyControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->energy());
 	exitSlitGapControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->exitSlitGap());
 	exitSlitPositionControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->exitSlitPosition());
+	endStationTranslationSetpointControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->endStationTranslationSetpoint());
+	endStationTranslationFeedbackControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->endStationTranslationFeedback());
 	gratingSelectionControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->grating());
 
 	hexapodVelocityControlEditor_ = new AMExtendedControlEditor(SGMBeamline::sgm()->hexapod()->systemVelocity());
@@ -32,7 +34,7 @@ void SGMPersistentView::setupUi()
 
 	QGroupBox* sgmControlsGroupBox = new QGroupBox("SGM Beamline");
 	sgmControlsGroupBox->setFlat(true);
-
+	QGroupBox* endStationGroupBox = new QGroupBox("End Station Translation");
 
 	QVBoxLayout* controlsGroupLayout = new QVBoxLayout();
 
@@ -41,6 +43,12 @@ void SGMPersistentView::setupUi()
 	controlsGroupLayout->addWidget(exitSlitPositionControlEditor_);
 	controlsGroupLayout->addWidget(gratingSelectionControlEditor_);
 	controlsGroupLayout->addWidget(hexapodVelocityControlEditor_);
+	QHBoxLayout* endStationTranslationLayout = new QHBoxLayout();
+
+	endStationTranslationLayout->addWidget(endStationTranslationSetpointControlEditor_);
+	endStationTranslationLayout->addWidget(endStationTranslationFeedbackControlEditor_);
+	endStationGroupBox->setLayout(endStationTranslationLayout);
+	controlsGroupLayout->addWidget(endStationGroupBox);
 	controlsGroupLayout->addWidget(manipulatorsMotorGroupView);
 
 

--- a/source/ui/SGM/SGMPersistentView.cpp
+++ b/source/ui/SGM/SGMPersistentView.cpp
@@ -47,6 +47,7 @@ void SGMPersistentView::setupUi()
 
 	endStationTranslationLayout->addWidget(endStationTranslationSetpointControlEditor_);
 	endStationTranslationLayout->addWidget(endStationTranslationFeedbackControlEditor_);
+	endStationTranslationFeedbackControlEditor_->setPrecision(12);
 	endStationGroupBox->setLayout(endStationTranslationLayout);
 	controlsGroupLayout->addWidget(endStationGroupBox);
 	controlsGroupLayout->addWidget(manipulatorsMotorGroupView);

--- a/source/ui/SGM/SGMPersistentView.h
+++ b/source/ui/SGM/SGMPersistentView.h
@@ -41,6 +41,8 @@ protected:
 	AMExtendedControlEditor* exitSlitPositionControlEditor_;
 	AMExtendedControlEditor* gratingSelectionControlEditor_;
 	AMExtendedControlEditor* hexapodVelocityControlEditor_;
+	AMExtendedControlEditor* endStationTranslationSetpointControlEditor_;
+	AMExtendedControlEditor* endStationTranslationFeedbackControlEditor_;
 	SGMHexapodTrajectoryView* hexapodTrajectoryView_;
 
 };


### PR DESCRIPTION
- Added end station translation setpoint (step) and feedback (encoder count, readonly) controls to SGMBeamline.
- Added end station setpoint as exposed control to SGMBeamline
- Added end station translation feedback as a detector emulator to the SGMBeamline
- Added AMExtendedControlEditors to SGM Persistent View for the end station setpoint and feedback.

Estimate 2