### PR TITLE
Pull Request for Issue1572: Implement caching in commonly used 1D data sources and analysis blocks

### DIFF
--- a/source/analysis/AM1DCalibrationAB.cpp
+++ b/source/analysis/AM1DCalibrationAB.cpp
@@ -405,7 +405,7 @@ bool AM1DCalibrationAB::values(const AMnDIndex &indexStart, const AMnDIndex &ind
         computeCachedValues();
 
     int totalSize = indexStart.totalPointsTo(indexEnd);
-    memcpy(outputValues, cachedData_.constData()+indexStart.i()*size(1), totalSize*sizeof(double));
+    memcpy(outputValues, cachedData_.constData()+indexStart.i(), totalSize*sizeof(double));
 
 	return true;
 }

--- a/source/analysis/AM1DCalibrationAB.cpp
+++ b/source/analysis/AM1DCalibrationAB.cpp
@@ -353,14 +353,14 @@ void AM1DCalibrationAB::computeCachedValues() const
     cacheUpdateRequired_ = false;
 }
 
-bool AM1DCalibrationAB::canAnalyze(const QString &dataName, const QString &NormalizationName) const
+bool AM1DCalibrationAB::canAnalyze(const QString &dataName, const QString &normalizationName) const
 {
 	// Can always analyze two 1D data sources.
 	if (sources_.count() == 2)
 		return true;
 
-	// The first data source is reserved for the data.
-	if (indexOfInputSource(dataName) >= 0 && indexOfInputSource(NormalizationName))
+	// Both data and normalization names must correspond to valid data sources.
+	if (indexOfInputSource(dataName) >= 0 && indexOfInputSource(normalizationName))
 		return true;
 
 	return false;

--- a/source/analysis/AM1DCalibrationAB.cpp
+++ b/source/analysis/AM1DCalibrationAB.cpp
@@ -31,7 +31,8 @@ AM1DCalibrationAB::AM1DCalibrationAB(const QString &outputName, QObject *parent)
 	canAnalyze_ = false;
 	dataName_ = "";
 	normalizationName_ = "";
-	axes_ << AMAxisInfo("invalid", 0, "No input data");
+    cacheUpdateRequired_ = false;
+    axes_ << AMAxisInfo("invalid", 0, "No input data");
 	setState(AMDataSource::InvalidFlag);
 
 	energyCalibrationOffset_ = 0;
@@ -89,8 +90,9 @@ void AM1DCalibrationAB::setEnergyCalibrationOffset(double offset)
 	if(offset == energyCalibrationOffset_)
 		return;
 	energyCalibrationOffset_ = offset;
-	emitSizeChanged(0);
-	setModified(true);
+    cacheUpdateRequired_ = true;
+    setModified(true);
+    emitSizeChanged();
 	emitValuesChanged();
 }
 
@@ -100,8 +102,9 @@ void AM1DCalibrationAB::setEnergyCalibrationScaling(double scaling)
 		return;
 
 	energyCalibrationScaling_ = scaling;
-	emitSizeChanged(0);
-	setModified(true);
+    cacheUpdateRequired_ = true;
+    setModified(true);
+    emitSizeChanged();
 	emitValuesChanged();
 }
 
@@ -111,8 +114,9 @@ void AM1DCalibrationAB::setEnergyCalibrationReference(double reference)
 		return;
 
 	energyCalibrationReference_ = reference;
-	emitSizeChanged(0);
-	setModified(true);
+    cacheUpdateRequired_ = true;
+    setModified(true);
+    emitSizeChanged();
 	emitValuesChanged();
 }
 
@@ -122,6 +126,7 @@ void AM1DCalibrationAB::setIsTransmission(bool isTransmission)
 		return;
 
 	isTransmission_ = isTransmission;
+    cacheUpdateRequired_ = true;
 	setModified(true);
 	emitValuesChanged();
 }
@@ -133,6 +138,7 @@ void AM1DCalibrationAB::setToEdgeJump(bool toEdgeJump)
 		return;
 
 	toEdgeJump_ = toEdgeJump;
+    cacheUpdateRequired_ = true;
 	setModified(true);
 	emitValuesChanged();
 }
@@ -143,6 +149,7 @@ void AM1DCalibrationAB::setPreEdgePoint(int preEdgePoint)
 		return;
 
 	preEdgePoint_ = preEdgePoint;
+    cacheUpdateRequired_ = true;
 	setModified(true);
 	emitValuesChanged();
 }
@@ -153,6 +160,7 @@ void AM1DCalibrationAB::setPostEdgePoint(int postEdgePoint)
 		return;
 
 	postEdgePoint_ = postEdgePoint;
+    cacheUpdateRequired_ = true;
 	setModified(true);
 	emitValuesChanged();
 }
@@ -186,6 +194,9 @@ void AM1DCalibrationAB::setInputSources()
 
 		axes_[0] = data_->axisInfoAt(0);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size().product());
