### PR TITLE
Pull Request for Issue1573: Implement caching in commonly used 2D data sources and analysis blocks

### DIFF
--- a/source/analysis/AM1DCalibrationAB.cpp
+++ b/source/analysis/AM1DCalibrationAB.cpp
@@ -18,7 +18,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 
-#include <QDebug>
 #include <QtCore/qmath.h>
 
 #include "AM1DCalibrationAB.h"
@@ -134,7 +133,6 @@ void AM1DCalibrationAB::setToEdgeJump(bool toEdgeJump)
 		return;
 
 	toEdgeJump_ = toEdgeJump;
-	qDebug() << "toEdgeJump is now" << toEdgeJump_;
 	setModified(true);
 	emitValuesChanged();
 }
@@ -411,7 +409,6 @@ bool AM1DCalibrationAB::values(const AMnDIndex &indexStart, const AMnDIndex &ind
 
 
 
-		qDebug() << "the choosen pre edge point is" << preEdgePointValue << " with a value of" << offset  ;
 		// shift spectra so that pre edge reference point is 0
 		for (int i = 0; i < totalSize; i++)
 			outputValues[i] = outputValues[i] - offset;

--- a/source/analysis/AM2DAdditionAB.cpp
+++ b/source/analysis/AM2DAdditionAB.cpp
@@ -143,6 +143,7 @@ void AM2DAdditionAB::onInputSourceSizeChanged()
 	}
 
     cacheUpdateRequired_ = true;
+    cachedData_ = QVector<double>(size().product());
 }
 
 // Connected to be called when the state() flags of any input source change
@@ -238,9 +239,9 @@ void AM2DAdditionAB::reviewState()
 void AM2DAdditionAB::computeCachedValues() const
 {
     AMnDIndex start = AMnDIndex(0, 0);
-    AMnDIndex end = size();
+    AMnDIndex end = size()-1;
     int totalSize = start.totalPointsTo(end);
-
+    qDebug() << totalSize << size().product();
     QVector<double> data = QVector<double>(totalSize);
     sources_.at(0)->values(start, end, data.data());
 

--- a/source/analysis/AM2DAdditionAB.cpp
+++ b/source/analysis/AM2DAdditionAB.cpp
@@ -65,7 +65,7 @@ AMNumber AM2DAdditionAB::value(const AMnDIndex &indexes) const
 
     return cachedData_.at(indexes.flatIndexInArrayOfSize(size()));
 }
-
+#include <QDebug>
 bool AM2DAdditionAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
 {
 	if(indexStart.rank() != 2 || indexEnd.rank() != 2)

--- a/source/analysis/AM2DAdditionAB.cpp
+++ b/source/analysis/AM2DAdditionAB.cpp
@@ -24,6 +24,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 AM2DAdditionAB::AM2DAdditionAB(const QString &outputName, QObject *parent)
 	: AMStandardAnalysisBlock(outputName, parent)
 {
+    cacheUpdateRequired_ = false;
 	axes_ << AMAxisInfo("invalid", 0, "No input data") << AMAxisInfo("invalid", 0, "No input data");
 	setState(AMDataSource::InvalidFlag);
 }
@@ -59,12 +60,10 @@ AMNumber AM2DAdditionAB::value(const AMnDIndex &indexes) const
 			return AMNumber(AMNumber::OutOfBoundsError);
 #endif
 
-	double val = 0;
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	for (int i = 0; i < sources_.size(); i++)
-		val += (double)sources_.at(i)->value(indexes);
-
-	return val;
+    return cachedData_.at(indexes.flatIndexInArrayOfSize(size()));
 }
 
 bool AM2DAdditionAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
@@ -84,23 +83,11 @@ bool AM2DAdditionAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexE
 		return false;
 #endif
 
