### PR TITLE
Pull Request for Issue1520: Removed stretch from GSE layout

### DIFF
--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -246,7 +246,6 @@ void AMScanView::setupUI() {
 	QVBoxLayout* vl = new QVBoxLayout();
 	vl->setMargin(6);
 	vl->setSpacing(0);
-	vl->addStretch();
 
 	toolsView_ = new AMScanViewPlotToolsView(0);
 


### PR DESCRIPTION
Stretch in the scanView in the vertical layout was keeping from using available screen space on higher resolution monitors.  

#1520