+
 		setDescription(QString("Normalized %1").arg(data_->name()));
 
 		connect(data_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -208,10 +219,138 @@ void AM1DCalibrationAB::setInputSources()
 
 	reviewState();
 
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
+    emitAxisInfoChanged();
 	emitInfoChanged();
+}
+
+void AM1DCalibrationAB::computeCachedValues() const
+{
+    AMnDIndex start = AMnDIndex(0);
+    AMnDIndex end = size()-1;
+    int totalSize = start.totalPointsTo(end);
+    int totalPoints = size(0);
+
+    QVector<double> data = QVector<double>(totalSize);
+    QVector<double> normalizer = QVector<double>(totalSize);
+
+    data_->values(start, end, data.data());
+    normalizer_->values(start, end, normalizer.data());
+
+    cachedData_ = QVector<double>(totalSize);
+
+    for (int i = 0; i < totalSize; i++){
+
+        if(isTransmission()){
+
+            if (data.at(i) == 0) // don't divide by zero
+                cachedData_[i] = 0;
+
+            else if (normalizer.at(i) * data.at(i) < 0)  //Don't take the log of a negative number
+                cachedData_[i] = 0;
+
+            else
+                cachedData_[i] = qLn(normalizer.at(i)/data.at(i));
+        }
+        else{
+
+            if (normalizer.at(i) == 0)  // don't divide by zero
+                cachedData_[i] = 0;
+
+            else if (normalizer.at(i) < 0) // Not sure, I didn't put it here (DM)
+                cachedData_[i] = -1;
+
+            else
+                cachedData_[i] = data.at(i)/normalizer.at(i);
+        }
+    }
+
+    if (toEdgeJump_){
+
+        int preEdgePointValue = 0;
+        int postEdgePointValue = 0;
+
+        // Determine a safe preEdgePoint
+        if ((preEdgePoint_ < 0) || (preEdgePoint_ > (totalPoints-1))){
+
+            preEdgePointValue = 0;
+
+            if(totalPoints > 1)
+                preEdgePointValue = 1; // Don't use the first point by default, because it's too-often bad.
+        }
+
+        else
+            preEdgePointValue = preEdgePoint_;
+
+        // Determine a safe postEdgePoint
+        if ((postEdgePoint() < 0) || (postEdgePoint() > (totalPoints-1)))
+            postEdgePointValue = totalPoints - 1;
+
+        else
+            postEdgePointValue = postEdgePoint_;
+
+        // determine value of desired offset reference point, this is ugly because it must handle the case that the reference point is outside the requested index range for all modes...
+        double offset = 0;
+
+        if (isTransmission()){
+
+            if (data.at(preEdgePointValue) == 0) // don't divide by zero
+                offset = 0;
+
+            else if (normalizer.at(preEdgePointValue) * data.at(preEdgePointValue) < 0)  //Don't take the log of a negative number
+                offset = 0;
+
+            else
+                offset = qLn(normalizer.at(preEdgePointValue)/data.at(preEdgePointValue));
+        }
+
+        else{
+
+            if (normalizer.at(preEdgePointValue) == 0)  // don't divide by zero
+                offset = 0;
+
+            else
+                offset = data.at(preEdgePointValue)/normalizer.at(preEdgePointValue);
+        }
+
+        // shift spectra so that pre edge reference point is 0
+        for (int i = 0; i < totalSize; i++)
+            cachedData_[i] -= offset;
+
+        // determine value of post edge scaling reference point, this is ugly because it must handle the case that the reference point is outside the requested index range for all modes...
+        double scale = 1;
+
+        if (isTransmission()){
+
+            if (data.at(postEdgePointValue) == 0) // don't divide by zero
+                scale = 1;
+
+            else if (normalizer.at(postEdgePointValue) * data.at(postEdgePointValue) < 0)  //Don't take the log of a negative number
+                scale = 1;
+
+            else
+                scale = qLn(normalizer.at(postEdgePointValue)/data.at(postEdgePointValue)) - offset;
+        }
+
+        else{
+
+            if (normalizer.at(postEdgePointValue) == 0)  // don't divide by zero
+                scale = 1;
+
+            else
+                scale = (data.at(postEdgePointValue)/normalizer.at(postEdgePointValue)) - offset;
+        }
+
+        // scale spectra so that post edge reference point is 1
+        if (scale != 0){ // if the postEdgePoint is zero, do nothing, otherwise scale and shift the output values
+
+            for (int i = 0; i < totalSize; i++)
+                cachedData_[i] /= scale;
+        }
+    }
+
+    cacheUpdateRequired_ = false;
 }
 
 bool AM1DCalibrationAB::canAnalyze(const QString &dataName, const QString &NormalizationName) const
@@ -227,13 +366,6 @@ bool AM1DCalibrationAB::canAnalyze(const QString &dataName, const QString &Norma
 	return false;
 }
 
-
-
-
-
-
-
-
 AMNumber AM1DCalibrationAB::value(const AMnDIndex &indexes) const
 {
 	if (indexes.rank() != 1)
@@ -247,74 +379,11 @@ AMNumber AM1DCalibrationAB::value(const AMnDIndex &indexes) const
 			return AMNumber(AMNumber::OutOfBoundsError);
 #endif
 
+        if (cacheUpdateRequired_)
+            computeCachedValues();
 
-	double retVal;
-	int totalPoints = data_->size(0);
-
-
-	if(isTransmission_)
-	{
-		if (double(normalizer_->value(indexes)) == 0)
-				retVal = 0;
-
-		else if (double(normalizer_->value(indexes)) * double(data_->value(indexes)) < 0)  //Don't take the log of a negative number
-			retVal = 0;
-
-		else
-			retVal = qLn(double(normalizer_->value(indexes))/double(data_->value(indexes)));
-	}
-	else
-	{
-		if (double(normalizer_->value(indexes)) == 0)  // don't divide by zero
-			retVal = 0;
-
-		else if (double(normalizer_->value(indexes)) < 0) // Not sure, I didn't put it here (DM)
-			retVal = -1;
-
-		else
-			retVal = double(data_->value(indexes))/double(normalizer_->value(indexes));
-	}
-
-	if(toEdgeJump_)
-	{
-		int preEdgePointValue, postEdgePointValue;
-
-		// Determine a safe preEdgePoint
-		if(preEdgePoint() < 0 or preEdgePoint() > totalPoints -1)
-		{
-			preEdgePointValue = 0;
-			if(totalPoints > 1)  preEdgePointValue = 1; //Don't use the first point by defualt, because it's too-often bad.
-		}
-		else
-			preEdgePointValue = preEdgePoint();
-
-		// Determine a safe totalPoints
-		if(postEdgePoint() < 0 or postEdgePoint() > totalPoints -1)
-			postEdgePointValue = totalPoints - 1;
-		else
-			postEdgePointValue = postEdgePoint();
-
-		// determine value of desired offset reference point
-		double offset = int(data_->value(preEdgePointValue));
-		// shift spectra so that pre edge reference point is 0
-			retVal = retVal - offset;
-
-		// determine value of post edge scaling reference point
-		double scale = data_->value(postEdgePointValue);
-		// scale spectra so that post edge reference point is 1
-		if (scale != 0){ // if the postEdgePoint is zero, do nothing, otherwise scale and shift the output values
-			retVal = retVal / scale;
-
-		}
-	}
-	return retVal;
+        return cachedData_.at(indexes.i());
 }
