### PR TITLE
Pull Request for Issue1605: Initial XES scan axis values incorrect

### DIFF
--- a/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
@@ -47,6 +47,8 @@ REIXSXESImageInterpolationAB::REIXSXESImageInterpolationAB(const QString &output
 	energyCalibrationOffset_ = 0;
 	tiltCalibrationOffset_ = 0;
 
+	interpolationLevel_ = 10;
+	binningLevel_ = 2;
 
 	inputSource_ = 0;
 	cacheInvalid_ = true;
@@ -59,8 +61,6 @@ REIXSXESImageInterpolationAB::REIXSXESImageInterpolationAB(const QString &output
 	connect(&callCorrelation_, SIGNAL(executed()), this, SLOT(correlateNow()));
 	setDescription("XES Interpolated Spectrum");
 
-	interpolationLevel_ = 10;
-	binningLevel_ = 2;
 	// shift values can start out empty.
 	shiftValues1_ << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0;
 	shiftValues2_ << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0 << 0;

--- a/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
@@ -303,12 +303,12 @@ void REIXSXESImageInterpolationAB::setInputDataSourcesImplementation(const QList
 	cachedValues_ = QVector<double>(axes_.at(0).size);
 	axisValueCacheInvalid_ = true;
 	cachedAxisValues_ = QVector<double>(axes_.at(0).size);
-	onInputSourceSizeChanged();
 	reviewState();
 
-	emitSizeChanged(0);
+	emitSizeChanged();
+	onInputSourceSizeChanged();
 	emitValuesChanged();
-	emitAxisInfoChanged(0);
+	emitAxisInfoChanged();
 }
 
 
@@ -610,6 +610,7 @@ void REIXSXESImageInterpolationAB::onInputSourceValuesChanged(const AMnDIndex &s
 
 void REIXSXESImageInterpolationAB::onInputSourceSizeChanged()
 {
+
 	cacheInvalid_ = true;
 	axisValueCacheInvalid_ = true;
 
@@ -628,8 +629,8 @@ void REIXSXESImageInterpolationAB::onInputSourceSizeChanged()
 
 	// If the sumRangeMin/sumRangeMax were out of range before, they might be valid now.
 	reviewState();
-	if(sizeChanged)
-		emitSizeChanged(0);
+//	if(sizeChanged)
+//		emitSizeChanged();
 	emitValuesChanged();
 }
 
@@ -1014,7 +1015,7 @@ void REIXSXESImageInterpolationAB::setEnergyCalibrationOffset(double energyCalib
 
 	energyCalibrationOffset_ = energyCalibrationOffset;
 	axisValueCacheInvalid_ = true;
-	emitSizeChanged(0);
+	emitSizeChanged();
 	emitValuesChanged();
 	setModified(true);
 }
@@ -1026,7 +1027,7 @@ void REIXSXESImageInterpolationAB::setTiltCalibrationOffset(double tiltCalibrati
 
 	tiltCalibrationOffset_ = tiltCalibrationOffset;
 	axisValueCacheInvalid_ = true;
-	emitSizeChanged(0);
+	emitSizeChanged();
 	emitValuesChanged();
 	setModified(true);
 }

--- a/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
+++ b/source/analysis/REIXS/REIXSXESImageInterpolationAB.cpp
@@ -303,6 +303,7 @@ void REIXSXESImageInterpolationAB::setInputDataSourcesImplementation(const QList
 	cachedValues_ = QVector<double>(axes_.at(0).size);
 	axisValueCacheInvalid_ = true;
 	cachedAxisValues_ = QVector<double>(axes_.at(0).size);
+	onInputSourceSizeChanged();
 	reviewState();
 
 	emitSizeChanged(0);

--- a/source/ui/REIXS/REIXSSampleManagementPre2013Widget.cpp
+++ b/source/ui/REIXS/REIXSSampleManagementPre2013Widget.cpp
@@ -19,8 +19,8 @@ REIXSSampleManagementPre2013Widget::REIXSSampleManagementPre2013Widget(QWidget *
 
 	cameraWidget1_ = new AMBeamlineCameraWidget(this, false);
 	cameraWidget1_->playSource(sampleCamera1Url);
-	cameraWidget1_->setCrosshairCenterPosition(QPointF(0.75, 0.6));
-	cameraWidget1_->setCrosshairPosition(QPointF(0.75, 0.6));
+	cameraWidget1_->setCrosshairCenterPosition(QPointF(0.477193, 0.64924));
+	cameraWidget1_->setCrosshairPosition(QPointF(0.477193, 0.64924));
 	cameraWidget1_->setCrosshairVisible(true);
 	cameraWidget1_->setCrosshairLocked(true);
 	cameraWidget1_->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -28,8 +28,8 @@ REIXSSampleManagementPre2013Widget::REIXSSampleManagementPre2013Widget(QWidget *
 
 	cameraWidget2_ = new AMBeamlineCameraWidget(this, false);
 	cameraWidget2_->playSource(sampleCamera2Url);
-	cameraWidget2_->setCrosshairCenterPosition(QPointF(0.5, 0.7));
-	cameraWidget2_->setCrosshairPosition(QPointF(0.5, 0.7));
+	cameraWidget2_->setCrosshairCenterPosition(QPointF(0.587617, 0.551402));
+	cameraWidget2_->setCrosshairPosition(QPointF(0.587617, 0.551402));
 	cameraWidget2_->setCrosshairVisible(true);
 	cameraWidget2_->setCrosshairLocked(true);
 	cameraWidget2_->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);


### PR DESCRIPTION
Moved the initialization of the binning values before the axis values are set invalid in the constructor so that the first computeCachedAxisValues call uses the correct bin level.