-	int totalSize = indexStart.totalPointsTo(indexEnd);
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	QVector<double> data = QVector<double>(totalSize);
-	sources_.at(0)->values(indexStart, indexEnd, data.data());
-
-	// Do the first data source separately to initialize the values.
-	for (int i = 0; i < totalSize; i++)
-		outputValues[i] = data.at(i);
-
-	// Iterate through the rest of the sources.
-	for (int i = 1, count = sources_.size(); i < count; i++){
-
-		sources_.at(i)->values(indexStart, indexEnd, data.data());
-
-		for (int j = 0; j < totalSize; j++)
-			outputValues[j] += data.at(j);
-	}
+    int totalSize = indexStart.totalPointsTo(indexEnd);
+    memcpy(outputValues, cachedData_.constData()+indexStart.flatIndexInArrayOfSize(size()), totalSize*sizeof(double));
 
 	return true;
 }
@@ -136,7 +123,8 @@ bool AM2DAdditionAB::axisValues(int axisNumber, int startIndex, int endIndex, do
 // Connected to be called when the values of the input data source change
 void AM2DAdditionAB::onInputSourceValuesChanged(const AMnDIndex& start, const AMnDIndex& end)
 {
-	emitValuesChanged(start, end);
+    cacheUpdateRequired_ = true;
+    emitValuesChanged(start, end);
 }
 
 // Connected to be called when the size of the input source changes
@@ -153,6 +141,8 @@ void AM2DAdditionAB::onInputSourceSizeChanged()
 		axes_[1].size = sources_.at(0)->size(1);
 		emitSizeChanged(1);
 	}
+
+    cacheUpdateRequired_ = true;
 }
 
 // Connected to be called when the state() flags of any input source change
@@ -243,4 +233,28 @@ void AM2DAdditionAB::reviewState()
 		setState(0);
 	else
 		setState(AMDataSource::InvalidFlag);
+}
+
+void AM2DAdditionAB::computeCachedValues() const
+{
+    AMnDIndex start = AMnDIndex(0, 0);
+    AMnDIndex end = size();
+    int totalSize = start.totalPointsTo(end);
+
+    QVector<double> data = QVector<double>(totalSize);
+    sources_.at(0)->values(start, end, data.data());
+
+    // Do the first data source separately to initialize the values.
+    cachedData_ = data;
+
+    // Iterate through the rest of the sources.
+    for (int i = 1, count = sources_.size(); i < count; i++){
+
+        sources_.at(i)->values(start, end, data.data());
+
+        for (int j = 0; j < totalSize; j++)
+            cachedData_[j] += data.at(j);
+    }
+
+    cacheUpdateRequired_ = false;
 }

--- a/source/analysis/AM2DAdditionAB.h
+++ b/source/analysis/AM2DAdditionAB.h
@@ -76,6 +76,14 @@ protected:
 	virtual void setInputDataSourcesImplementation(const QList<AMDataSource*>& dataSources);
 	/// Helper function to look at our overall situation and determine what the output state should be.
 	void reviewState();
+
+    /// Computes the cached data for access getters value() and values().
+    void computeCachedValues() const;
+
+    /// Flag for knowing whether we need to compute the values.
+    mutable bool cacheUpdateRequired_;
+    /// The vector holding the data.
+    mutable QVector<double> cachedData_;
 };
 
 #endif // AM2DADDITIONAB_H

--- a/source/analysis/AM2DNormalizationAB.cpp
+++ b/source/analysis/AM2DNormalizationAB.cpp
@@ -30,6 +30,7 @@ AM2DNormalizationAB::AM2DNormalizationAB(const QString &outputName, QObject *par
 	canAnalyze_ = false;
 	dataName_ = "";
 	normalizationName_ = "";
+    cacheUpdateRequired_ = false;
 	axes_ << AMAxisInfo("invalid", 0, "No input data") << AMAxisInfo("invalid", 0, "No input data");
 	setState(AMDataSource::InvalidFlag);
 }
@@ -102,6 +103,9 @@ void AM2DNormalizationAB::setInputSources()
 		axes_[0] = data_->axisInfoAt(0);
 		axes_[1] = data_->axisInfoAt(1);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size().product());