-
-
-
-
-
-
 
 bool AM1DCalibrationAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
 {
@@ -332,120 +401,11 @@ bool AM1DCalibrationAB::values(const AMnDIndex &indexStart, const AMnDIndex &ind
 		return false;
 #endif
 
-	int totalSize = indexStart.totalPointsTo(indexEnd);
-	int totalPoints = data_->size(0);
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	QVector<double> data = QVector<double>(totalSize);
-	QVector<double> normalizer = QVector<double>(totalSize);
-
-	data_->values(indexStart, indexEnd, data.data());
-	normalizer_->values(indexStart, indexEnd, normalizer.data());
-
-	for (int i = 0; i < totalSize; i++){
-
-		if(isTransmission())
-		{
-			if (data.at(i) == 0) // don't divide by zero
-				outputValues[i] = 0;
-
-			else if (normalizer.at(i) * data.at(i) < 0)  //Don't take the log of a negative number
-				outputValues[i] = 0;
-
-			else
-				outputValues[i] = qLn(normalizer.at(i)/data.at(i));
-		}
-		else
-		{
-			if (normalizer.at(i) == 0)  // don't divide by zero
-				outputValues[i] = 0;
-
-			else if (normalizer.at(i) < 0) // Not sure, I didn't put it here (DM)
-				outputValues[i] = -1;
-
-			else
-				outputValues[i] = data.at(i)/normalizer.at(i);
-		}
-	}
-
-	if(toEdgeJump_)
-	{
-		int preEdgePointValue, postEdgePointValue;
-
-		// Determine a safe preEdgePoint
-		if(preEdgePoint_ < 0 or preEdgePoint_ > totalPoints -1)
-		{
-			preEdgePointValue = 0;
-			if(totalPoints > 1)  preEdgePointValue = 1; //Don't use the first point by defualt, because it's too-often bad.
-		}
-		else
-			preEdgePointValue = preEdgePoint_;
-
-		// Determine a safe postEdgePoint
-		if(postEdgePoint() < 0 or postEdgePoint() > totalPoints -1)
-			postEdgePointValue = totalPoints - 1;
-		else
-			postEdgePointValue = postEdgePoint_;
-
-		// determine value of desired offset reference point, this is ugly because it must handle the case that the reference point is outside the requested index range for all modes...
-		double offset;
-		if(isTransmission())
-		{
-			if (double(data_->value(preEdgePointValue)) == 0) // don't divide by zero
-				offset = 0;
-
-			else if (double(normalizer_->value(preEdgePointValue)) * double(data_->value(preEdgePointValue)) < 0)  //Don't take the log of a negative number
-				offset = 0;
-
-			else
-				offset = qLn(double(normalizer_->value(preEdgePointValue))/double(data_->value(preEdgePointValue)));
-		}
-		else
-		{
-			if (double(normalizer_->value(preEdgePointValue)) == 0)  // don't divide by zero
-				offset = 0;
-			else
-				offset = double(data_->value(preEdgePointValue))/double(normalizer_->value(preEdgePointValue));
-		}
-
-
-
-		// shift spectra so that pre edge reference point is 0
-		for (int i = 0; i < totalSize; i++)
-			outputValues[i] = outputValues[i] - offset;
-
-		// determine value of post edge scaling reference point, this is ugly because it must handle the case that the reference point is outside the requested index range for all modes...
-		double scale;
-		if(isTransmission())
-		{
-			if (double(data_->value(postEdgePointValue)) == 0) // don't divide by zero
-				scale = 1;
-
-			else if (double(normalizer_->value(postEdgePointValue)) * double(data_->value(postEdgePointValue)) < 0)  //Don't take the log of a negative number
-				scale = 1;
-
-			else
-				scale = qLn(double(normalizer_->value(postEdgePointValue))/double(data_->value(postEdgePointValue))) - offset;
-		}
-		else
-		{
-			if (double(normalizer_->value(postEdgePointValue)) == 0)  // don't divide by zero
-				scale = 1;
-
-			else
-				scale = (double(data_->value(postEdgePointValue))/double(normalizer_->value(postEdgePointValue))) - offset;
-		}
-
-
-		// scale spectra so that post edge reference point is 1
-		if (scale != 0){ // if the postEdgePoint is zero, do nothing, otherwise scale and shift the output values
-			for (int i = 0; i < totalSize; i++)
-			{
-				outputValues[i] = outputValues[i] / scale;
-			}
-		}
-	}
-
-
+    int totalSize = indexStart.totalPointsTo(indexEnd);
+    memcpy(outputValues, cachedData_.constData()+indexStart.i()*size(1), totalSize*sizeof(double));
 
 	return true;
 }
@@ -481,23 +441,23 @@ bool AM1DCalibrationAB::axisValues(int axisNumber, int startIndex, int endIndex,
 	data_->axisValues(axisNumber, startIndex, endIndex, axisData.data());
 
 	for (int i = 0; i < totalSize; i++)
-        outputValues[i] = double(axisData.at(i))*energyCalibrationScaling_ + energyCalibrationOffsetAndReference;
+        outputValues[i] = axisData.at(i)*energyCalibrationScaling_ + energyCalibrationOffsetAndReference;
 
 	return true;
 }
 
 void AM1DCalibrationAB::onInputSourceValuesChanged(const AMnDIndex& start, const AMnDIndex& end)
 {
+    cacheUpdateRequired_ = true;
 	emitValuesChanged(start, end);
 }
 
 void AM1DCalibrationAB::onInputSourceSizeChanged()
 {
-	if(axes_.at(0).size != data_->size(0)){
-
-		axes_[0].size = data_->size(0);
-		emitSizeChanged(0);
-	}
+    axes_[0].size = data_->size(0);
+    cacheUpdateRequired_ = true;
+    cachedData_ = QVector<double>(axes_.at(0).size);
+    emitSizeChanged();
 }
 
 void AM1DCalibrationAB::onInputSourceStateChanged() {
@@ -545,6 +505,9 @@ void AM1DCalibrationAB::setInputDataSourcesImplementation(const QList<AMDataSour
 
 		axes_[0] = data_->axisInfoAt(0);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size().product());
+
 		setDescription(QString("Normalized %1").arg(data_->name()));
 
 		connect(data_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -565,9 +528,9 @@ void AM1DCalibrationAB::setInputDataSourcesImplementation(const QList<AMDataSour
 
 
 	setModified(true);
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
+    emitAxisInfoChanged();
 	emitInfoChanged();
 }
 

--- a/source/analysis/AM1DCalibrationAB.h
+++ b/source/analysis/AM1DCalibrationAB.h
@@ -157,6 +157,9 @@ protected:
 	/// Helper method that sets the data_ and normalizer_ pointer to the correct data source based on the current state of analyzedName_.
 	void setInputSources();
 
+    /// Computes the cached data for access getters value() and values().
+    void computeCachedValues() const;
+
 	/// Pointer to the data source that will be analyzed.
 	AMDataSource *data_;
 	/// Pointer to the data source that is the normalizer.
@@ -185,6 +188,11 @@ protected:
 	QString normalizationName_;
 	/// Flag holding whether or not the data source can be analyzed.
 	bool canAnalyze_;
+
+    /// Flag for knowing whether we need to compute the values.
+    mutable bool cacheUpdateRequired_;
+    /// The vector holding the data.
+    mutable QVector<double> cachedData_;
 };
 
 #endif // AM1DCalibrationAB_H

--- a/source/analysis/AM1DDerivativeAB.cpp
+++ b/source/analysis/AM1DDerivativeAB.cpp
@@ -31,6 +31,7 @@ AM1DDerivativeAB::AM1DDerivativeAB(const QString &outputName, QObject *parent)
 	inputSource_ = 0;
 	analyzedName_ = "";
 	canAnalyze_ = false;
+    cacheUpdateRequired_ = false;
 
 	axes_ << AMAxisInfo("invalid", 0, "No input data");
 	setState(AMDataSource::InvalidFlag);
@@ -96,6 +97,9 @@ void AM1DDerivativeAB::setInputDataSourcesImplementation(const QList<AMDataSourc
 
 		axes_[0] = inputSource_->axisInfoAt(0);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size(0));
+
 		setDescription(QString("Derivative of %1").arg(inputSource_->name()));
 
 		connect(inputSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -111,9 +115,9 @@ void AM1DDerivativeAB::setInputDataSourcesImplementation(const QList<AMDataSourc
 
 	reviewState();
 
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
+    emitAxisInfoChanged();
 	emitInfoChanged();
 }
 
@@ -136,6 +140,10 @@ void AM1DDerivativeAB::setInputSource()
 		canAnalyze_ = true;
 
 		axes_[0] = inputSource_->axisInfoAt(0);
+
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size(0));
+
 		setDescription(QString("Derivative of %1").arg(inputSource_->name()));
 
 		connect(inputSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -153,10 +161,73 @@ void AM1DDerivativeAB::setInputSource()
 
 	reviewState();
 
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
-	emitInfoChanged();
+    emitAxisInfoChanged();
+    emitInfoChanged();
+}
+
+void AM1DDerivativeAB::computeCachedValues() const
+{
+    AMnDIndex start = AMnDIndex(0);
+    AMnDIndex end = size()-1;
+    int totalSize = start.totalPointsTo(end);
+
+    QVector<double> data = QVector<double>(totalSize);
+    QVector<double> axis = QVector<double>(totalSize);
+    AMAxisInfo axisInfo = inputSource_->axisInfoAt(0);
+
+    inputSource_->values(start, end, data.data());
+
+    // This is much faster because we can compute all the axis values ourselves rather than ask for them one at a time.
+    if (axisInfo.isUniform){
+
+        double axisStart = double(axisInfo.start);
+        double axisStep = double(axisInfo.increment);
+
+        for (int i = 0; i < totalSize; i++)
+            axis[i] = axisStart + i*axisStep;
+
+        // Because we computed the axis values we are guarenteed that the values won't be bad.
+        cachedData_[0] = (data.at(1)-data.at(0))/(axis.at(1)-axis.at(0));
+        cachedData_[totalSize-1] = (data.at(totalSize-1)-data.at(totalSize-2))/(axis.at(totalSize-1)-axis.at(totalSize-2));
+
+        for (int i = 1, count = totalSize-1; i < count; i++)
+            cachedData_[i] = (data.at(i+1)-data.at(i-1))/(2*(axis.at(i+1)-axis.at(i-1)));
+    }
+
+    else {
+
+        // Fill the axis vector.  Should minimize the overhead of making the same function calls and casting the values multiple times.
+        for (int i = 0; i < totalSize; i++)
+            axis[i] = double(inputSource_->axisValue(0, i));
+
+        // Fill a list of all the indices that will cause division by zero.
+        QList<int> badIndices;
+
+        if (axis.at(0) == axis.at(1))
+            badIndices.append(0);
+
+        for (int i = 1, count = totalSize-1; i < count; i++)
+            if (axis.at(i+1) == axis.at(i-1))
+                badIndices.append(i);
+
+        if (axis.at(totalSize-1) == axis.at(totalSize-2))
+            badIndices.append(totalSize-1);
+
+        // Compute all the values
+        cachedData_[0] = (data.at(1)-data.at(0))/(axis.at(1)-axis.at(0));
+        cachedData_[totalSize-1] = (data.at(totalSize-1)-data.at(totalSize-2))/(axis.at(totalSize-1)-axis.at(totalSize-2));
+
+        for (int i = 1, count = totalSize-1; i < count; i++)
+            cachedData_[i] = (data.at(i+1)-data.at(i-1))/(2*(axis.at(i+1)-axis.at(i-1)));
+
+        // Fix all the values where division by zero would have occured.  Unfortunately, the default value is currently 0, which is generally important when taking the derivative.
+        for (int i = 0, count = badIndices.size(); i < count; i++)
+            cachedData_[badIndices.at(i)] = 0;
+    }
+
+    cacheUpdateRequired_ = false;
 }
 
 bool AM1DDerivativeAB::canAnalyze(const QString &name) const
@@ -190,41 +261,10 @@ AMNumber AM1DDerivativeAB::value(const AMnDIndex& indexes) const
 			return AMNumber(AMNumber::OutOfBoundsError);
 #endif
 
-	int index = indexes.i();
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	// Forward difference.
-	if(index == 0){
-
-		if ((double)inputSource_->axisValue(0, 1) == (double)inputSource_->axisValue(0, 0))
-			return 0;
-
-		return ((double)inputSource_->value(1)-
-				(double)inputSource_->value(0))/
-				((double)inputSource_->axisValue(0, 1)-
-				 (double)inputSource_->axisValue(0, 0));
-	}
-	// Backward difference.
-	else if(index+1 == axes_.at(0).size){
-
-		if ((double)inputSource_->axisValue(0, index) == (double)inputSource_->axisValue(0, index-1))
-				return 0;
-
-		return ((double)inputSource_->value(index)-
-				(double)inputSource_->value(index-1))/
-				((double)inputSource_->axisValue(0, index)-
-				 (double)inputSource_->axisValue(0, index-1));
-	}
-	// Central difference.
-	else {
-
-		if ((double)inputSource_->axisValue(0, index+1) == (double)inputSource_->axisValue(0, index-1))
-				return 0;
-
-		return ((double)inputSource_->value(index+1)-
-				(double)inputSource_->value(index-1))/
-				(2*((double)inputSource_->axisValue(0, index+1)-
-				 (double)inputSource_->axisValue(0, index-1)));
-	}
+    return cachedData_.at(indexes.i());
 }
 
 bool AM1DDerivativeAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
@@ -243,234 +283,15 @@ bool AM1DDerivativeAB::values(const AMnDIndex &indexStart, const AMnDIndex &inde
 		return false;
 #endif
 
-	// Because the indexStart and indexEnd might not correspond to 0 and size-1, we might need to grab more values from inputSource (from one side or the other).
-	int totalSize = indexStart.totalPointsTo(indexEnd);
-	int offset = indexStart.i();
-	// Bools for knowing whether the indices we were given are at either extreme of the array.
-	bool veryStart = (offset == 0);
-	bool veryEnd = (totalSize == int(axes_.at(0).size));
+    int totalSize = indexStart.totalPointsTo(indexEnd);
 
-	if (totalSize == 1)
+    if (totalSize == 1)
 		return false;
 
-	// Although substantially more code, I have split up each possibility so that it covers everything properly.  Perhaps later I'll find a code optimization.
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	// If we are computing the entire thing then we can get the data without and changes.
-	if (veryStart && veryEnd){
-
-		QVector<double> data = QVector<double>(totalSize);
-		QVector<double> axis = QVector<double>(totalSize);
-		AMAxisInfo axisInfo = inputSource_->axisInfoAt(0);
-
-		inputSource_->values(indexStart, indexEnd, data.data());
-
-		// This is much faster because we can compute all the axis values ourselves rather than ask for them one at a time.
-		if (axisInfo.isUniform){
-
-			double axisStart = double(axisInfo.start);
-			double axisStep = double(axisInfo.increment);
-
-			for (int i = 0; i < totalSize; i++)
-				axis[i] = axisStart + i*axisStep;
-
-			// Because we computed the axis values we are guarenteed that the values won't be bad.
-			outputValues[0] = (data.at(1)-data.at(0))/(axis.at(1)-axis.at(0));
-			outputValues[totalSize-1] = (data.at(totalSize-1)-data.at(totalSize-2))/(axis.at(totalSize-1)-axis.at(totalSize-2));
-
-			for (int i = 1, count = totalSize-1; i < count; i++)
-				outputValues[i] = (data.at(i+1)-data.at(i-1))/(2*(axis.at(i+1)-axis.at(i-1)));
-		}
-
-		else {
-
-			// Fill the axis vector.  Should minimize the overhead of making the same function calls and casting the values multiple times.
-			for (int i = 0; i < totalSize; i++)
-				axis[i] = double(inputSource_->axisValue(0, i));
-
-			// Fill a list of all the indices that will cause division by zero.
-			QList<int> badIndices;
-
-			if (axis.at(0) == axis.at(1))
-				badIndices.append(0);
-
-			for (int i = 1, count = totalSize-1; i < count; i++)
-				if (axis.at(i+1) == axis.at(i-1))
-					badIndices.append(i);
-
-			if (axis.at(totalSize-1) == axis.at(totalSize-2))
-				badIndices.append(totalSize-1);
-
-			// Compute all the values
-			outputValues[0] = (data.at(1)-data.at(0))/(axis.at(1)-axis.at(0));
-			outputValues[totalSize-1] = (data.at(totalSize-1)-data.at(totalSize-2))/(axis.at(totalSize-1)-axis.at(totalSize-2));
-
-			for (int i = 1, count = totalSize-1; i < count; i++)
-				outputValues[i] = (data.at(i+1)-data.at(i-1))/(2*(axis.at(i+1)-axis.at(i-1)));
-
-			// Fix all the values where division by zero would have occured.  Unfortunately, the default value is currently 0, which is generally important when taking the derivative.
-			for (int i = 0, count = badIndices.size(); i < count; i++)
-				outputValues[badIndices.at(i)] = 0;
-		}
-	}
-
-	// If we have the very start and not the very end then we have to get more data from the input source from the end.
-	else if (veryStart){
-
-		int dataSize = totalSize+1;
-		QVector<double> data = QVector<double>(dataSize);
-		QVector<double> axis = QVector<double>(dataSize);
-		AMAxisInfo axisInfo = inputSource_->axisInfoAt(0);
-
-		inputSource_->values(indexStart, AMnDIndex(indexEnd.i()+1), data.data());
-
-		// This is much faster because we can compute all the axis values ourselves rather than ask for them one at a time.
-		if (axisInfo.isUniform){
-
-			double axisStart = double(axisInfo.start);
-			double axisStep = double(axisInfo.increment);
-
-			for (int i = 0; i < dataSize; i++)
-				axis[i] = axisStart + i*axisStep;
-
-			// Because we computed the axis values we are guarenteed that the values won't be bad.
-			outputValues[0] = (data.at(1)-data.at(0))/(axis.at(1)-axis.at(0));
-
-			// This is safe because data and axis have an extra point more at the end.
-			for (int i = 1; i < totalSize; i++)
-				outputValues[i] = (data.at(i+1)-data.at(i-1))/(2*(axis.at(i+1)-axis.at(i-1)));
-		}
-
-		else {
-
-			// Fill the axis vector.  Should minimize the overhead of making the same function calls and casting the values multiple times.
-			for (int i = 0; i < dataSize; i++)
-				axis[i] = double(inputSource_->axisValue(0, i+offset));
-
-			// Fill a list of all the indices that will cause division by zero.
-			QList<int> badIndices;
-
-			if (axis.at(0) == axis.at(1))
-				badIndices.append(0);
-
-			for (int i = 1, count = dataSize-1; i < count; i++)
-				if (axis.at(i+1) == axis.at(i-1))
-					badIndices.append(i);
-
-			// Compute all the values
-			outputValues[0] = (data.at(1)-data.at(0))/(axis.at(1)-axis.at(0));
-
-			for (int i = 1; i < totalSize; i++)
-				outputValues[i] = (data.at(i+1)-data.at(i-1))/(2*(axis.at(i+1)-axis.at(i-1)));
-
-			// Fix all the values where division by zero would have occured.  Unfortunately, the default value is currently 0, which is generally important when taking the derivative.
-			for (int i = 0, count = badIndices.size(); i < count; i++)
-				outputValues[badIndices.at(i)] = 0;
-		}
-	}
-
-	// If we have the very end and not the very start then we have get more data from the input source from the front.
-	else if (veryEnd){
-
-		int dataSize = totalSize+1;
-		QVector<double> data = QVector<double>(dataSize);
-		QVector<double> axis = QVector<double>(dataSize);
-		AMAxisInfo axisInfo = inputSource_->axisInfoAt(0);
-
-		inputSource_->values(AMnDIndex(indexStart.i()-1), indexEnd, data.data());
-
-		// This is much faster because we can compute all the axis values ourselves rather than ask for them one at a time.
-		if (axisInfo.isUniform){
-
-			double axisStart = double(axisInfo.start);
-			double axisStep = double(axisInfo.increment);
-
-			for (int i = 0; i < dataSize; i++)
-				axis[i] = axisStart + (i+offset)*axisStep;
-
-			// Because we computed the axis values we are guarenteed that the values won't be bad.
-			// This looks a little weird because data has one extra point at the beginning.
-			for (int i = 0, count = totalSize-1; i < count; i++)
-				outputValues[i] = (data.at(i+2)-data.at(i))/(2*(axis.at(i+2)-axis.at(i)));
-
-			outputValues[totalSize-1] = (data.at(totalSize-1)-data.at(totalSize-2))/(axis.at(totalSize-1)-axis.at(totalSize-2));
-		}
-
-		else {
-
-			// Fill the axis vector.  Should minimize the overhead of making the same function calls and casting the values multiple times.
-			for (int i = 0; i < dataSize; i++)
-				axis[i] = inputSource_->axisValue(0, i+offset);
-
-			// Fill a list of all the indices that will cause division by zero.
-			QList<int> badIndices;
-
-			for (int i = 1, count = dataSize-1; i < count; i++)
-				if (axis.at(i+1) == axis.at(i-1))
-					badIndices.append(i);
-
-			if (axis.at(dataSize-1) == axis.at(dataSize-2))
-				badIndices.append(totalSize-1);
-
-			// Compute all the values
-			for (int i = 0, count = totalSize-1; i < count; i++)
-				outputValues[i] = (data.at(i+2)-data.at(i))/(2*(axis.at(i+2)-axis.at(i)));
-
-			outputValues[totalSize-1] = (data.at(totalSize)-data.at(totalSize-1))/(axis.at(totalSize)-axis.at(totalSize-1));
-
-			// Fix all the values where division by zero would have occured.  Unfortunately, the default value is currently 0, which is generally important when taking the derivative.
-			for (int i = 0, count = badIndices.size(); i < count; i++)
-				outputValues[badIndices.at(i)] = 0;
-		}
-	}
-
-	// If we don't have either then we need to grab an extra point from either side.
-	else{
-
-		int dataSize = totalSize+2;
-		QVector<double> data = QVector<double>(totalSize);
-		QVector<double> axis = QVector<double>(totalSize);
-		AMAxisInfo axisInfo = inputSource_->axisInfoAt(0);
-
-		inputSource_->values(AMnDIndex(indexStart.i()-1), AMnDIndex(indexEnd.i()+1), data.data());
-
-		// This is much faster because we can compute all the axis values ourselves rather than ask for them one at a time.
-		if (axisInfo.isUniform){
-
-			double axisStart = double(axisInfo.start);
-			double axisStep = double(axisInfo.increment);
-
-			for (int i = 0; i < dataSize; i++)
-				axis[i] = axisStart + (i+offset)*axisStep;
-
-			// Because we computed the axis values we are guarenteed that the values won't be bad.
-			// This is okay because we have an extra point on both ends and the arrays don't line up.
-			for (int i = 0; i < totalSize; i++)
-				outputValues[i] = (data.at(i+2)-data.at(i))/(2*(axis.at(i+2)-axis.at(i)));
-		}
-
-		else {
-
-			// Fill the axis vector.  Should minimize the overhead of making the same function calls and casting the values multiple times.
-			for (int i = 0; i < dataSize; i++)
-				axis[i] = inputSource_->axisValue(0, i+offset);
-
-			// Fill a list of all the indices that will cause division by zero.
-			QList<int> badIndices;
-
-			for (int i = 1; i < dataSize; i++)
-				if (axis.at(i+1) == axis.at(i-1))
-					badIndices.append(i);
-
-			// Compute all the values
-			// This is okay because we have an extra point on both ends and the arrays don't line up.
-			for (int i = 0; i < totalSize; i++)
-				outputValues[i] = (data.at(i+2)-data.at(i))/(2*(axis.at(i+2)-axis.at(i)));
-
-			// Fix all the values where division by zero would have occured.  Unfortunately, the default value is currently 0, which is generally important when taking the derivative.
-			for (int i = 0, count = badIndices.size(); i < count; i++)
-				outputValues[badIndices.at(i)] = 0;
-		}
-	}
+    memcpy(outputValues, cachedData_.constData()+indexStart.i(), totalSize*sizeof(double));
 
 	return true;
 }
@@ -503,13 +324,16 @@ bool AM1DDerivativeAB::axisValues(int axisNumber, int startIndex, int endIndex, 
 
 void AM1DDerivativeAB::onInputSourceValuesChanged(const AMnDIndex& start, const AMnDIndex& end)
 {
+    cacheUpdateRequired_ = true;
 	emitValuesChanged(start, end);
 }
 
 void AM1DDerivativeAB::onInputSourceSizeChanged()
 {
 	axes_[0].size = inputSource_->size(0);
-	emitSizeChanged(0);
+    cacheUpdateRequired_ = true;
+    cachedData_ = QVector<double>(size(0));
+    emitSizeChanged();
 }
 
 void AM1DDerivativeAB::onInputSourceStateChanged()

--- a/source/analysis/AM1DDerivativeAB.h
+++ b/source/analysis/AM1DDerivativeAB.h
@@ -102,7 +102,10 @@ protected:
 	/// Helper method that sets the inputSource_ pointer to the correct one based on the current state of analyzedName_.
 	void setInputSource();
 
-	/// Pointer to the data source that will be analyzed.
+    /// Computes the cached data for access getters value() and values().
+    void computeCachedValues() const;
+
+    /// Pointer to the data source that will be analyzed.
 	AMDataSource* inputSource_;	// our single input source, or 0 if we don't have one.
 
 	/// The name of the data source that should be analyzed.
@@ -112,6 +115,11 @@ protected:
 
 	/// Helper function to look at our overall situation and determine what the output state should be.
 	void reviewState();
+
+    /// Flag for knowing whether we need to compute the values.
+    mutable bool cacheUpdateRequired_;
+    /// The vector holding the data.
+    mutable QVector<double> cachedData_;
 };
 
 #endif // AM1DDERIVATIVEAB_H

--- a/source/analysis/AM1DNormalizationAB.cpp
+++ b/source/analysis/AM1DNormalizationAB.cpp
@@ -29,7 +29,8 @@ AM1DNormalizationAB::AM1DNormalizationAB(const QString &outputName, QObject *par
 	canAnalyze_ = false;
 	dataName_ = "";
 	normalizationName_ = "";
-	axes_ << AMAxisInfo("invalid", 0, "No input data");
+    cacheUpdateRequired_ = false;
+    axes_ << AMAxisInfo("invalid", 0, "No input data");
 	setState(AMDataSource::InvalidFlag);
 }
 
@@ -100,6 +101,9 @@ void AM1DNormalizationAB::setInputSources()
 
 		axes_[0] = data_->axisInfoAt(0);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size().product());
