### PR TITLE
PullRequest for Issue1595: add BioXAS main endstation table coordinator application and related softIOC

### DIFF
--- a/BioXASMainTableCoordinator.pro
+++ b/BioXASMainTableCoordinator.pro
@@ -1,0 +1,8 @@
+# #####################################################################
+# QMake project file for BioXAS Main beamline softIOC coordinator Sept 2015 xuetao.liu@lightsource.com
+# #####################################################################
+
+TEMPLATE = subdirs
+SUBDIRS += \
+	Initialize.pro \
+	BioXASMainTableCoordinator_internal.pro

--- a/BioXASMainTableCoordinator_internal.pro
+++ b/BioXASMainTableCoordinator_internal.pro
@@ -1,0 +1,12 @@
+
+include ( $$PATH_TO_AM/compositeCommon/AMPVControl.pri )
+include ( $$PATH_TO_AM/compositeCommon/AMControlSet.pri )
+
+TARGET = BioXASMainTableSoftIOCCoordinator
+
+HEADERS += \  
+	source/beamline/BioXAS/BioXASMainTableCoordinator.h
+
+SOURCES += \
+	source/application/BioXAS/BioXASMainTableCoordinatorMain.cpp \
+	source/beamline/BioXAS/BioXASMainTableCoordinator.cpp

--- a/BioXASSideTableCoordinator_internal.pro
+++ b/BioXASSideTableCoordinator_internal.pro
@@ -4,9 +4,11 @@ include ( $$PATH_TO_AM/compositeCommon/AMControlSet.pri )
 
 TARGET = BioXASSideTableSoftIOCCoordinator
 
-HEADERS += \  
-    source/beamline/BioXAS/BioXASSideTableCoordinator.h
+HEADERS += \
+	source/beamline/BioXAS/BioXASSideTableCoordinator.h
 
 SOURCES += \
-    source/beamline/BioXAS/BioXASSideTableCoordinator.cpp \
-    source/application/BioXAS/BioXASSideTableCoordinatorMain.cpp
+	source/application/BioXAS/BioXASSideTableCoordinatorMain.cpp \
+	source/beamline/BioXAS/BioXASSideTableCoordinator.cpp
+
+

--- a/acquaman_suite.pro
+++ b/acquaman_suite.pro
@@ -11,9 +11,10 @@ SUBDIRS += \
 	AMCrashReporter.pro \
 	CLSNetworkDirectorySynchronizer.pro \
 	BioXASMainAcquaman.pro \
+	BioXASMainTableCoordinator.pro \
 	BioXASSideAcquaman.pro \
-	BioXASImagingAcquaman.pro \
 	BioXASSideTableCoordinator.pro \
+	BioXASImagingAcquaman.pro \
 	BioXASToolSuite.pro \
 	MidIRBPM.pro \
 	REIXSTest.pro \