+
 		setDescription(QString("Normalized %1 map").arg(data_->name()));
 
 		connect(data_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -125,12 +129,37 @@ void AM2DNormalizationAB::setInputSources()
 
 	reviewState();
 
-	emitSizeChanged(0);
-	emitSizeChanged(1);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
-	emitAxisInfoChanged(1);
-	emitInfoChanged();
+    emitAxisInfoChanged();
+    emitInfoChanged();
+}
+
+void AM2DNormalizationAB::computeCachedValues() const
+{
+    AMnDIndex start = AMnDIndex(0, 0);
+    AMnDIndex end = size()-1;
+    int totalSize = start.totalPointsTo(end);
+
+    QVector<double> data = QVector<double>(totalSize);
+    QVector<double> normalizer = QVector<double>(totalSize);
+
+    data_->values(start, end, data.data());
+    normalizer_->values(start, end, normalizer.data());
+
+    for (int i = 0; i < totalSize; i++){
+
+        if (normalizer.at(i) == 0)
+            cachedData_[i] = 0;
+
+        else if (normalizer.at(i) < 0 || data.at(i) == -1)
+            cachedData_[i] = -1;
+
+        else
+            cachedData_[i] = data.at(i)/normalizer.at(i);
+    }
+
+    cacheUpdateRequired_ = false;
 }
 
 bool AM2DNormalizationAB::canAnalyze(const QString &dataName, const QString &normalizationName) const
@@ -160,15 +189,10 @@ AMNumber AM2DNormalizationAB::value(const AMnDIndex &indexes) const
 		return AMNumber(AMNumber::OutOfBoundsError);
 #endif
 
-	// Can't divide by zero.
-	if (double(normalizer_->value(indexes)) == 0)
-		return 0;
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	// The normalizer must be positive.
-	if (double(normalizer_->value(indexes)) < 0)
-		return -1;
-
-	return double(data_->value(indexes))/double(normalizer_->value(indexes));
+    return cachedData_.at(indexes.i()*size(1)+indexes.j());
 }
 
 bool AM2DNormalizationAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
@@ -185,27 +209,13 @@ bool AM2DNormalizationAB::values(const AMnDIndex &indexStart, const AMnDIndex &i
 		return false;
 #endif
 
-	int totalSize = indexStart.totalPointsTo(indexEnd);
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	QVector<double> data = QVector<double>(totalSize);
-	QVector<double> normalizer = QVector<double>(totalSize);
+    int totalSize = indexStart.totalPointsTo(indexEnd);
+    memcpy(outputValues, cachedData_.constData()+indexStart.i()*size(1), totalSize*sizeof(double));
 
-	data_->values(indexStart, indexEnd, data.data());
-	normalizer_->values(indexStart, indexEnd, normalizer.data());
-
-	for (int i = 0; i < totalSize; i++){
-
-		if (normalizer.at(i) == 0)
-			outputValues[i] = 0;
-
-		else if (normalizer.at(i) < 0 || data.at(i) == -1)
-			outputValues[i] = -1;
-
-		else
-			outputValues[i] = data.at(i)/normalizer.at(i);
-	}
-
-	return true;
+    return true;
 }
 
 AMNumber AM2DNormalizationAB::axisValue(int axisNumber, int index) const