+
 		setDescription(QString("Normalized %1").arg(data_->name()));
 
 		connect(data_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -122,10 +126,37 @@ void AM1DNormalizationAB::setInputSources()
 
 	reviewState();
 
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
-	emitInfoChanged();
+    emitAxisInfoChanged();
+    emitInfoChanged();
+}
+
+void AM1DNormalizationAB::computeCachedValues() const
+{
+    AMnDIndex start = AMnDIndex(0);
+    AMnDIndex end = size()-1;
+    int totalSize = size(0);
+
+    QVector<double> data = QVector<double>(totalSize);
+    QVector<double> normalizer = QVector<double>(totalSize);
+
+    data_->values(start, end, data.data());
+    normalizer_->values(start, end, normalizer.data());
+
+    for (int i = 0; i < totalSize; i++){
+
+        if (normalizer.at(i) == 0)
+            cachedData_[i] = 0;
+
+        else if (normalizer.at(i) < 0 || data.at(i) == -1)
+            cachedData_[i] = -1;
+
+        else
+            cachedData_[i] = data.at(i)/normalizer.at(i);
+    }
+
+    cacheUpdateRequired_ = false;
 }
 
 bool AM1DNormalizationAB::canAnalyze(const QString &dataName, const QString &normalizationName) const
@@ -154,15 +185,10 @@ AMNumber AM1DNormalizationAB::value(const AMnDIndex &indexes) const
 			return AMNumber(AMNumber::OutOfBoundsError);
 #endif
 
