### PR TITLE
Pull Request for Issue1586: Pseudo Motor not updating setpoint

### DIFF
--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -145,6 +145,9 @@ AMControl::FailureExplanation AMPseudoMotorControl::move(double setpoint)
 		return AMControl::LimitFailure;
 	}
 
+	// Update the setpoint.
+	setSetpoint(setpoint);
+
 	// If the new setpoint is within tolerance, no need to proceed with move.
 	// Instead report a successful move to setpoint.
 
@@ -155,10 +158,6 @@ AMControl::FailureExplanation AMPseudoMotorControl::move(double setpoint)
 	}
 
 	// Otherwise, an actual move is needed.
-	// Update the setpoint.
-
-	setSetpoint(setpoint);
-
 	// Create new move action.
 
 	AMAction3 *moveAction = createMoveAction(setpoint_);


### PR DESCRIPTION
Moved setting of setpoint to above the check which fakes the move when it is within tolerance.