@@ -238,22 +248,18 @@ bool AM2DNormalizationAB::axisValues(int axisNumber, int startIndex, int endInde
 
 void AM2DNormalizationAB::onInputSourceValuesChanged(const AMnDIndex& start, const AMnDIndex& end)
 {
+    cacheUpdateRequired_ = true;
 	emitValuesChanged(start, end);
 }
 
 void AM2DNormalizationAB::onInputSourceSizeChanged()
 {
-	if(axes_.at(0).size != data_->size(0)){
+    axes_[0].size = data_->size(0);
+    axes_[1].size = data_->size(1);
 
-		axes_[0].size = data_->size(0);
-		emitSizeChanged(0);
-	}
-
-	if(axes_.at(1).size != data_->size(1)){
-
-		axes_[1].size = data_->size(1);
-		emitSizeChanged(1);
-	}
+    cacheUpdateRequired_ = true;
+    cachedData_ = QVector<double>(size().product());
+    emitSizeChanged();
 }
 
 void AM2DNormalizationAB::onInputSourceStateChanged() {
@@ -303,6 +309,9 @@ void AM2DNormalizationAB::setInputDataSourcesImplementation(const QList<AMDataSo
 		axes_[0] = data_->axisInfoAt(0);
 		axes_[1] = data_->axisInfoAt(1);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size().product());
+
 		setDescription(QString("Normalized %1 map").arg(data_->name()));
 
 		connect(data_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -321,11 +330,9 @@ void AM2DNormalizationAB::setInputDataSourcesImplementation(const QList<AMDataSo
 
 	reviewState();
 
-	emitSizeChanged(0);
-	emitSizeChanged(1);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
-	emitAxisInfoChanged(1);
+    emitAxisInfoChanged();
 	emitInfoChanged();
 }
 

--- a/source/analysis/AM2DNormalizationAB.h
+++ b/source/analysis/AM2DNormalizationAB.h
@@ -109,6 +109,9 @@ protected:
 	/// Helper method that sets the data_ and normalizer_ pointer to the correct data source based on the current state of analyzedName_.
 	void setInputSources();
 
+    /// Computes the cached data for access getters value() and values().
+    void computeCachedValues() const;
+
 	/// Pointer to the data source that will be analyzed.
 	AMDataSource *data_;
 	/// Pointer to the data source that is the normalizer.
@@ -120,6 +123,11 @@ protected:
 	QString normalizationName_;
 	/// Flag holding whether or not the data source can be analyzed.
 	bool canAnalyze_;
+
+    /// Flag for knowing whether we need to compute the values.
+    mutable bool cacheUpdateRequired_;
+    /// The vector holding the data.
+    mutable QVector<double> cachedData_;
 };
 
 #endif // AM2DNORMALIZATIONAB_H

--- a/source/dataman/datasource/AMDataSourceImageData.cpp
+++ b/source/dataman/datasource/AMDataSourceImageData.cpp
@@ -26,8 +26,6 @@ AMDataSourceImageData::AMDataSourceImageData(QObject* parent)
 {
 	source_ = 0;
 	updateCacheRequired_ = true;
-	dirtyRectBottomLeft_ = AMnDIndex();
-	dirtyRectTopRight_ = AMnDIndex();
 }
 
 AMDataSourceImageData::~AMDataSourceImageData()
@@ -145,35 +143,9 @@ void AMDataSourceImageData::onAxisValuesChanged(int axisId)
 
 void AMDataSourceImageData::onDataChanged(const AMnDIndex &start, const AMnDIndex &end)
 {
+    Q_UNUSED(start)
+    Q_UNUSED(end)
 	updateCacheRequired_ = true;
-
-	AMnDIndex dirtyStartIndex = start.isValid() ? start : AMnDIndex(0, 0);
-	AMnDIndex dirtyEndIndex = end.isValid() ? end : AMnDIndex(xSize_-1, ySize_-1);
-
-	if (!dirtyRectBottomLeft_.isValid())
-		dirtyRectBottomLeft_ = AMnDIndex(dirtyStartIndex.i(), dirtyStartIndex.j());
-
-	else {
-
-		if (dirtyRectBottomLeft_.i() > dirtyStartIndex.i())
-			dirtyRectBottomLeft_[0] = dirtyStartIndex.i();
-
-		if (dirtyRectBottomLeft_.j() > dirtyStartIndex.j())
-			dirtyRectBottomLeft_[1] = dirtyStartIndex.j();
-	}
-
-	if (!dirtyRectTopRight_.isValid())
-		dirtyRectTopRight_ = AMnDIndex(dirtyEndIndex.i(), dirtyEndIndex.j());
-
-	else {
-
-		if (dirtyRectTopRight_.i() < dirtyEndIndex.i())
-			dirtyRectTopRight_[0] = dirtyEndIndex.i();
-
-		if (dirtyRectTopRight_.j() < dirtyEndIndex.j())
-			dirtyRectTopRight_[1] = dirtyEndIndex.j();
-	}
-
 	emitDataChanged();
 }
 
@@ -268,18 +240,18 @@ MPlotRange AMDataSourceImageData::range() const
 
 void AMDataSourceImageData::updateCachedValues() const
 {
-	QVector<double> newData = QVector<double>(dirtyRectBottomLeft_.totalPointsTo(dirtyRectTopRight_));
+    AMnDIndex start = AMnDIndex(0, 0);
+    AMnDIndex end = AMnDIndex(xSize_-1, ySize_-1);
+    QVector<double> newData = QVector<double>(start.totalPointsTo(end));
 
-	if (source_->values(dirtyRectBottomLeft_, dirtyRectTopRight_, newData.data())){
+    if (source_->values(start, end, newData.data())){
 
-		int iOffset = dirtyRectBottomLeft_.i()*ySize_;
-		int jOffset = dirtyRectBottomLeft_.j();
 		double rangeMinimum = newData.first();
 		double rangeMaximum = newData.first();
 
-		for (int j = 0, jSize = dirtyRectTopRight_.j()-dirtyRectBottomLeft_.j()+1; j < jSize; j++){
+        for (int j = 0, jSize = end.j()-start.j()+1; j < jSize; j++){
 
-			for (int i = 0, iSize = dirtyRectTopRight_.i()-dirtyRectBottomLeft_.i()+1; i < iSize; i++){
+            for (int i = 0, iSize = end.i()-start.i()+1; i < iSize; i++){
 
 				double newValue = newData.at(i*jSize+j);
 
@@ -289,25 +261,11 @@ void AMDataSourceImageData::updateCachedValues() const
 				if (newValue < rangeMinimum)
 					rangeMinimum = newValue;
 
-				data_[i*ySize_ + iOffset + j + jOffset] = newValue;
+                data_[i*ySize_ + j] = newValue;
 			}
 		}
 
-		// The default range is invalid.
-		if (range_.isNull() || dirtyRectBottomLeft_.totalPointsTo(dirtyRectTopRight_) == xSize_*ySize_)
-			range_ = MPlotRange(rangeMinimum, rangeMaximum);
-
-		else {
-
-			if (range_.x() > rangeMinimum)
-				range_.setX(rangeMinimum);
-
-			if (range_.y() < rangeMaximum)
-				range_.setY(rangeMaximum);
-		}
-
-		dirtyRectBottomLeft_ = AMnDIndex();
-		dirtyRectTopRight_ = AMnDIndex();
+        range_ = MPlotRange(rangeMinimum, rangeMaximum);
 		updateCacheRequired_ = false;
 	}
 }

--- a/source/dataman/datasource/AMDataSourceImageData.cpp
+++ b/source/dataman/datasource/AMDataSourceImageData.cpp
@@ -123,18 +123,18 @@ void AMDataSourceImageData::onAxisValuesChanged(int axisId)
 {
 	if (axisId == -1){
 
-        source_->axisValues(0, 0, xSize_-1, xAxis_.data());
-        source_->axisValues(1, 0, ySize_-1, yAxis_.data());
+		source_->axisValues(0, 0, xSize_-1, xAxis_.data());
+		source_->axisValues(1, 0, ySize_-1, yAxis_.data());
 	}
 
 	else if (axisId == 0){
 
-        source_->axisValues(0, 0, xSize_-1, xAxis_.data());
+		source_->axisValues(0, 0, xSize_-1, xAxis_.data());
 	}
 
 	else if (axisId == 1) {
 
-        source_->axisValues(1, 0, ySize_-1, yAxis_.data());
+		source_->axisValues(1, 0, ySize_-1, yAxis_.data());
 	}
 
 	recomputeBoundingRect(axisId);

--- a/source/dataman/datasource/AMDataSourceImageData.cpp
+++ b/source/dataman/datasource/AMDataSourceImageData.cpp
@@ -218,28 +218,22 @@ void AMDataSourceImageData::updateCachedValues() const
 {
     AMnDIndex start = AMnDIndex(0, 0);
     AMnDIndex end = AMnDIndex(xSize_-1, ySize_-1);
-    QVector<double> newData = QVector<double>(start.totalPointsTo(end));
 
-    if (source_->values(start, end, newData.data())){
+    if (source_->values(start, end, data_.data())){
 
-		double rangeMinimum = newData.first();
-		double rangeMaximum = newData.first();
+        double rangeMinimum = data_.first();
+        double rangeMaximum = data_.first();
 
-        for (int j = 0, jSize = end.j()-start.j()+1; j < jSize; j++){
+        for (int i = 0, size = data_.size(); i < size; i++){
 
-            for (int i = 0, iSize = end.i()-start.i()+1; i < iSize; i++){
+            double newValue = data_.at(i);
 
-				double newValue = newData.at(i*jSize+j);
+            if (newValue > rangeMaximum)
+                rangeMaximum = newValue;
 
-				if (newValue > rangeMaximum)
-					rangeMaximum = newValue;
-
-				if (newValue < rangeMinimum)
-					rangeMinimum = newValue;
-
-                data_[i*ySize_ + j] = newValue;
-			}
-		}
+            if (newValue < rangeMinimum)
+                rangeMinimum = newValue;
+        }
 
         range_ = MPlotRange(rangeMinimum, rangeMaximum);
 		updateCacheRequired_ = false;

--- a/source/dataman/datasource/AMDataSourceImageData.cpp
+++ b/source/dataman/datasource/AMDataSourceImageData.cpp
@@ -137,7 +137,7 @@ void AMDataSourceImageData::onAxisValuesChanged(int axisId)
 		source_->axisValues(1, 0, ySize_-1, yAxis_.data());
 	}
 
-	recomputeBoundingRect(axisId);
+    recomputeBoundingRect();
 	emitBoundsChanged();
 }
 
@@ -176,7 +176,7 @@ void AMDataSourceImageData::onSizeChanged(int axisId)
 	onDataChanged(AMnDIndex(0,0), AMnDIndex(xSize_-1, ySize_-1));
 }
 
-void AMDataSourceImageData::recomputeBoundingRect(int axisId)
+void AMDataSourceImageData::recomputeBoundingRect()
 {
 	if(!isValid_)
 		boundingRect_ = QRectF();
@@ -184,7 +184,7 @@ void AMDataSourceImageData::recomputeBoundingRect(int axisId)
 	if(xSize_ == 0 || ySize_ == 0)
 		boundingRect_ = QRectF();
 
-	else if (axisId == -1){
+    else {
 
 		double minimumX = xAxis_.at(0);
 		double maximumX = xAxis_.at(xSize_-1);
@@ -198,30 +198,6 @@ void AMDataSourceImageData::recomputeBoundingRect(int axisId)
 			qSwap(minimumY, maximumY);
 
 		boundingRect_ = QRectF(minimumX, minimumY, maximumX-minimumX, maximumY-minimumY);
-	}
-
-	else if (axisId == 0){
-
-		double minimumX = xAxis_.at(0);
-		double maximumX = xAxis_.at(xSize_-1);
-
-		if(maximumX < minimumX)
-			qSwap(minimumX, maximumX);
-
-		boundingRect_.setX(minimumX);
-		boundingRect_.setWidth(maximumX-minimumX);
-	}
-
-	else if (axisId == 1){
-
-		double minimumY = yAxis_.at(0);
-		double maximumY = yAxis_.at(ySize_-1);
-
-		if(maximumY < minimumY)
-			qSwap(minimumY, maximumY);
-
-		boundingRect_.setY(minimumY);
-		boundingRect_.setHeight(maximumY-minimumY);
 	}
 }
 

--- a/source/dataman/datasource/AMDataSourceImageData.h
+++ b/source/dataman/datasource/AMDataSourceImageData.h
@@ -73,7 +73,7 @@ protected slots:
 	/// Handles updating the size of the given axis.  Will invalidate the axis values of that axis.
 	void onSizeChanged(int axisId);
 	/// Recomputes the bounding rect. Called if the size or axis values change.  Only updates the corresponding size if specified.
-	void recomputeBoundingRect(int axisId);
+    void recomputeBoundingRect();
 
 	/// ensure that we don't keep trying to read data from a source that has been deleted.
 	void onDataSourceDeleted();

--- a/source/dataman/datasource/AMDataSourceImageData.h
+++ b/source/dataman/datasource/AMDataSourceImageData.h
@@ -99,13 +99,8 @@ protected:
 	QVector<double> yAxis_;
 	/// The cached z-values.
 	mutable QVector<double> data_;
-
 	/// Flag used for knowing when to recache the data in the model.
-	mutable bool updateCacheRequired_;
-	/// QPoint that defines the bottom left point of the dirty data.
-	mutable AMnDIndex dirtyRectBottomLeft_;
-	/// QPoint that defines the top right point of the dirty data.
-	mutable AMnDIndex dirtyRectTopRight_;
+    mutable bool updateCacheRequired_;
 };
 
 

--- a/source/dataman/datasource/AMDataSourceImageDatawDefault.cpp
+++ b/source/dataman/datasource/AMDataSourceImageDatawDefault.cpp
@@ -39,19 +39,18 @@ void AMDataSourceImageDatawDefault::setDefaultValue(double value)
 
 void AMDataSourceImageDatawDefault::updateCachedValues() const
 {
-	dirtyRectBottomLeft_ = AMnDIndex(0,0);
-	QVector<double> newData = QVector<double>(dirtyRectBottomLeft_.totalPointsTo(dirtyRectTopRight_));
+    AMnDIndex start = AMnDIndex(0, 0);
+    AMnDIndex end = AMnDIndex(xSize_-1, ySize_-1);
+    QVector<double> newData = QVector<double>(start.totalPointsTo(end));
 
-	if (source_->values(dirtyRectBottomLeft_, dirtyRectTopRight_, newData.data())){
+    if (source_->values(start, end, newData.data())){
 
-		int iOffset = dirtyRectBottomLeft_.i()*ySize_;
-		int jOffset = dirtyRectBottomLeft_.j();
 		double rangeMinimum = newData.first();
 		double rangeMaximum = newData.first();
 
-		for (int j = 0, jSize = dirtyRectTopRight_.j()-dirtyRectBottomLeft_.j()+1; j < jSize; j++){
+        for (int j = 0, jSize = end.j()-start.j()+1; j < jSize; j++){
 
-			for (int i = 0, iSize = dirtyRectTopRight_.i()-dirtyRectBottomLeft_.i()+1; i < iSize; i++){
+            for (int i = 0, iSize = end.i()-start.i()+1; i < iSize; i++){
 
 				double newValue = newData.at(i*jSize+j);
 
@@ -61,25 +60,11 @@ void AMDataSourceImageDatawDefault::updateCachedValues() const
 				if (newValue < rangeMinimum && newValue != defaultValue_)
 					rangeMinimum = newValue;
 
-				data_[i*ySize_ + iOffset + j + jOffset] = newValue;
+                data_[i*ySize_ + j] = newValue;
 			}
 		}
 
-		// The default range is invalid.
-		if (range_.isNull() && rangeMinimum != defaultValue_ && rangeMaximum != defaultValue_)
-			range_ = MPlotRange(rangeMinimum, rangeMaximum);
-
-		else {
-
-			if (range_.x() > rangeMinimum && rangeMinimum != defaultValue_)
-				range_.setX(rangeMinimum);
-
-			if (range_.y() < rangeMaximum && rangeMaximum != defaultValue_)
-				range_.setY(rangeMaximum);
-		}
-
-		dirtyRectBottomLeft_ = AMnDIndex();
-		dirtyRectTopRight_ = AMnDIndex();
+        range_ = MPlotRange(rangeMinimum, rangeMaximum);
 		updateCacheRequired_ = false;
 	}
 }


### PR DESCRIPTION
Implemented caching on the commonly used analysis blocks as well as the MPlot-AM data handlers.  

@iainworkman, you will notice that AM3DAdditionAB has some changes in it here as well.  It isn't that we missed anything in the original pull request, but certain behaviours only became apparent when updating the data on a 1 point at a time basis, which is untestable for data sources of rank 3.