-	// Can't divide by zero.
-	if (double(normalizer_->value(indexes)) == 0)
-		return 0;
+        if (cacheUpdateRequired_)
+            computeCachedValues();
 
-	// The normalizer must be positive.
-	if (double(normalizer_->value(indexes)) < 0)
-		return -1;
-
-	return double(data_->value(indexes))/double(normalizer_->value(indexes));
+        return cachedData_.at(indexes.i());
 }
 
 bool AM1DNormalizationAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
@@ -181,27 +207,13 @@ bool AM1DNormalizationAB::values(const AMnDIndex &indexStart, const AMnDIndex &i
 		return false;
 #endif
 
-	int totalSize = indexStart.totalPointsTo(indexEnd);
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	QVector<double> data = QVector<double>(totalSize);
-	QVector<double> normalizer = QVector<double>(totalSize);
+    int totalSize = indexStart.totalPointsTo(indexEnd);
+    memcpy(outputValues, cachedData_.constData()+indexStart.i()*size(1), totalSize*sizeof(double));
 
-	data_->values(indexStart, indexEnd, data.data());
-	normalizer_->values(indexStart, indexEnd, normalizer.data());
-
-	for (int i = 0; i < totalSize; i++){
-
-		if (normalizer.at(i) == 0)
-			outputValues[i] = 0;
-
-		else if (normalizer.at(i) < 0)
-			outputValues[i] = -1;
-
-		else
-			outputValues[i] = data.at(i)/normalizer.at(i);
-	}
-
-	return true;
+    return true;
 }
 
 AMNumber AM1DNormalizationAB::axisValue(int axisNumber, int index) const