--- a/source/application/BioXAS/BioXASMainTableCoordinatorMain.cpp
+++ b/source/application/BioXAS/BioXASMainTableCoordinatorMain.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright 2010-2012 Mark Boots, David Chevrier, and Darren Hunter.
+Copyright 2013-2014 David Chevrier and Darren Hunter.
+
+This file is part of the Acquaman Data Acquisition and Management framework ("Acquaman").
+
+Acquaman is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Acquaman is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <QCoreApplication>
+#include "beamline/BioXAS/BioXASMainTableCoordinator.h"
+
+int main(int argc, char *argv[])
+{
+
+	// =================================
+	QCoreApplication app(argc, argv);
+	app.setApplicationName("BioXAS Main SoftIOC Coordinator");
+
+	BioXASMainTableCoordinator *coordinator = new BioXASMainTableCoordinator();
+
+	Q_UNUSED(coordinator)
+
+	return app.exec();
+}

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -191,7 +191,7 @@ void BioXASMainBeamline::setupComponents()
 	connect( standardsWheel_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
 	// Endstation table.
-	endstationTable_ = new BioXASEndstationTable("MainEndstationTable", "SMTR1607-7-I21-02");
+	endstationTable_ = new BioXASEndstationTable("MainEndstationTable", "BL1607-7-I21", true, this);
 	connect( endstationTable_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// Scaler

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -46,6 +46,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/BioXAS/BioXASMainDBHRMirrors.h"
 #include "beamline/BioXAS/BioXASMainCarbonFilterFarm.h"
 #include "beamline/BioXAS/BioXASMainStandardsWheel.h"
+#include "beamline/BioXAS/BioXASEndstationTable.h"
 
 #include "util/AMErrorMonitor.h"
 #include "util/AMBiHash.h"
@@ -184,6 +185,7 @@ protected:
 	CLSKeithley428 *i0Keithley_;
 	CLSKeithley428 *i1Keithley_;
 	CLSKeithley428 *i2Keithley_;
+
 };
 
 #endif // BIOXASMAINBEAMLINE_H

--- a/source/beamline/BioXAS/BioXASMainTableCoordinator.cpp
+++ b/source/beamline/BioXAS/BioXASMainTableCoordinator.cpp
@@ -28,9 +28,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 BioXASMainTableCoordinator::BioXASMainTableCoordinator(QObject *parent) :
 	QObject(parent)
 {
-	tableVerticalMotorPosition_ = 619.125;
-	tableVerticalDownstreamMotorPosition_ = 619.125;
-	tableHorizontalMotorPosition_ = 543.725;
+	tableVerticalMotorPosition_ = 600;
+	tableVerticalDownstreamMotorPosition_ = 400;
+	tableHorizontalMotorPosition_ = 600;
 
 	initialized_ = false;
 	connectedOnce_ = false;

--- a/source/beamline/BioXAS/BioXASMainTableCoordinator.cpp
+++ b/source/beamline/BioXAS/BioXASMainTableCoordinator.cpp
@@ -1,0 +1,496 @@
+/*
+Copyright 2010-2012 Mark Boots, David Chevrier, and Darren Hunter.
+Copyright 2013-2014 David Chevrier and Darren Hunter.
+
+This file is part of the Acquaman Data Acquisition and Management framework ("Acquaman").
+Acquaman is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Acquaman is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include "BioXASMainTableCoordinator.h"
+
+#include <math.h>
+
+#include "beamline/AMPVControl.h"
+
+
+BioXASMainTableCoordinator::BioXASMainTableCoordinator(QObject *parent) :
+	QObject(parent)
+{
+	tableVerticalMotorPosition_ = 619.125;
+	tableVerticalDownstreamMotorPosition_ = 619.125;
+	tableHorizontalMotorPosition_ = 543.725;
+
+	initialized_ = false;
+	connectedOnce_ = false;
+
+	initializePhysicalMotorControls();
+	initializeSoftIOCMotorControls();
+	initializePVControlSet();
+	initializeSignalConnector();
+}
+
+BioXASMainTableCoordinator::~BioXASMainTableCoordinator()
+{
+	if (allControls_)
+		allControls_->clear();
+}
+
+void BioXASMainTableCoordinator::onAllControlsConnected(bool connected){
+	if( connected ){
+		connectedOnce_ = true;
+
+		qDebug() << "Checking start up value from the OLD vertical upstream feedback as " << verticalUpstreamFeedbackControl_->value();
+		qDebug() << "Checking start up value from the OLD vertical DownStream feedback as " << verticalDownstreamInboundFeedbackControl_->value();
+		onVerticalFeedbackControlValueChanged();
+		qDebug() << "Checking start up value from the OLD vertical upstream status as " << verticalUpstreamStatusControl_->value();
+		qDebug() << "Checking start up value from the OLD vertical DownStream status as " << verticalDownstreamInboundStatusControl_->value();
+		onVerticalStatusControlValueChanged();
+
+		qDebug() << "Checking start up value from the OLD Horizontal upstream feedback as " << horizontalUpstreamFeedbackControl_->value();
+		qDebug() << "Checking start up value from the OLD Horizontal DownStream feedback as " << horizontalDownstreamFeedbackControl_->value();
+		onHorizontalFeedbackControlValueChanged();
+		qDebug() << "Checking start up value from the OLD Horizontal upstream status as " << horizontalUpstreamStatusControl_->value();
+		qDebug() << "Checking start up value from the OLD Horizontal DownStream status as " << horizontalDownstreamStatusControl_->value();
+		onHorizontalStatusControlValueChanged();
+
+		initialized_ = true;
+	} else {
+		initialized_ = false;
+	}
+}
+
+void BioXASMainTableCoordinator::onVerticalFeedbackControlValueChanged()
+{
+	if ( !connectedOnce_ )
+		return;
+
+	double upstreamHeight = verticalUpstreamFeedbackControl_->value();
+	double downstreamInboundHeight = verticalDownstreamInboundFeedbackControl_->value();
+	double downstreamOutboundHeight = verticalDownstreamOutboundFeedbackControl_->value();
+	manipulateVerticalPVChange(upstreamHeight, downstreamInboundHeight, downstreamOutboundHeight, softIOCHeightFeedbackControl_, softIOCPitchFeedbackControl_, softIOCRollFeedbackControl_);
+}
+
+void BioXASMainTableCoordinator::onVerticalStatusControlValueChanged()
+{
+	if ( !connectedOnce_ )
+		return;
+
+	// Status value: 0 - "MOVE DONE";  1 - "MOVE ACTIVE"; 2 - "AT LIMIT" ("MINOR"); 3 - "FORCED STOP" ("MINOR"); 4 - "ERROR" ("MAJOR")
+	// Status is "MOVE ACTIVE" if at least one motor is moving or the largest status value
+	double upstreamControlStatus = verticalUpstreamStatusControl_->value();
+
+	double downstreamInboundControlStatus = verticalDownstreamInboundStatusControl_->value();
+	double downstreamOutboundControlStatus = verticalDownstreamInboundStatusControl_->value();
+	double downstreamControlStatus = (downstreamInboundControlStatus > downstreamOutboundControlStatus ? downstreamInboundControlStatus : downstreamOutboundControlStatus);
+
+	double status = (upstreamControlStatus > downstreamControlStatus ? upstreamControlStatus : downstreamControlStatus);
+
+	softIOCHeightStatusControl_->move(status);
+	softIOCPitchStatusControl_->move(status);
+	softIOCRollStatusControl_->move(status);
+}
+
+void BioXASMainTableCoordinator::onHorizontalFeedbackControlValueChanged()
+{
+	if ( !connectedOnce_ )
+		return;
+
+	double horizontalUpstreamFeedbackValue = horizontalUpstreamFeedbackControl_->value();
+	double horizontalDownstreamFeedbackValue = horizontalDownstreamFeedbackControl_->value();
+	manipulateHorizontalPVChange(horizontalUpstreamFeedbackValue, horizontalDownstreamFeedbackValue, softIOCLateralFeedbackControl_, softIOCYawFeedbackControl_);
+}
+
+void BioXASMainTableCoordinator::onHorizontalStatusControlValueChanged()
+{
+	if ( !connectedOnce_ )
+		return;
+
+	// Status value: 0 - "MOVE DONE";  1 - "MOVE ACTIVE"; 2 - "AT LIMIT" ("MINOR"); 3 - "FORCED STOP" ("MINOR"); 4 - "ERROR" ("MAJOR")
+	// Status is "MOVE ACTIVE" if at least one motor is moving or the largest status value
+	double upstreamControlStatus = horizontalUpstreamStatusControl_->value();
+	double downstreamControlStatus = horizontalDownstreamStatusControl_->value();
+	double status = (upstreamControlStatus > downstreamControlStatus ? upstreamControlStatus : downstreamControlStatus);
+
+	softIOCLateralStatusControl_->move(status);
+	softIOCYawStatusControl_->move(status);
+}
+
+
+void BioXASMainTableCoordinator::onHeightControlValueChanged(double value)
+{
+	// if we didn't finish the initializaion process, skip this signal
+	if(!initialized_)
+		return;
+
+	double upstreamHeight = verticalUpstreamFeedbackControl_->value();
+	double downstreamInboundHeight = verticalDownstreamInboundFeedbackControl_->value();
+	double downstreamOutboundHeight = verticalDownstreamOutboundFeedbackControl_->value();
+
+	// try to populate the height changes to the physical PVs
+	double delta = value - softIOCHeightFeedbackControl_->value();
+	double targetUpstreamHeight = upstreamHeight + delta;
+	double targetDownstreamInboundHeight = downstreamInboundHeight + delta;
+	double targetDownstreamOutboundHeight = downstreamOutboundHeight + delta;
+
+	verticalUpstreamControl_->move(targetUpstreamHeight);
+	verticalDownstreamInboundControl_->move(targetDownstreamInboundHeight);
+	verticalDownstreamOutboundControl_->move(targetDownstreamOutboundHeight);
+}
+
+void BioXASMainTableCoordinator::onHeightStopControlValueChanged()
+{
+	if(!initialized_)
+		return;
+
+	if (softIOCHeightStopControl_->withinTolerance(1)) {
+		verticalUpstreamStopControl_->move(1);
+		verticalDownstreamInboundStopControl_->move(1);
+		verticalDownstreamOutboundStopControl_->move(1);
+
+		softIOCHeightStopControl_->move(0); // restore the value to 0
+	}
+}
+
+void BioXASMainTableCoordinator::onPitchControlValueChanged(double angle)
+{
+	// if we didn't finish the initializaion process, skip this signal
+	if(!initialized_)
+		return;
+
+	// downstream control will move in the direction of the angle and upstream will move against the direction of the angle
+	double pitchDelta = tableVerticalMotorPosition_ * tan(degreeToRadian(angle));
+	double targetUpstreamHeight = softIOCHeightFeedbackControl_->value() - pitchDelta ;
+	double targetDownstreamHeight = softIOCHeightFeedbackControl_->value() + pitchDelta;
+
+	double rollDelta = tableVerticalDownstreamMotorPosition_ * tan(degreeToRadian(softIOCRollFeedbackControl_->value()));
+	double targetDownstreamInboundHeight = targetDownstreamHeight - rollDelta;
+	double targetDownstreamOutboundHeight = targetDownstreamHeight + rollDelta;
+
+	verticalUpstreamControl_->move(targetUpstreamHeight);
+	verticalDownstreamInboundControl_->move(targetDownstreamInboundHeight);
+	verticalDownstreamOutboundControl_->move(targetDownstreamOutboundHeight);
+}
+
+void BioXASMainTableCoordinator::onPitchStopControlValueChanged()
+{
+	if(!initialized_)
+		return;
+
+	if (softIOCPitchStopControl_->withinTolerance(1)) {
+		verticalUpstreamStopControl_->move(1);
+		verticalDownstreamInboundStopControl_->move(1);
+		verticalDownstreamOutboundStopControl_->move(1);
+
+		softIOCPitchStopControl_->move(0); // restore the value to 0
+	}
+}
+
+void BioXASMainTableCoordinator::onRollControlValueChanged(double angle)
+{
+	// if we didn't finish the initializaion process, skip this signal
+	if(!initialized_)
+		return;
+
+	// calculate the downstream table height
+	double pitchDelta = tableVerticalMotorPosition_ * tan(degreeToRadian(softIOCPitchFeedbackControl_->value()));
+	double downstreamTableHeight = softIOCHeightFeedbackControl_->value() + pitchDelta;
+
+	// downstream outbound control will move in the direction of the angle and downstream inbound will move against the direction of the angle
+	double rollDelta = tableVerticalDownstreamMotorPosition_ * tan(degreeToRadian(angle));
+	double targetDownstreamInboundHeight = downstreamTableHeight - rollDelta;
+	double targetDownstreamOutboundHeight = downstreamTableHeight + rollDelta;
+
+	verticalDownstreamInboundControl_->move(targetDownstreamInboundHeight);
+	verticalDownstreamOutboundControl_->move(targetDownstreamOutboundHeight);
+}
+
+void BioXASMainTableCoordinator::onRollStopControlValueChanged()
+{
+	if(!initialized_)
+		return;
+
+	if (softIOCRollStopControl_->withinTolerance(1)) {
+		verticalUpstreamStopControl_->move(1);
+		verticalDownstreamInboundStopControl_->move(1);
+		verticalDownstreamOutboundStopControl_->move(1);
+
+		softIOCRollStopControl_->move(0); // restore the value to 0
+	}
+}
+
+void BioXASMainTableCoordinator::onLateralControlValueChanged(double value)
+{
+	if(!initialized_)
+		return;
+
+	double upstreamLateral = horizontalUpstreamFeedbackControl_->value();
+	double downstreamLateral = horizontalDownstreamFeedbackControl_->value();
+
+	// try to populate the lateral changes to the physical PVs
+	double delta = value - softIOCLateralFeedbackControl_->value();
+	double horizontalUpstreamPosition = upstreamLateral + delta;
+	double horizontalDownstreamPosition = downstreamLateral + delta;
+
+	horizontalUpstreamControl_->move(horizontalUpstreamPosition);
+	horizontalDownstreamControl_->move(horizontalDownstreamPosition);
+}
+
+void BioXASMainTableCoordinator::onLateralStopControlValueChanged()
+{
+	if(!initialized_)
+		return;
+
+	if (softIOCLateralStopControl_->withinTolerance(1)) {
+		horizontalUpstreamStopControl_->move(1);
+		horizontalDownstreamStopControl_->move(1);
+
+		softIOCLateralStopControl_->move(0); // restore the value to 0
+	}
+}
+
+void BioXASMainTableCoordinator::onYawControlValueChanged(double angle)
+{
+	if(!initialized_)
+		return;
+
+	// try to populate the yaw changes to the physical PVs
+	double setpoint = tableHorizontalMotorPosition_ * tan(degreeToRadian(angle));
+	double targetUpstreamLateral = softIOCLateralFeedbackControl_->value() - setpoint ;
+	double targetDownstreamLateral = softIOCLateralFeedbackControl_->value() + setpoint;
+
+	horizontalUpstreamControl_->move(targetUpstreamLateral);
+	horizontalDownstreamControl_->move(targetDownstreamLateral);
+}
+
+void BioXASMainTableCoordinator::onYawStopControlValueChanged()
+{
+	if(!initialized_)
+		return;
+
+	if (softIOCYawStopControl_->withinTolerance(1)) {
+		horizontalUpstreamStopControl_->move(1);
+		horizontalDownstreamStopControl_->move(1);
+
+		softIOCYawStopControl_->move(0); // restore the value to 0
+	}
+}
+
+void BioXASMainTableCoordinator::initializePhysicalMotorControls()
+{
+	verticalUpstreamControl_ = new AMSinglePVControl("Main Vertical Upstream", "SMTR1607-7-I21-02:mm", this, 0.001);
+	verticalUpstreamFeedbackControl_ = new AMReadOnlyPVControl("Main Vertical Upstream Feedback", "SMTR1607-7-I21-02:mm:fbk", this);
+	verticalUpstreamStatusControl_ = new AMReadOnlyPVControl("Main Vertical Upstream Status", "SMTR1607-7-I21-02:status", this);
+	verticalUpstreamStopControl_ = new AMSinglePVControl("Main Vertical Upstream Stop", "SMTR1607-7-I21-02:stop", this);
+
+	verticalDownstreamInboundControl_ = new AMSinglePVControl("Main Vertical Downstream Inbound", "SMTR1607-7-I21-03:mm", this, 0.001);
+	verticalDownstreamInboundFeedbackControl_ = new AMReadOnlyPVControl("Main Vertical Downstream Inbound Feedback", "SMTR1607-7-I21-03:mm:fbk", this);
+	verticalDownstreamInboundStatusControl_ = new AMReadOnlyPVControl("Main Vertical Downstream Inbound Status", "SMTR1607-7-I21-03:status", this);
+	verticalDownstreamInboundStopControl_ = new AMSinglePVControl("Main Vertical Downstream Inbound Stop", "SMTR1607-7-I21-03:stop", this);
+
+	verticalDownstreamOutboundControl_ = new AMSinglePVControl("Main Vertical Downstream Outbound", "SMTR1607-7-I21-04:mm", this, 0.001);
+	verticalDownstreamOutboundFeedbackControl_ = new AMReadOnlyPVControl("Main Vertical Downstream Outbound Feedback", "SMTR1607-7-I21-04:mm:fbk", this);
+	verticalDownstreamOutboundStatusControl_ = new AMReadOnlyPVControl("Main Vertical Downstream Outbound Status", "SMTR1607-7-I21-04:status", this);
+	verticalDownstreamOutboundStopControl_ = new AMSinglePVControl("Main Vertical Downstream Outbound Stop", "SMTR1607-7-I21-04:stop", this);
+
+	horizontalUpstreamControl_ = new AMSinglePVControl("Main Horizonal Upstream", "SMTR1607-7-I21-05:mm", this, 0.001);
+	horizontalUpstreamFeedbackControl_ = new AMReadOnlyPVControl("Main Horizonal Upstream Feedback", "SMTR1607-7-I21-05:mm:fbk", this);
+	horizontalUpstreamStatusControl_ = new AMReadOnlyPVControl("Main Horizonal Upstream Status", "SMTR1607-7-I21-05:status", this);
+	horizontalUpstreamStopControl_ = new AMSinglePVControl("Main Horizonal Upstream Stop", "SMTR1607-7-I21-05:stop", this);
+
+	horizontalDownstreamControl_ = new AMSinglePVControl("Main Horizonal Downstream", "SMTR1607-7-I21-06:mm", this, 0.001);
+	horizontalDownstreamFeedbackControl_ = new AMReadOnlyPVControl("Main Horizonal Downstream Feedback", "SMTR1607-7-I21-06:mm:fbk", this);
+	horizontalDownstreamStatusControl_ = new AMReadOnlyPVControl("Main Horizonal Downstream Status", "SMTR1607-7-I21-06:status", this);
+	horizontalDownstreamStopControl_ = new AMSinglePVControl("Main Horizonal Downstream Stop", "SMTR1607-7-I21-06:stop", this);
+}
+
+void BioXASMainTableCoordinator::initializeSoftIOCMotorControls()
+{
+	softIOCHeightControl_ = new AMSinglePVControl("Main softIOC Height", "BL1607-7-I21:Height:mm", this, 0.001);
+	softIOCHeightFeedbackControl_ = new AMSinglePVControl("Main softIOC Height Feedback", "BL1607-7-I21:Height:mm:fbk", this, 0.001);
+	softIOCHeightStatusControl_ = new AMSinglePVControl("Main softIOC Height Status", "BL1607-7-I21:Height:status", this, 0.5);
+	softIOCHeightStopControl_ = new AMSinglePVControl("Main softIOC Height Stop", "BL1607-7-I21:Height:stop", this, 0.5);
+
+	softIOCPitchControl_ = new AMSinglePVControl("Main softIOC Pitch", "BL1607-7-I21:Pitch:deg", this, 0.001);
+	softIOCPitchFeedbackControl_ = new AMSinglePVControl("Main softIOC Pitch Feedback", "BL1607-7-I21:Pitch:deg:fbk", this, 0.001);
+	softIOCPitchStatusControl_ = new AMSinglePVControl("Main softIOC Pitch Status", "BL1607-7-I21:Pitch:status", this, 0.5);
+	softIOCPitchStopControl_ = new AMSinglePVControl("Main softIOC Pitch Stop", "BL1607-7-I21:Pitch:stop", this, 0.5);
+
+	softIOCRollControl_ = new AMSinglePVControl("Main softIOC Roll", "BL1607-7-I21:Roll:deg", this, 0.001);
+	softIOCRollFeedbackControl_ = new AMSinglePVControl("Main softIOC Roll Feedback", "BL1607-7-I21:Roll:deg:fbk", this, 0.001);
+	softIOCRollStatusControl_ = new AMSinglePVControl("Main softIOC Roll Status", "BL1607-7-I21:Roll:status", this, 0.5);
+	softIOCRollStopControl_ = new AMSinglePVControl("Main softIOC Roll Stop", "BL1607-7-I21:Roll:stop", this, 0.5);
+
+	softIOCLateralControl_ = new AMSinglePVControl("Main softIOC Lateral", "BL1607-7-I21:Lateral:mm", this, 0.001);
+	softIOCLateralFeedbackControl_ = new AMSinglePVControl("Main softIOC Lateral Feedback", "BL1607-7-I21:Lateral:mm:fbk", this, 0.001);
+	softIOCLateralStatusControl_ = new AMSinglePVControl("Main softIOC Lateral Status", "BL1607-7-I21:Lateral:status", this, 0.5);
+	softIOCLateralStopControl_ = new AMSinglePVControl("Main softIOC Lateral Stop", "BL1607-7-I21:Lateral:stop", this, 0.5);
+
+	softIOCYawControl_ = new AMSinglePVControl("Main softIOC Yaw", "BL1607-7-I21:Yaw:deg", this, 0.001);
+	softIOCYawFeedbackControl_ = new AMSinglePVControl("Main softIOC Yaw Feedback", "BL1607-7-I21:Yaw:deg:fbk", this, 0.001);
+	softIOCYawStatusControl_ = new AMSinglePVControl("Main softIOC Yaw Status", "BL1607-7-I21:Yaw:status", this, 0.5);
+	softIOCYawStopControl_ = new AMSinglePVControl("Main softIOC Yaw Stop", "BL1607-7-I21:Yaw:stop", this, 0.5);
+}
+
+void BioXASMainTableCoordinator::initializePVControlSet()
+{
+	allControls_ = new AMControlSet(this);
+
+	// physical PV controls
+	allControls_->addControl(verticalUpstreamControl_);
+	allControls_->addControl(verticalUpstreamFeedbackControl_);
+	allControls_->addControl(verticalUpstreamStatusControl_);
+	allControls_->addControl(verticalUpstreamStopControl_);
+	allControls_->addControl(verticalDownstreamInboundControl_);
+	allControls_->addControl(verticalDownstreamInboundFeedbackControl_);
+	allControls_->addControl(verticalDownstreamInboundStatusControl_);
+	allControls_->addControl(verticalDownstreamInboundStopControl_);
+	allControls_->addControl(verticalDownstreamOutboundControl_);
+	allControls_->addControl(verticalDownstreamOutboundFeedbackControl_);
+	allControls_->addControl(verticalDownstreamOutboundStatusControl_);
+	allControls_->addControl(verticalDownstreamOutboundStopControl_);
+	allControls_->addControl(horizontalUpstreamControl_);
+	allControls_->addControl(horizontalUpstreamFeedbackControl_);
+	allControls_->addControl(horizontalUpstreamStatusControl_);
+	allControls_->addControl(horizontalUpstreamStopControl_);
+	allControls_->addControl(horizontalDownstreamControl_);
+	allControls_->addControl(horizontalDownstreamFeedbackControl_);
+	allControls_->addControl(horizontalDownstreamStatusControl_);
+	allControls_->addControl(horizontalDownstreamStopControl_);
+
+	// SoftIOC PV controls
+	allControls_->addControl(softIOCHeightControl_);
+	allControls_->addControl(softIOCHeightFeedbackControl_);
+	allControls_->addControl(softIOCHeightStatusControl_);
+	allControls_->addControl(softIOCHeightStopControl_);
+	allControls_->addControl(softIOCPitchControl_);
+	allControls_->addControl(softIOCPitchFeedbackControl_);
+	allControls_->addControl(softIOCPitchStatusControl_);
+	allControls_->addControl(softIOCPitchStopControl_);
+	allControls_->addControl(softIOCRollControl_);
+	allControls_->addControl(softIOCRollFeedbackControl_);
+	allControls_->addControl(softIOCRollStatusControl_);
+	allControls_->addControl(softIOCRollStopControl_);
+
+	allControls_->addControl(softIOCLateralControl_);
+	allControls_->addControl(softIOCLateralFeedbackControl_);
+	allControls_->addControl(softIOCLateralStatusControl_);
+	allControls_->addControl(softIOCLateralStopControl_);
+	allControls_->addControl(softIOCYawControl_);
+	allControls_->addControl(softIOCYawFeedbackControl_);
+	allControls_->addControl(softIOCYawStatusControl_);
+	allControls_->addControl(softIOCYawStopControl_);
+}
+
+void BioXASMainTableCoordinator::initializeSignalConnector()
+{
+	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(onAllControlsConnected(bool)));
+
+	// physical PV controls
+	connect(verticalUpstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
+	connect(verticalUpstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
+
+	connect(verticalDownstreamInboundFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
+	connect(verticalDownstreamInboundStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
+
+	connect(verticalDownstreamOutboundFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
+	connect(verticalDownstreamOutboundStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
+
+	connect(horizontalUpstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalFeedbackControlValueChanged()));
+	connect(horizontalUpstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalStatusControlValueChanged()));
+
+	connect(horizontalDownstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalFeedbackControlValueChanged()));
+	connect(horizontalDownstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalStatusControlValueChanged()));
+
+
+	// SoftIOC PV controls
+	connect(softIOCHeightControl_, SIGNAL(valueChanged(double)), this, SLOT(onHeightControlValueChanged(double)));
+	connect(softIOCHeightStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onHeightStopControlValueChanged()));
+	connect(softIOCPitchControl_, SIGNAL(valueChanged(double)), this, SLOT(onPitchControlValueChanged(double)));
+	connect(softIOCPitchStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onPitchStopControlValueChanged()));
+	connect(softIOCRollControl_, SIGNAL(valueChanged(double)), this, SLOT(onRollControlValueChanged(double)));
+	connect(softIOCRollStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onRollStopControlValueChanged()));
+
+	connect(softIOCLateralControl_, SIGNAL(valueChanged(double)), this, SLOT(onLateralControlValueChanged(double)));
+	connect(softIOCLateralStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onLateralStopControlValueChanged()));
+	connect(softIOCYawControl_, SIGNAL(valueChanged(double)), this, SLOT(onYawControlValueChanged(double)));
+	connect(softIOCYawStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onYawStopControlValueChanged()));
+
+}
+
+double BioXASMainTableCoordinator::calculateTableHeight(double upstreamHeight, double downstreamInboundHeight, double downstreamOutboundHeight) const
+{
+	double downstreamHeight = (downstreamInboundHeight + downstreamOutboundHeight) / 2;
+
+	// The vertical height is the height of the center of the table, which is the average of upstream value and the downstream value
+	return (upstreamHeight + downstreamHeight) / 2;
+}
+
+double BioXASMainTableCoordinator::calculateTablePitch(double upstreamHeight, double downstreamInboundHeight, double downstreamOutboundHeight) const
+{
+	double downstreamHeight = (downstreamInboundHeight + downstreamOutboundHeight) / 2;
+
+	// The pitch is the degree of the arcTangent value of (dH - uH) / distance
+	return radianToDegree(atan((downstreamHeight - upstreamHeight) / (tableVerticalMotorPosition_ * 2)));
+}
+
+double BioXASMainTableCoordinator::calculateTableRoll(double downstreamInboundHeight, double downstreamOutboundHeight) const
+{
+	// The Roll is the degree of the arcTangent value of (dOutH - dInH) / distance
+	return radianToDegree(atan((downstreamOutboundHeight - downstreamInboundHeight) / (tableVerticalDownstreamMotorPosition_ * 2)));
+}
+
+double BioXASMainTableCoordinator::calculateTableLateral(const double upstreamLateral, const double downstreamLateral) const
+{
+	// The lateral is the lateral of the center of the table, which is the average of upstream value and the downstream value
+	return ( upstreamLateral + downstreamLateral ) / 2;
+}
+
+double BioXASMainTableCoordinator::calculateTableYaw(const double upstreamLateral, const double downstreamLateral) const
+{
+	// The yaw is the degree of the arcTangent value of (dH - uH) / distance
+	return radianToDegree(atan((downstreamLateral - upstreamLateral) / (tableHorizontalMotorPosition_ * 2)));
+}
+
+void BioXASMainTableCoordinator::manipulateVerticalPVChange(double upstreamHeight, double downstreamInboundHeight, double downstreamOutboundHeight, AMControl* heightPV, AMControl *pitchPV, AMControl *rollPV)
+{
+	double height = calculateTableHeight(upstreamHeight, downstreamInboundHeight, downstreamOutboundHeight);
+	double pitch =  calculateTablePitch(upstreamHeight, downstreamInboundHeight, downstreamOutboundHeight);
+	double roll =  calculateTableRoll(downstreamInboundHeight, downstreamOutboundHeight);
+
+	if (!heightPV->withinTolerance(height)) {
+		heightPV->move(height);
+	}
+
+	if (!pitchPV->withinTolerance(pitch)) {
+		pitchPV->move(pitch);
+	}
+
+	if (!rollPV->withinTolerance(roll)) {
+		rollPV->move(roll);
+	}
+}
+
+void BioXASMainTableCoordinator::manipulateHorizontalPVChange(double upstreamOffset, double downstreamOffset, AMControl* lateralPV, AMControl* yawPV)
+{
+	double lateral = calculateTableLateral(upstreamOffset, downstreamOffset);
+	double yaw = calculateTableYaw(upstreamOffset, downstreamOffset);
+
+	if ( !lateralPV->withinTolerance(lateral) ) {
+		lateralPV->move(lateral);
+	}
+	if ( !yawPV->withinTolerance(yaw) ) {
+		yawPV->move(yaw);
+	}
+}

--- a/source/beamline/BioXAS/BioXASMainTableCoordinator.h
+++ b/source/beamline/BioXAS/BioXASMainTableCoordinator.h
@@ -1,0 +1,211 @@
+/*
+Copyright 2010-2012 Mark Boots, David Chevrier, and Darren Hunter.
+Copyright 2013-2014 David Chevrier and Darren Hunter.
+
+This file is part of the Acquaman Data Acquisition and Management framework ("Acquaman").
+Acquaman is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Acquaman is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef BIOXASMAINTABLECOORDINATOR_H
+#define BIOXASMAINTABLECOORDINATOR_H
+
+#include "beamline/AMControlSet.h"
+
+///
+/// NOTE:
+/// The position of Height / lateral / pitch / yaw is based on the position of the center of the table
+///
+
+class BioXASMainTableCoordinator : public QObject
+{
+	Q_OBJECT
+public:
+	/// Simple constructor for class
+	BioXASMainTableCoordinator(QObject *parent = 0);
+
+	/// Destructor
+	virtual ~BioXASMainTableCoordinator();
+
+protected slots:
+	/// Handles watching for when the controls actually connect
+	void onAllControlsConnected(bool connected);
+
+	/// ===== Handles changes coming from the MaxVMotor controls ====
+	/// Handles Vertical Upstream/Downstream feedback control value changed
+	void onVerticalFeedbackControlValueChanged();
+	/// Handles Vertical Upstream/Downstream status control value changed
+	void onVerticalStatusControlValueChanged();
+
+	/// Handles Horizontal Upstream/Downstrea feedback control value changed
+	void onHorizontalFeedbackControlValueChanged();
+	/// Handles Horizontal Upstream/Downstrea status control value changed
+	void onHorizontalStatusControlValueChanged();
+
+	/// ==== Handles changes coming from the softIOC conrols ====
+	/// Handles table Height control value changed
+	void onHeightControlValueChanged(double value);
+	/// Handles table Height stop control value changed
+	void onHeightStopControlValueChanged();
+	/// Handles table Pitch control value changed
+	void onPitchControlValueChanged(double angle);
+	/// Handles table Pitch stop control value changed
+	void onPitchStopControlValueChanged();
+	/// Handles table Roll control value changed
+	void onRollControlValueChanged(double angle);
+	/// Handles table Roll stop control value changed
+	void onRollStopControlValueChanged();
+
+	/// Handles table Lateral control value changed
+	void onLateralControlValueChanged(double value);
+	/// Handles table Lateral stop control value changed
+	void onLateralStopControlValueChanged();
+	/// Handles table Yaw control value changed
+	void onYawControlValueChanged(double angle);
+	/// Handles table yaw stop control value changed
+	void onYawStopControlValueChanged();
+
+
+protected:
+	double radianToDegree(double radian) const { return radian * 57.2957795; }
+	double degreeToRadian(double degree) const { return degree * 0.0174532925; }
+
+	/// to initialize the phycisal Motor controls
+	void initializePhysicalMotorControls();
+	/// to initialize the softIOC Motor controls
+	void initializeSoftIOCMotorControls();
+	/// to initialize the PV control set
+	void initializePVControlSet();
+	/// to initialize the signal slot connectors
+	void initializeSignalConnector();
+
+	/// get the current height of the tablle
+	double calculateTableHeight(double upstreamHeight, double downstreamInboundHeight, double downstreamOutboundHeight) const;
+	/// get the current pitch of the tablle
+	double calculateTablePitch(double upstreamHeight, double downstreamInboundHeight, double downstreamOutboundHeight) const;
+	/// get the current Roll of the tablle
+	double calculateTableRoll(double downstreamInboundHeight, double downstreamOutboundHeight) const;
+	/// get the current lateral of the tablle
+	double calculateTableLateral(const double upstreamLateral, const double downstreamLateral) const;
+	/// get the current yaw of the tablle
+	double calculateTableYaw(const double upstreamLateral, const double downstreamLateral) const;
+
+	/// Apply the value changes of the vertical (feedback) PVs to the softIOC height (feedback) PV, Pitch (feedback) PV, Roll (feedback) PV
+	void manipulateVerticalPVChange(double upstreamHeight, double downstreamInboundHeight, double downstreamOutboundHeight, AMControl* heightPV, AMControl *pitchPV, AMControl *rollPV);
+	/// Apply the value changes of the horizontal (feedback) PVs to the softIOC lateral (feedback) PV and yaw (feedback) PV
+	void manipulateHorizontalPVChange(double upstreamOffset, double downstreamOffset, AMControl* lateralPV, AMControl* yawPV);
+
+protected:
+	/// const for motors
+	double tableVerticalMotorPosition_; // the distance between the upstream / downstream motor to the center of the table, which is fixed
+	double tableVerticalDownstreamMotorPosition_; // the distance between the downstream motors to the center of the table (central line), which is fixed
+	double tableHorizontalMotorPosition_; // the distance between the upstream / downstream motor to the center of the table, which is fixed
+
+	/// flag of whether the coordinator is initialized or not
+	bool initialized_;
+	/// Holds whether or not we've connected at least once
+	bool connectedOnce_;
+	/// All the controls (for checking connectivity)
+	AMControlSet *allControls_;
+
+	/// ============ Original PVs ==================
+	/// BioXAS Main table Vertical Upstream PV control
+	AMControl *verticalUpstreamControl_;
+	/// BioXAS Main table Vertical Upstream feedbak PV control
+	AMControl *verticalUpstreamFeedbackControl_;
+	/// BioXAS Main table Vertical Upstream status PV control
+	AMControl *verticalUpstreamStatusControl_;
+	AMControl *verticalUpstreamStopControl_;
+
+	/// BioXAS Main table Vertical Downstream Inbound PV control
+	AMControl *verticalDownstreamInboundControl_;
+	/// BioXAS Main table Vertical Downstream feedbak PV control
+	AMControl *verticalDownstreamInboundFeedbackControl_;
+	/// BioXAS Main table Vertical Downstream status PV control
+	AMControl *verticalDownstreamInboundStatusControl_;
+	AMControl *verticalDownstreamInboundStopControl_;
+
+	/// BioXAS Main table Vertical Downstream Outbound PV control
+	AMControl *verticalDownstreamOutboundControl_;
+	/// BioXAS Main table Vertical Downstream feedbak PV control
+	AMControl *verticalDownstreamOutboundFeedbackControl_;
+	/// BioXAS Main table Vertical Downstream status PV control
+	AMControl *verticalDownstreamOutboundStatusControl_;
+	AMControl *verticalDownstreamOutboundStopControl_;
+
+	/// BioXAS Main table Horizontal Upstream PV control
+	AMControl *horizontalUpstreamControl_;
+	/// BioXAS Main table Horizontal Upstream feedbak PV control
+	AMControl *horizontalUpstreamFeedbackControl_;
+	/// BioXAS Main table Horizontal Upstream status PV control
+	AMControl *horizontalUpstreamStatusControl_;
+	AMControl *horizontalUpstreamStopControl_;
+
+	/// BioXAS Main table horizonal Downstream PV control
+	AMControl *horizontalDownstreamControl_;
+	/// BioXAS Main table Horizontal Downstream feedbak PV control
+	AMControl *horizontalDownstreamFeedbackControl_;
+	/// BioXAS Main table Horizontal Downstream status PV control
+	AMControl *horizontalDownstreamStatusControl_;
+	AMControl *horizontalDownstreamStopControl_;
+
+	/// ============ SoftIOC PVs ==================
+	/// BioXAS Main table softIOC height PV control
+	AMControl *softIOCHeightControl_;
+	/// BioXAS Main table softIOC height feedbak PV control
+	AMControl *softIOCHeightFeedbackControl_;
+	/// BioXAS Main table softIOC height status PV control
+	AMControl *softIOCHeightStatusControl_;
+	/// BioXAS Main table softIOC height stop PV control
+	AMControl *softIOCHeightStopControl_;
+
+	/// BioXAS Main table softIOC pitch PV control
+	AMControl *softIOCPitchControl_;
+	/// BioXAS Main table softIOC pitch feedbak PV control
+	AMControl *softIOCPitchFeedbackControl_;
+	/// BioXAS Main table softIOC pitch status PV control
+	AMControl *softIOCPitchStatusControl_;
+	/// BioXAS Main table softIOC pitch stop PV control
+	AMControl *softIOCPitchStopControl_;
+
+	/// BioXAS Main table softIOC Roll PV control
+	AMControl *softIOCRollControl_;
+	/// BioXAS Main table softIOC Roll feedbak PV control
+	AMControl *softIOCRollFeedbackControl_;
+	/// BioXAS Main table softIOC Roll status PV control
+	AMControl *softIOCRollStatusControl_;
+	/// BioXAS Main table softIOC Roll stop PV control
+	AMControl *softIOCRollStopControl_;
+
+	/// BioXAS Main table softIOC Lateral PV control
+	AMControl *softIOCLateralControl_;
+	/// BioXAS Main table softIOC Lateral feedbak PV control
+	AMControl *softIOCLateralFeedbackControl_;
+	/// BioXAS Main table softIOC Lateral status PV control
+	AMControl *softIOCLateralStatusControl_;
+	/// BioXAS Main table softIOC Lateral stop PV control
+	AMControl *softIOCLateralStopControl_;
+
+	/// BioXAS Main table softIOC yaw PV control
+	AMControl *softIOCYawControl_;
+	/// BioXAS Main table softIOC yaw feedbak PV control
+	AMControl *softIOCYawFeedbackControl_;
+	/// BioXAS Main table softIOC yaw status PV control
+	AMControl *softIOCYawStatusControl_;
+	/// BioXAS Main table softIOC yaw stop PV control
+	AMControl *softIOCYawStopControl_;
+
+};
+
+#endif // BIOXASMAINTABLECOORDINATOR_H

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -249,7 +249,7 @@ public:
 	/// Returns the four element Vortex detector.
 //	BioXASFourElementVortexDetector *fourElementVortexDetector() const { return fourElementVortexDetector_; }
 
-	// Endstation table
+	/// Endstation table
 	BioXASEndstationTable *endstationTable() const { return endstationTable_; }
 
 signals:
@@ -465,7 +465,7 @@ protected:
 
 	AMControlSet *temperatureSet_;
 
-	// endstation table
+	/// endstation table
 	BioXASEndstationTable *endstationTable_;
 
 	/// Cryostat motors.

--- a/source/beamline/BioXAS/BioXASSideTableCoordinator.cpp
+++ b/source/beamline/BioXAS/BioXASSideTableCoordinator.cpp
@@ -34,105 +34,10 @@ BioXASSideTableCoordinator::BioXASSideTableCoordinator(QObject *parent) :
 	initialized_ = false;
 	connectedOnce_ = false;
 
-	// ============ Original PVs ==================
-	verticalUpstreamControl_ = new AMSinglePVControl("Side Vertical Upstream", "SMTR1607-6-I22-02:mm", this, 0.001);
-	verticalUpstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Vertical Upstream Feedback", "SMTR1607-6-I22-02:mm:fbk", this);
-	verticalUpstreamStatusControl_ = new AMReadOnlyPVControl("Side Vertical Upstream Status", "SMTR1607-6-I22-02:status", this);
-	verticalUpstreamStopControl_ = new AMSinglePVControl("Side Vertical Upstream Stop", "SMTR1607-6-I22-02:stop", this);
-
-	verticalDownstreamControl_ = new AMSinglePVControl("Side Vertical Downstream", "SMTR1607-6-I22-03:mm", this, 0.001);
-	verticalDownstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Vertical Downstream Feedback", "SMTR1607-6-I22-03:mm:fbk", this);
-	verticalDownstreamStatusControl_ = new AMReadOnlyPVControl("Side Vertical Downstream Status", "SMTR1607-6-I22-03:status", this);
-	verticalDownstreamStopControl_ = new AMSinglePVControl("Side Vertical Downstream Stop", "SMTR1607-6-I22-03:stop", this);
-
-
-	horizontalUpstreamControl_ = new AMSinglePVControl("Side Horizonal Upstream", "SMTR1607-6-I22-04:mm", this, 0.001);
-	horizontalUpstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Horizonal Upstream Feedback", "SMTR1607-6-I22-04:mm:fbk", this);
-	horizontalUpstreamStatusControl_ = new AMReadOnlyPVControl("Side Horizonal Upstream Status", "SMTR1607-6-I22-04:status", this);
-	horizontalUpstreamStopControl_ = new AMSinglePVControl("Side Horizonal Upstream Stop", "SMTR1607-6-I22-04:stop", this);
-
-	horizontalDownstreamControl_ = new AMSinglePVControl("Side Horizonal Downstream", "SMTR1607-6-I22-05:mm", this, 0.001);
-	horizontalDownstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Horizonal Downstream Feedback", "SMTR1607-6-I22-05:mm:fbk", this);
-	horizontalDownstreamStatusControl_ = new AMReadOnlyPVControl("Side Horizonal Downstream Status", "SMTR1607-6-I22-05:status", this);
-	horizontalDownstreamStopControl_ = new AMSinglePVControl("Side Horizonal Downstream Stop", "SMTR1607-6-I22-05:stop", this);
-
-	// ============ SoftIOC PVs ==================
-	softIOCHeightControl_ = new AMSinglePVControl("Side softIOC Height", "BL1607-6-I22:Height:mm", this, 0.001);
-	softIOCHeightFeedbackControl_ = new AMSinglePVControl("Side softIOC Height Feedback", "BL1607-6-I22:Height:mm:fbk", this, 0.001);
-	softIOCHeightStatusControl_ = new AMSinglePVControl("Side softIOC Height Status", "BL1607-6-I22:Height:status", this, 0.5);
-	softIOCHeightStopControl_ = new AMSinglePVControl("Side softIOC Height Stop", "BL1607-6-I22:Height:stop", this, 0.5);
-
-	softIOCPitchControl_ = new AMSinglePVControl("Side softIOC Pitch", "BL1607-6-I22:Pitch:deg", this, 0.001);
-	softIOCPitchFeedbackControl_ = new AMSinglePVControl("Side softIOC Pitch Feedback", "BL1607-6-I22:Pitch:deg:fbk", this, 0.001);
-	softIOCPitchStatusControl_ = new AMSinglePVControl("Side softIOC Pitch Status", "BL1607-6-I22:Pitch:status", this, 0.5);
-	softIOCPitchStopControl_ = new AMSinglePVControl("Side softIOC Pitch Stop", "BL1607-6-I22:Pitch:stop", this, 0.5);
-
-	softIOCLateralControl_ = new AMSinglePVControl("Side softIOC Lateral", "BL1607-6-I22:Lateral:mm", this, 0.001);
-	softIOCLateralFeedbackControl_ = new AMSinglePVControl("Side softIOC Lateral Feedback", "BL1607-6-I22:Lateral:mm:fbk", this, 0.001);
-	softIOCLateralStatusControl_ = new AMSinglePVControl("Side softIOC Lateral Status", "BL1607-6-I22:Lateral:status", this, 0.5);
-	softIOCLateralStopControl_ = new AMSinglePVControl("Side softIOC Lateral Stop", "BL1607-6-I22:Lateral:stop", this, 0.5);
-
-	softIOCYawControl_ = new AMSinglePVControl("Side softIOC Yaw", "BL1607-6-I22:Yaw:deg", this, 0.001);
-	softIOCYawFeedbackControl_ = new AMSinglePVControl("Side softIOC Yaw Feedback", "BL1607-6-I22:Yaw:deg:fbk", this, 0.001);
-	softIOCYawStatusControl_ = new AMSinglePVControl("Side softIOC Yaw Status", "BL1607-6-I22:Yaw:status", this, 0.5);
-	softIOCYawStopControl_ = new AMSinglePVControl("Side softIOC Yaw Stop", "BL1607-6-I22:Yaw:stop", this, 0.5);
-
-	allControls_ = new AMControlSet(this);
-	allControls_->addControl(verticalUpstreamControl_);
-	allControls_->addControl(verticalUpstreamFeedbackControl_);
-	allControls_->addControl(verticalUpstreamStatusControl_);
-	allControls_->addControl(verticalUpstreamStopControl_);
-	allControls_->addControl(verticalDownstreamControl_);
-	allControls_->addControl(verticalDownstreamFeedbackControl_);
-	allControls_->addControl(verticalDownstreamStatusControl_);
-	allControls_->addControl(verticalDownstreamStopControl_);
-	allControls_->addControl(horizontalUpstreamControl_);
-	allControls_->addControl(horizontalUpstreamFeedbackControl_);
-	allControls_->addControl(horizontalUpstreamStatusControl_);
-	allControls_->addControl(horizontalUpstreamStopControl_);
-	allControls_->addControl(horizontalDownstreamControl_);
-	allControls_->addControl(horizontalDownstreamFeedbackControl_);
-	allControls_->addControl(horizontalDownstreamStatusControl_);
-	allControls_->addControl(horizontalDownstreamStopControl_);
-	allControls_->addControl(softIOCHeightControl_);
-	allControls_->addControl(softIOCHeightFeedbackControl_);
-	allControls_->addControl(softIOCHeightStatusControl_);
-	allControls_->addControl(softIOCHeightStopControl_);
-	allControls_->addControl(softIOCPitchControl_);
-	allControls_->addControl(softIOCPitchFeedbackControl_);
-	allControls_->addControl(softIOCPitchStatusControl_);
-	allControls_->addControl(softIOCPitchStopControl_);
-	allControls_->addControl(softIOCLateralControl_);
-	allControls_->addControl(softIOCLateralFeedbackControl_);
-	allControls_->addControl(softIOCLateralStatusControl_);
-	allControls_->addControl(softIOCLateralStopControl_);
-	allControls_->addControl(softIOCYawControl_);
-	allControls_->addControl(softIOCYawFeedbackControl_);
-	allControls_->addControl(softIOCYawStatusControl_);
-	allControls_->addControl(softIOCYawStopControl_);
-
-	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(onAllControlsConnected(bool)));
-
-	connect(verticalUpstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
-	connect(verticalUpstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
-
-	connect(verticalDownstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
-	connect(verticalDownstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
-
-	connect(horizontalUpstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalFeedbackControlValueChanged()));
-	connect(horizontalUpstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalStatusControlValueChanged()));
-
-	connect(horizontalDownstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalFeedbackControlValueChanged()));
-	connect(horizontalDownstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalStatusControlValueChanged()));
-
-	connect(softIOCHeightControl_, SIGNAL(valueChanged(double)), this, SLOT(onHeightControlValueChanged(double)));
-	connect(softIOCHeightStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onHeightStopControlValueChanged()));
-	connect(softIOCPitchControl_, SIGNAL(valueChanged(double)), this, SLOT(onPitchControlValueChanged(double)));
-	connect(softIOCPitchStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onPitchStopControlValueChanged()));
-	connect(softIOCLateralControl_, SIGNAL(valueChanged(double)), this, SLOT(onLateralControlValueChanged(double)));
-	connect(softIOCLateralStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onLateralStopControlValueChanged()));
-	connect(softIOCYawControl_, SIGNAL(valueChanged(double)), this, SLOT(onYawControlValueChanged(double)));
-	connect(softIOCYawStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onYawStopControlValueChanged()));
+	initializePhysicalMotorControls();
+	initializeSoftIOCMotorControls();
+	initializePVControlSet();
+	initializeSignalConnector();
 }
 
 BioXASSideTableCoordinator::~BioXASSideTableCoordinator(){}
@@ -326,6 +231,125 @@ void BioXASSideTableCoordinator::onYawStopControlValueChanged()
 
 		softIOCYawStopControl_->move(0); // restore the value to 0
 	}
+}
+
+void BioXASSideTableCoordinator::initializePhysicalMotorControls()
+{
+	// ============ Physical PVs ==================
+	verticalUpstreamControl_ = new AMSinglePVControl("Side Vertical Upstream", "SMTR1607-6-I22-02:mm", this, 0.001);
+	verticalUpstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Vertical Upstream Feedback", "SMTR1607-6-I22-02:mm:fbk", this);
+	verticalUpstreamStatusControl_ = new AMReadOnlyPVControl("Side Vertical Upstream Status", "SMTR1607-6-I22-02:status", this);
+	verticalUpstreamStopControl_ = new AMSinglePVControl("Side Vertical Upstream Stop", "SMTR1607-6-I22-02:stop", this);
+
+	verticalDownstreamControl_ = new AMSinglePVControl("Side Vertical Downstream", "SMTR1607-6-I22-03:mm", this, 0.001);
+	verticalDownstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Vertical Downstream Feedback", "SMTR1607-6-I22-03:mm:fbk", this);
+	verticalDownstreamStatusControl_ = new AMReadOnlyPVControl("Side Vertical Downstream Status", "SMTR1607-6-I22-03:status", this);
+	verticalDownstreamStopControl_ = new AMSinglePVControl("Side Vertical Downstream Stop", "SMTR1607-6-I22-03:stop", this);
+
+
+	horizontalUpstreamControl_ = new AMSinglePVControl("Side Horizonal Upstream", "SMTR1607-6-I22-04:mm", this, 0.001);
+	horizontalUpstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Horizonal Upstream Feedback", "SMTR1607-6-I22-04:mm:fbk", this);
+	horizontalUpstreamStatusControl_ = new AMReadOnlyPVControl("Side Horizonal Upstream Status", "SMTR1607-6-I22-04:status", this);
+	horizontalUpstreamStopControl_ = new AMSinglePVControl("Side Horizonal Upstream Stop", "SMTR1607-6-I22-04:stop", this);
+
+	horizontalDownstreamControl_ = new AMSinglePVControl("Side Horizonal Downstream", "SMTR1607-6-I22-05:mm", this, 0.001);
+	horizontalDownstreamFeedbackControl_ = new AMReadOnlyPVControl("Side Horizonal Downstream Feedback", "SMTR1607-6-I22-05:mm:fbk", this);
+	horizontalDownstreamStatusControl_ = new AMReadOnlyPVControl("Side Horizonal Downstream Status", "SMTR1607-6-I22-05:status", this);
+	horizontalDownstreamStopControl_ = new AMSinglePVControl("Side Horizonal Downstream Stop", "SMTR1607-6-I22-05:stop", this);
+}
+
+void BioXASSideTableCoordinator::initializeSoftIOCMotorControls()
+{
+	// ============ SoftIOC PVs ==================
+	softIOCHeightControl_ = new AMSinglePVControl("Side softIOC Height", "BL1607-6-I22:Height:mm", this, 0.001);
+	softIOCHeightFeedbackControl_ = new AMSinglePVControl("Side softIOC Height Feedback", "BL1607-6-I22:Height:mm:fbk", this, 0.001);
+	softIOCHeightStatusControl_ = new AMSinglePVControl("Side softIOC Height Status", "BL1607-6-I22:Height:status", this, 0.5);
+	softIOCHeightStopControl_ = new AMSinglePVControl("Side softIOC Height Stop", "BL1607-6-I22:Height:stop", this, 0.5);
+
+	softIOCPitchControl_ = new AMSinglePVControl("Side softIOC Pitch", "BL1607-6-I22:Pitch:deg", this, 0.001);
+	softIOCPitchFeedbackControl_ = new AMSinglePVControl("Side softIOC Pitch Feedback", "BL1607-6-I22:Pitch:deg:fbk", this, 0.001);
+	softIOCPitchStatusControl_ = new AMSinglePVControl("Side softIOC Pitch Status", "BL1607-6-I22:Pitch:status", this, 0.5);
+	softIOCPitchStopControl_ = new AMSinglePVControl("Side softIOC Pitch Stop", "BL1607-6-I22:Pitch:stop", this, 0.5);
+
+	softIOCLateralControl_ = new AMSinglePVControl("Side softIOC Lateral", "BL1607-6-I22:Lateral:mm", this, 0.001);
+	softIOCLateralFeedbackControl_ = new AMSinglePVControl("Side softIOC Lateral Feedback", "BL1607-6-I22:Lateral:mm:fbk", this, 0.001);
+	softIOCLateralStatusControl_ = new AMSinglePVControl("Side softIOC Lateral Status", "BL1607-6-I22:Lateral:status", this, 0.5);
+	softIOCLateralStopControl_ = new AMSinglePVControl("Side softIOC Lateral Stop", "BL1607-6-I22:Lateral:stop", this, 0.5);
+
+	softIOCYawControl_ = new AMSinglePVControl("Side softIOC Yaw", "BL1607-6-I22:Yaw:deg", this, 0.001);
+	softIOCYawFeedbackControl_ = new AMSinglePVControl("Side softIOC Yaw Feedback", "BL1607-6-I22:Yaw:deg:fbk", this, 0.001);
+	softIOCYawStatusControl_ = new AMSinglePVControl("Side softIOC Yaw Status", "BL1607-6-I22:Yaw:status", this, 0.5);
+	softIOCYawStopControl_ = new AMSinglePVControl("Side softIOC Yaw Stop", "BL1607-6-I22:Yaw:stop", this, 0.5);
+}
+
+void BioXASSideTableCoordinator::initializePVControlSet()
+{
+	allControls_ = new AMControlSet(this);
+
+	// ============ Physical PVs ==================
+	allControls_->addControl(verticalUpstreamControl_);
+	allControls_->addControl(verticalUpstreamFeedbackControl_);
+	allControls_->addControl(verticalUpstreamStatusControl_);
+	allControls_->addControl(verticalUpstreamStopControl_);
+	allControls_->addControl(verticalDownstreamControl_);
+	allControls_->addControl(verticalDownstreamFeedbackControl_);
+	allControls_->addControl(verticalDownstreamStatusControl_);
+	allControls_->addControl(verticalDownstreamStopControl_);
+	allControls_->addControl(horizontalUpstreamControl_);
+	allControls_->addControl(horizontalUpstreamFeedbackControl_);
+	allControls_->addControl(horizontalUpstreamStatusControl_);
+	allControls_->addControl(horizontalUpstreamStopControl_);
+	allControls_->addControl(horizontalDownstreamControl_);
+	allControls_->addControl(horizontalDownstreamFeedbackControl_);
+	allControls_->addControl(horizontalDownstreamStatusControl_);
+	allControls_->addControl(horizontalDownstreamStopControl_);
+
+
+	// ============ SoftIOC PVs ==================
+	allControls_->addControl(softIOCHeightControl_);
+	allControls_->addControl(softIOCHeightFeedbackControl_);
+	allControls_->addControl(softIOCHeightStatusControl_);
+	allControls_->addControl(softIOCHeightStopControl_);
+	allControls_->addControl(softIOCPitchControl_);
+	allControls_->addControl(softIOCPitchFeedbackControl_);
+	allControls_->addControl(softIOCPitchStatusControl_);
+	allControls_->addControl(softIOCPitchStopControl_);
+	allControls_->addControl(softIOCLateralControl_);
+	allControls_->addControl(softIOCLateralFeedbackControl_);
+	allControls_->addControl(softIOCLateralStatusControl_);
+	allControls_->addControl(softIOCLateralStopControl_);
+	allControls_->addControl(softIOCYawControl_);
+	allControls_->addControl(softIOCYawFeedbackControl_);
+	allControls_->addControl(softIOCYawStatusControl_);
+	allControls_->addControl(softIOCYawStopControl_);
+}
+
+void BioXASSideTableCoordinator::initializeSignalConnector()
+{
+	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(onAllControlsConnected(bool)));
+
+	// ============ Physical PVs ==================
+	connect(verticalUpstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
+	connect(verticalUpstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
+
+	connect(verticalDownstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalFeedbackControlValueChanged()));
+	connect(verticalDownstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onVerticalStatusControlValueChanged()));
+
+	connect(horizontalUpstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalFeedbackControlValueChanged()));
+	connect(horizontalUpstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalStatusControlValueChanged()));
+
+	connect(horizontalDownstreamFeedbackControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalFeedbackControlValueChanged()));
+	connect(horizontalDownstreamStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onHorizontalStatusControlValueChanged()));
+
+	// ============ SoftIOC PVs ==================
+	connect(softIOCHeightControl_, SIGNAL(valueChanged(double)), this, SLOT(onHeightControlValueChanged(double)));
+	connect(softIOCHeightStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onHeightStopControlValueChanged()));
+	connect(softIOCPitchControl_, SIGNAL(valueChanged(double)), this, SLOT(onPitchControlValueChanged(double)));
+	connect(softIOCPitchStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onPitchStopControlValueChanged()));
+	connect(softIOCLateralControl_, SIGNAL(valueChanged(double)), this, SLOT(onLateralControlValueChanged(double)));
+	connect(softIOCLateralStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onLateralStopControlValueChanged()));
+	connect(softIOCYawControl_, SIGNAL(valueChanged(double)), this, SLOT(onYawControlValueChanged(double)));
+	connect(softIOCYawStopControl_, SIGNAL(valueChanged(double)), this, SLOT(onYawStopControlValueChanged()));
 }
 
 double BioXASSideTableCoordinator::calculateTableHeight(const double upstreamHeight, const double downstreamHeight) const

--- a/source/beamline/BioXAS/BioXASSideTableCoordinator.h
+++ b/source/beamline/BioXAS/BioXASSideTableCoordinator.h
@@ -77,6 +77,15 @@ protected:
 	double radianToDegree(double radian) const { return radian * 57.2957795; }
 	double degreeToRadian(double degree) const { return degree * 0.0174532925; }
 
+	/// to initialize the phycisal Motor controls
+	void initializePhysicalMotorControls();
+	/// to initialize the softIOC Motor controls
+	void initializeSoftIOCMotorControls();
+	/// to initialize the PV control set
+	void initializePVControlSet();
+	/// to initialize the signal slot connectors
+	void initializeSignalConnector();
+
 	/// get the current height of the tablle
 	double calculateTableHeight(const double upstreamHeight, const double downstreamHeight) const;
 	/// get the current pitch of the tablle

--- a/source/ui/BioXAS/BioXASEndstationTableView.cpp
+++ b/source/ui/BioXAS/BioXASEndstationTableView.cpp
@@ -11,32 +11,46 @@ BioXASEndstationTableView::BioXASEndstationTableView(BioXASEndstationTable *ends
 {
 	endstationTable_ = endstationTable;
 
-	heightControlEditor_ = new AMExtendedControlEditor(endstationTable_->heightPVController());
-	heightControlEditor_->hideBorder();
-	pitchControlEditor_ = new AMExtendedControlEditor(endstationTable_->pitchPVController());
-	pitchControlEditor_->hideBorder();
-	lateralControlEditor_ = new AMExtendedControlEditor(endstationTable_->lateralPVController());
-	lateralControlEditor_->hideBorder();
-	yawControlEditor_ = new AMExtendedControlEditor(endstationTable_->yawPVController());
-	yawControlEditor_->hideBorder();
+	heightControlEditor_ = createControlEditorView(endstationTable_->heightPVController());
+	pitchControlEditor_ = createControlEditorView(endstationTable_->pitchPVController());
 	if (endstationTable->rollPVController()) {
-		rollControlEditor_ = new AMExtendedControlEditor(endstationTable_->rollPVController());
+		rollControlEditor_ = createControlEditorView(endstationTable_->rollPVController());
 		rollControlEditor_->hideBorder();
 	}
+	lateralControlEditor_ = createControlEditorView(endstationTable_->lateralPVController());
+	yawControlEditor_ = createControlEditorView(endstationTable_->yawPVController());
 
+	int curRow = 0;
 	QGridLayout *tableControlLayout = new QGridLayout;
-	tableControlLayout->addWidget(new QLabel("Height"),   0, 0, 1, 1);
-	tableControlLayout->addWidget(heightControlEditor_,   0, 1, 1, 1);
-	tableControlLayout->addWidget(new QLabel("Pitch"),    1, 0, 1, 1);
-	tableControlLayout->addWidget(pitchControlEditor_,    1, 1, 1, 1);
-	tableControlLayout->addWidget(new QLabel("Lateral"),  2, 0, 1, 1);
-	tableControlLayout->addWidget(lateralControlEditor_,  2, 1, 1, 1);
-	tableControlLayout->addWidget(new QLabel("Yaw"),      3, 0, 1, 1);
-	tableControlLayout->addWidget(yawControlEditor_,      3, 1, 1, 1);
+	tableControlLayout->addWidget(new QLabel("Height"),   curRow, 0, 1, 1);
+	tableControlLayout->addWidget(heightControlEditor_,   curRow, 1, 1, 1);
+
+	curRow++;
+	tableControlLayout->addWidget(new QLabel("Pitch"),    curRow, 0, 1, 1);
+	tableControlLayout->addWidget(pitchControlEditor_,    curRow, 1, 1, 1);
+
 	if (endstationTable_->rollPVController()) {
-		tableControlLayout->addWidget(new QLabel("Roll"),  4, 0, 1, 1);
-		tableControlLayout->addWidget(rollControlEditor_,  4, 1, 1, 1);
+		curRow++;
+		tableControlLayout->addWidget(new QLabel("Roll"),  curRow, 0, 1, 1);
+		tableControlLayout->addWidget(rollControlEditor_,  curRow, 1, 1, 1);
 	}
 
+	curRow++;
+	tableControlLayout->addWidget(new QLabel("Lateral"),  curRow, 0, 1, 1);
+	tableControlLayout->addWidget(lateralControlEditor_,  curRow, 1, 1, 1);
+
+	curRow++;
+	tableControlLayout->addWidget(new QLabel("Yaw"),      curRow, 0, 1, 1);
+	tableControlLayout->addWidget(yawControlEditor_,      curRow, 1, 1, 1);
+
 	setLayout(tableControlLayout);
+}
+
+AMExtendedControlEditor * BioXASEndstationTableView::createControlEditorView(AMControl* control)
+{
+	AMExtendedControlEditor *controlEditor_ = new AMExtendedControlEditor(control);
+	controlEditor_->setControlFormat('f', 3);
+	controlEditor_->hideBorder();
+
+	return controlEditor_;
 }

--- a/source/ui/BioXAS/BioXASEndstationTableView.h
+++ b/source/ui/BioXAS/BioXASEndstationTableView.h
@@ -18,6 +18,9 @@ signals:
 
 public slots:
 
+private:
+	AMExtendedControlEditor * createControlEditorView(AMControl* control);
+
 protected:
 	/// the instance of the enstation table
 	BioXASEndstationTable *endstationTable_;


### PR DESCRIPTION
Added:
 - BioXASMainTable softIOC app and DB file for: BL1607-7-I21:Height, BL1607-7-I21:Pitch, BL1607-7-I21:Roll, BL1607-7-I21:Lateral, BL1607-7-I21:Yaw PVs
  - BioXASMainTableCoordinator application to communicate among the softIOC pvs and physical PVs

Modified:
  - make a small adjustment to the BioXASEndstationTable view to display the value in a proper precision
  - change the BioXAS Main appcontroller to display the endstation table properly

---
NOTES:
 - the scripts to run softIOC DB application and the coordinator application are running on IOC1607-008
 - the scripts are installed and running on IOC1607-008 already