### PR TITLE
Pull Request for Issue638 - adjust XES integration time during a scan

### DIFF
--- a/REIXSAcquaman_internal.pro
+++ b/REIXSAcquaman_internal.pro
@@ -36,7 +36,9 @@ HEADERS +=	\
 	source/ui/REIXS/REIXSScalerView.h \
 	source/ui/REIXS/REIXSXESSpectrometerControlPanel.h \
 	source/acquaman/REIXS/REIXSScanActionControllerMCPFileWriter.h \
-    source/ui/REIXS/REIXSSampleManagementPre2013Widget.h
+    source/ui/REIXS/REIXSSampleManagementPre2013Widget.h \
+    source/ui/REIXS/REIXSAppBottomPanel.h \
+    source/ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.h
 
 SOURCES += \
 	source/application/REIXS/REIXSMain.cpp \
@@ -71,7 +73,13 @@ SOURCES += \
     source/ui/REIXS/REIXSScalerView.cpp \
     source/ui/REIXS/REIXSXESSpectrometerControlPanel.cpp \
     source/acquaman/REIXS/REIXSScanActionControllerMCPFileWriter.cpp \
-    source/ui/REIXS/REIXSSampleManagementPre2013Widget.cpp
+    source/ui/REIXS/REIXSSampleManagementPre2013Widget.cpp \
+    source/ui/REIXS/REIXSAppBottomPanel.cpp \
+    source/ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.cpp
+
+
+
+
 
 
 

--- a/source/acquaman/REIXS/REIXSXESScanConfiguration.cpp
+++ b/source/acquaman/REIXS/REIXSXESScanConfiguration.cpp
@@ -131,7 +131,9 @@ void REIXSXESScanConfiguration::computeTotalTimeImplementation()
 	double averageCountRate =  REIXSBeamline::bl()->mcpDetector()->countsPerSecond();
 	double estimatedTime = maximumTotalCounts_ / averageCountRate;
 
-	totalTime_ = qMin(double(maximumDurationSeconds_), estimatedTime);
+	double scanLength = REIXSBeamline::bl()->mcpDetector()->acquisitionTime();
+
+	totalTime_ = qMin(double(scanLength), estimatedTime);
 
 	setExpectedDuration(totalTime_);
 	emit totalTimeChanged(totalTime_);

--- a/source/application/REIXS/REIXSAppController.cpp
+++ b/source/application/REIXS/REIXSAppController.cpp
@@ -65,6 +65,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/REIXS/REIXSXESHexapodControlEditor.h"
 #include "ui/REIXS/REIXSXESSpectrometerControlEditor.h"
 #include "ui/REIXS/REIXSSampleChamberButtonPanel.h"
+#include "ui/REIXS/REIXSAppBottomPanel.h"
 
 
 REIXSAppController::REIXSAppController(QObject *parent) :
@@ -272,4 +273,12 @@ void REIXSAppController::makeConnections()
 	connect(rixsScanConfigurationViewHolder_, SIGNAL(showWorkflowRequested()), this, SLOT(goToWorkflow()));
 	connect(xasScanConfigurationViewHolder_, SIGNAL(showWorkflowRequested()), this, SLOT(goToWorkflow()));
 	connect(this, SIGNAL(scanEditorCreated(AMGenericScanEditor*)), this, SLOT(onScanEditorCreated(AMGenericScanEditor*)));
+}
+
+void REIXSAppController::addBottomPanel()
+{
+	REIXSAppBottomPanel *panel = new REIXSAppBottomPanel(AMActionRunner3::workflow());
+	mw_->addBottomWidget(panel);
+	connect(panel, SIGNAL(addExperimentButtonClicked()), this, SLOT(onAddButtonClicked()));
+	bottomPanel_ = panel;
 }

--- a/source/application/REIXS/REIXSAppController.h
+++ b/source/application/REIXS/REIXSAppController.h
@@ -93,6 +93,11 @@ protected slots:
 	void onScanAddedToEditor(AMGenericScanEditor *editor, AMScan *scan);
 
 protected:
+
+
+	/// Re-implementing the build bottom bar method to use the REIXS bottom bar with XES scan integration.
+	virtual void addBottomPanel();
+
 	/**
 	 * Implementation method that specifies REIXS specific actions taken when a
 	 * scan action is started

--- a/source/beamline/REIXS/REIXSXESMCPDetector.cpp
+++ b/source/beamline/REIXS/REIXSXESMCPDetector.cpp
@@ -159,6 +159,22 @@ bool REIXSXESMCPDetector::setAcquisitionTime(double seconds){
 	return true;
 }
 
+bool REIXSXESMCPDetector::addAcquisitionTime(double addSeconds){
+	if(addSeconds < 0.1)
+		return false;
+	if (!dwellTimeTimer_->isActive())
+		return false;
+
+	dwellTime_+= addSeconds;
+
+	dwellTimeTimer_->blockSignals(true);
+	dwellTimeTimer_->setInterval(dwellTime_*1000);
+	dwellTimeTimer_->blockSignals(false);
+
+	return true;
+}
+
+
 AMControl* REIXSXESMCPDetector::averagingPeriodControl(){
 	return averagingPeriodSecsControl_;
 }

--- a/source/beamline/REIXS/REIXSXESMCPDetector.h
+++ b/source/beamline/REIXS/REIXSXESMCPDetector.h
@@ -123,6 +123,8 @@ public:
 
 	/// Set the acquisition dwell time for triggered (RequestRead) detectors
 	virtual bool setAcquisitionTime(double seconds);
+	/// Adds time to the  acquisition dwell time
+	virtual bool addAcquisitionTime(double seconds);
 	/// Returns the tolerance for the acquisition time.
 	virtual double acquisitionTimeTolerance() const;
 

--- a/source/ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.cpp
+++ b/source/ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.cpp
@@ -1,0 +1,70 @@
+#include "REIXSActionRunnerBottomBarCurrentView3.h"
+#include "beamline/REIXS/REIXSBeamline.h"
+
+#include <QHBoxLayout>
+#include <QInputDialog>
+
+REIXSActionRunnerBottomBarCurrentView3::REIXSActionRunnerBottomBarCurrentView3(AMActionRunner3 *actionRunner, QWidget *parent) :
+	AMActionRunnerBottomBarCurrentView3(actionRunner, parent)
+{
+
+
+	addXESScanTime_ = new QToolButton;
+	addXESScanTime_->setIcon(QIcon(":/22x22/list-add.png"));
+	addXESScanTime_->setToolTip("Add time to scan.");
+	addXESScanTime_->setEnabled(false);
+	addXESScanTime_->setVisible(false);
+
+	QHBoxLayout* hl = qobject_cast<QHBoxLayout*>(layout());
+	hl->addWidget(addXESScanTime_);
+	setLayout(hl);
+
+	connect(addXESScanTime_, SIGNAL(clicked()), this, SLOT(onAddXESScanTimeClicked()));
+
+
+}
+
+
+void REIXSActionRunnerBottomBarCurrentView3::onCurrentActionChanged(AMAction3 *action)
+{
+	AMActionRunnerCurrentViewBase::onCurrentActionChanged(action);
+	AMActionRunnerBottomBarCurrentView3::onCurrentActionChanged(action);
+
+	action_ = action;
+
+			if (action && !action->parentAction() && action->info()->name() == "XES"){
+
+		action_ = qobject_cast<AMAction3 *>(action);
+		addXESScanTime_->setEnabled(true);
+		addXESScanTime_->setVisible(true);
+	}
+
+	else{
+
+		addXESScanTime_->setEnabled(false);
+		addXESScanTime_->setVisible(false);
+	}
+
+	if (!action){
+
+		whatIsRunning_ = "No action running.";
+		descriptionLabel_->setText(whatIsRunning_);
+	}
+}
+
+
+void REIXSActionRunnerBottomBarCurrentView3::onAddXESScanTimeClicked()
+{
+	bool ok;
+	double min = QInputDialog::getDouble(this, "Add time to XES Scan...", "Enter minutes to add:", 5, 0, 720, 0, &ok);
+
+	if (ok)
+	{
+		double expectedDuration = action_->info()->expectedDuration() + (min * 60);
+
+		if (REIXSBeamline::bl()->mcpDetector()->addAcquisitionTime(min * 60))
+			action_->info()->setExpectedDuration(expectedDuration);
+	}
+}
+
+

--- a/source/ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.h
+++ b/source/ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.h
@@ -1,0 +1,32 @@
+#ifndef REIXSACTIONRUNNERBOTTOMBARCURRENTVIEW3_H
+#define REIXSACTIONRUNNERBOTTOMBARCURRENTVIEW3_H
+
+#include "source/ui/actions3/AMActionRunnerBottomBarCurrentView3.h"
+
+class REIXSActionRunnerBottomBarCurrentView3 : public AMActionRunnerBottomBarCurrentView3
+{
+    Q_OBJECT
+public:
+	explicit REIXSActionRunnerBottomBarCurrentView3(AMActionRunner3 *actionRunner, QWidget *parent = 0);
+
+signals:
+
+public slots:
+
+protected slots:
+	/// When the current action in the AMActionRunner changes
+	virtual void onCurrentActionChanged(AMAction3 *action);
+	/// Displays dialog to extend the current XES scan duration
+	void onAddXESScanTimeClicked();
+
+protected:
+	/// The button to modify the XES scan time
+	QToolButton *addXESScanTime_;
+	/// Pointer to the running action (if it exists).
+	AMAction3 *action_;
+
+
+
+};
+
+#endif // REIXSACTIONRUNNERBOTTOMBARCURRENTVIEW3_H

--- a/source/ui/REIXS/REIXSAppBottomPanel.cpp
+++ b/source/ui/REIXS/REIXSAppBottomPanel.cpp
@@ -1,0 +1,13 @@
+
+#include "REIXSAppBottomPanel.h"
+
+class REIXSActionRunnerBottomBarCurrentView3;
+
+ REIXSAppBottomPanel::~REIXSAppBottomPanel(){}
+REIXSAppBottomPanel::REIXSAppBottomPanel(AMActionRunner3 *actionRunner, QWidget *parent)
+	: AMDatamanAppBottomPanel(parent)
+{
+	workflowView_ = new REIXSActionRunnerBottomBarCurrentView3(actionRunner);
+	layout_->insertStretch(2);
+	layout_->insertWidget(3, workflowView_);
+}

--- a/source/ui/REIXS/REIXSAppBottomPanel.h
+++ b/source/ui/REIXS/REIXSAppBottomPanel.h
@@ -1,0 +1,28 @@
+
+#ifndef REIXSAPPBOTTOMPANEL_H
+#define REIXSAPPBOTTOMPANEL_H
+
+#include "ui/AMDatamanAppBottomPanel.h"
+#include "actions3/AMActionRunner3.h"
+#include "ui/REIXS/REIXSActionRunnerBottomBarCurrentView3.h"
+
+
+/// This class implements the bottom panel used in the App for REIXS.  It contains a mini-view of the workflow and adds it between the add experiment button, the status view, and is XESScan/MCP aware for scan time modification
+class REIXSAppBottomPanel : public AMDatamanAppBottomPanel
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.  Passes in the action runner to appropriately build the mini-workflow view.
+	virtual ~REIXSAppBottomPanel();
+	REIXSAppBottomPanel(AMActionRunner3 *actionRunner, QWidget *parent = 0);
+
+	/// Returns the bottom bar view that is encapuslated.
+	AMActionRunnerBottomBarCurrentView3 *workFlowView() const { return workflowView_; }
+
+protected:
+	/// The current workflow view.
+	REIXSActionRunnerBottomBarCurrentView3 *workflowView_;
+};
+
+#endif // REIXSAPPBOTTOMPANEL_H


### PR DESCRIPTION
Created a REIXS specific bottom bar subclass that is XES scan aware and is able to add to the dwell time for a currently running MCPDetector acquisition.

I hope that this is a good way to approach this, and not too crude of a hack.

#638