@@ -234,16 +246,16 @@ bool AM1DNormalizationAB::axisValues(int axisNumber, int startIndex, int endInde
 
 void AM1DNormalizationAB::onInputSourceValuesChanged(const AMnDIndex& start, const AMnDIndex& end)
 {
-	emitValuesChanged(start, end);
+    cacheUpdateRequired_ = true;
+    emitValuesChanged(start, end);
 }
 
 void AM1DNormalizationAB::onInputSourceSizeChanged()
 {
-	if(axes_.at(0).size != data_->size(0)){
-
-		axes_[0].size = data_->size(0);
-		emitSizeChanged(0);
-	}
+    axes_[0].size = data_->size(0);
+    cacheUpdateRequired_ = true;
+    cachedData_ = QVector<double>(axes_.at(0).size);
+    emitSizeChanged();
 }
 
 void AM1DNormalizationAB::onInputSourceStateChanged() {
@@ -291,6 +303,9 @@ void AM1DNormalizationAB::setInputDataSourcesImplementation(const QList<AMDataSo
 
 		axes_[0] = data_->axisInfoAt(0);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size().product());
+
 		setDescription(QString("Normalized %1").arg(data_->name()));
 
 		connect(data_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onInputSourceValuesChanged(AMnDIndex,AMnDIndex)));
@@ -309,9 +324,9 @@ void AM1DNormalizationAB::setInputDataSourcesImplementation(const QList<AMDataSo
 
 	reviewState();
 
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
+    emitAxisInfoChanged();
 	emitInfoChanged();
 }
 

--- a/source/analysis/AM1DNormalizationAB.cpp
+++ b/source/analysis/AM1DNormalizationAB.cpp
@@ -211,7 +211,7 @@ bool AM1DNormalizationAB::values(const AMnDIndex &indexStart, const AMnDIndex &i
         computeCachedValues();
 
     int totalSize = indexStart.totalPointsTo(indexEnd);
-    memcpy(outputValues, cachedData_.constData()+indexStart.i()*size(1), totalSize*sizeof(double));
+    memcpy(outputValues, cachedData_.constData()+indexStart.i(), totalSize*sizeof(double));
 
     return true;
 }

--- a/source/analysis/AM1DNormalizationAB.h
+++ b/source/analysis/AM1DNormalizationAB.h
@@ -110,6 +110,9 @@ protected:
 	/// Helper method that sets the data_ and normalizer_ pointer to the correct data source based on the current state of analyzedName_.
 	void setInputSources();
 
+    /// Computes the cached data for access getters value() and values().
+    void computeCachedValues() const;
+
 	/// Pointer to the data source that will be analyzed.
 	AMDataSource *data_;
 	/// Pointer to the data source that is the normalizer.
@@ -121,6 +124,11 @@ protected:
 	QString normalizationName_;
 	/// Flag holding whether or not the data source can be analyzed.
 	bool canAnalyze_;
+
+    /// Flag for knowing whether we need to compute the values.
+    mutable bool cacheUpdateRequired_;
+    /// The vector holding the data.
+    mutable QVector<double> cachedData_;
 };
 
 #endif // AM1DNORMALIZATIONAB_H

--- a/source/analysis/AM1DSummingAB.cpp
+++ b/source/analysis/AM1DSummingAB.cpp
@@ -25,6 +25,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 AM1DSummingAB::AM1DSummingAB(const QString &outputName, QObject *parent)
 	: AMStandardAnalysisBlock(outputName, parent)
 {
+    cacheUpdateRequired_ = true;
 	axes_ << AMAxisInfo("invalid", 0, "No input data");
 	setState(AMDataSource::InvalidFlag);
 }
@@ -60,12 +61,10 @@ AMNumber AM1DSummingAB::value(const AMnDIndex &indexes) const
 			return AMNumber(AMNumber::OutOfBoundsError);
 #endif
 
-	double val = 0;
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	for (int i = 0; i < sources_.size(); i++)
-		val += (double)sources_.at(i)->value(indexes.i());
-
-	return val;
+    return cachedData_.at(indexes.i());
 }
 
 bool AM1DSummingAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEnd, double *outputValues) const
@@ -85,23 +84,11 @@ bool AM1DSummingAB::values(const AMnDIndex &indexStart, const AMnDIndex &indexEn
 		return false;
 #endif
 
-	int totalSize = indexStart.totalPointsTo(indexEnd);
+    if (cacheUpdateRequired_)
+        computeCachedValues();
 
-	QVector<double> data = QVector<double>(totalSize);
-	sources_.at(0)->values(indexStart, indexEnd, data.data());
-
-	// Do the first data source separately to initialize the values.
-	for (int i = 0; i < totalSize; i++)
-		outputValues[i] = data.at(i);
-
-	// Iterate through the rest of the sources.
-	for (int i = 1, count = sources_.size(); i < count; i++){
-
-		sources_.at(i)->values(indexStart, indexEnd, data.data());
-
-		for (int j = 0; j < totalSize; j++)
-			outputValues[j] += data.at(j);
-	}
+    int totalSize = indexStart.totalPointsTo(indexEnd);
+    memcpy(outputValues, cachedData_.constData()+indexStart.i(), totalSize*sizeof(double));
 
 	return true;
 }
@@ -139,15 +126,16 @@ bool AM1DSummingAB::axisValues(int axisNumber, int startIndex, int endIndex, dou
 // Connected to be called when the values of the input data source change
 void AM1DSummingAB::onInputSourceValuesChanged(const AMnDIndex& start, const AMnDIndex& end)
 {
+    cacheUpdateRequired_ = true;
 	emitValuesChanged(start, end);
 }
 
 // Connected to be called when the size of the input source changes
 void AM1DSummingAB::onInputSourceSizeChanged()
 {
-	if (sources_.at(0)->axes().size() > 0)
-		axes_[0] = sources_.at(0)->axisInfoAt(0);
-
+    axes_[0] = sources_.at(0)->axisInfoAt(0);
+    cacheUpdateRequired_ = true;
+    cachedData_ = QVector<double>(size(0));
 	emitSizeChanged();
 }
 
@@ -187,6 +175,8 @@ void AM1DSummingAB::setInputDataSourcesImplementation(const QList<AMDataSource*>
 
 		axes_[0] = sources_.at(0)->axisInfoAt(0);
 
+        cacheUpdateRequired_ = true;
+        cachedData_ = QVector<double>(size(0));
 		setDescription(QString("Sum of %1 spectra").arg(sources_.size()));
 
 		for (int i = 0; i < sources_.size(); i++){
@@ -199,9 +189,9 @@ void AM1DSummingAB::setInputDataSourcesImplementation(const QList<AMDataSource*>
 
 	reviewState();
 
-	emitSizeChanged(0);
+    emitSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
+    emitAxisInfoChanged();
 	emitInfoChanged();
 }
 
@@ -235,5 +225,29 @@ void AM1DSummingAB::reviewState()
 	if (valid)
 		setState(0);
 	else
-		setState(AMDataSource::InvalidFlag);
+        setState(AMDataSource::InvalidFlag);
+}
+
+void AM1DSummingAB::computeCachedValues() const
+{
+    AMnDIndex start = AMnDIndex(0);
+    AMnDIndex end = size()-1;
+    int totalSize = start.totalPointsTo(end);
+
+    QVector<double> data = QVector<double>(totalSize);
+    sources_.at(0)->values(start, end, data.data());
+
+    // Do the first data source separately to initialize the values.
+    cachedData_ = data;
+
+    // Iterate through the rest of the sources.
+    for (int i = 1, count = sources_.size(); i < count; i++){
+
+        sources_.at(i)->values(start, end, data.data());
+
+        for (int j = 0; j < totalSize; j++)
+            cachedData_[j] += data.at(j);
+    }
+
+    cacheUpdateRequired_ = false;
 }

--- a/source/analysis/AM1DSummingAB.h
+++ b/source/analysis/AM1DSummingAB.h
@@ -77,6 +77,14 @@ protected:
 	virtual void setInputDataSourcesImplementation(const QList<AMDataSource*>& dataSources);
 	/// Helper function to look at our overall situation and determine what the output state should be.
 	void reviewState();
+
+    /// Computes the cached data for access getters value() and values().
+    void computeCachedValues() const;
+
+    //// Flag for knowing whether we need to compute the values.
+    mutable bool cacheUpdateRequired_;
+    /// The vector holding the data.
+    mutable QVector<double> cachedData_;
 };
 
 #endif // AM1DSUMMINGAB_H

--- a/source/dataman/datasource/AMDataSourceSeriesData.cpp
+++ b/source/dataman/datasource/AMDataSourceSeriesData.cpp
@@ -31,9 +31,8 @@ AMDataSourceSeriesData::AMDataSourceSeriesData(const AMDataSource* dataSource, Q
 	axisSize_ = 0;
 	axis_ = QVector<qreal>();
 	data_ = QVector<qreal>();
-	dirtyRange_ = AMRange();
-	dataRange_ = AMRange();
-	setDataSource(dataSource);
+    cachedDataRectUpdateRequired_ = false;
+    setDataSource(dataSource);
 }
 
 void AMDataSourceSeriesData::setDataSource(const AMDataSource* dataSource) {
@@ -50,8 +49,6 @@ void AMDataSourceSeriesData::setDataSource(const AMDataSource* dataSource) {
 		axisSize_ = 0;
 		axis_ = QVector<qreal>();
 		data_ = QVector<qreal>();
-		dirtyRange_ = AMRange();
-		dataRange_ = AMRange();
 	}
 
 	else {
@@ -115,7 +112,7 @@ QRectF AMDataSourceSeriesData::boundingRect() const
 				updateCachedValues();
 
 			cachedDataRect_ = QRectF(axis_.first(),
-									 dataRange_.minimum(),
+                                     dataRange_.minimum(),
 									 qMax(axis_.last()-axis_.first(), std::numeric_limits<qreal>::min()),
 									 qMax(dataRange_.maximum()-dataRange_.minimum(), std::numeric_limits<qreal>::min()));
 		}
@@ -133,24 +130,10 @@ void AMDataSourceSeriesData::onDataSourceDeleted()
 
 void  AMDataSourceSeriesData::onDataChanged(const AMnDIndex &start, const AMnDIndex &end)
 {
+    Q_UNUSED(start)
+    Q_UNUSED(end)
 	updateCacheRequired_ = true;
 	cachedDataRectUpdateRequired_ = true;
-
-	int dirtyStartIndex = start.isValid() ? start.i() : 0;
-	int dirtyEndIndex = end.isValid() ? end.i() : (axisSize_-1);
-
-	if (!dirtyRange_.isValid())
-		dirtyRange_ = AMRange(dirtyStartIndex, dirtyEndIndex);
-
-	else {
-
-		if (dirtyStartIndex < dirtyRange_.minimum())
-			dirtyRange_.setMinimum(dirtyStartIndex);
-
-		if (dirtyEndIndex > dirtyRange_.maximum())
-			dirtyRange_.setMaximum(dirtyEndIndex);
-	}
-
 	MPlotAbstractSeriesData::emitDataChanged();
 }
 
@@ -180,42 +163,23 @@ void AMDataSourceSeriesData::onSizeChanged()
 
 void AMDataSourceSeriesData::updateCachedValues() const
 {
-	int size = dirtyRange_.maximum()-dirtyRange_.minimum()+1;
-	QVector<double> newData = QVector<double>(size, 0);
+    if (source_->values(0, axisSize_-1, data_.data())){
 
-	if (source_->values(dirtyRange_.minimum(), dirtyRange_.maximum(), newData.data())){
+        double rangeMinimum = data_.first();
+        double rangeMaximum = data_.first();
 
-		int iOffset = dirtyRange_.minimum();
-		double rangeMinimum = newData.first();
-		double rangeMaximum = newData.first();
+        for (int i = 0; i < axisSize_; i++){
 
-		for (int i = 0; i < size; i++){
-
-			double newValue = newData.at(i);
+            double newValue = data_.at(i);
 
 			if (newValue > rangeMaximum)
 				rangeMaximum = newValue;
 
 			if (newValue < rangeMinimum)
 				rangeMinimum = newValue;
-
-			data_[i+iOffset] = qreal(newValue);
 		}
 
-		// The default range is invalid.
-		if (!dataRange_.isValid() || size == axisSize_)
-			dataRange_ = AMRange(rangeMinimum, rangeMaximum);
-
-		else {
-
-			if (rangeMinimum < dataRange_.minimum())
-				dataRange_.setMinimum(rangeMinimum);
-
-			if (rangeMaximum > dataRange_.maximum())
-				dataRange_.setMaximum(rangeMaximum);
-		}
-
-		dirtyRange_ = AMRange();
+        dataRange_ = AMRange(rangeMinimum, rangeMaximum);
 		updateCacheRequired_ = false;
 	}
 }

--- a/source/dataman/datasource/AMDataSourceSeriesData.h
+++ b/source/dataman/datasource/AMDataSourceSeriesData.h
@@ -87,10 +87,8 @@ protected:
 	mutable QVector<qreal> data_;
 	/// Flag for when to update the cached data.
 	mutable bool updateCacheRequired_;
-	/// Holds the range of dirty values that need to be cached.
-	mutable AMRange dirtyRange_;
-	/// Holds the data range of the dependent values.
-	mutable AMRange dataRange_;
+    /// Holds the data range of the dependent values.
+    mutable AMRange dataRange_;
 };
 
 #endif // AMDATASOURCESERIESDATA_H


### PR DESCRIPTION
Implemented the caching on the 1D sources.  These were a lot easier because flat arrays are really straight-forward for 1D data sets.