### PR TITLE
Pull Request for Issue1606: Add ability to set the controls and detectors visible in AMGenericStepScanConfigurationView

### DIFF
--- a/source/acquaman/AMGenericStepScanConfiguration.cpp
+++ b/source/acquaman/AMGenericStepScanConfiguration.cpp
@@ -2,6 +2,7 @@
 
 #include "ui/acquaman/AMGenericStepScanConfigurationView.h"
 #include "acquaman/AMGenericStepScanController.h"
+#include "beamline/AMBeamline.h"
 
 #include <math.h>
 
@@ -48,7 +49,7 @@ AMScanController *AMGenericStepScanConfiguration::createController()
 
 AMScanConfigurationView *AMGenericStepScanConfiguration::createView()
 {
-	return new AMGenericStepScanConfigurationView(this);
+	return new AMGenericStepScanConfigurationView(this, AMBeamline::bl()->exposedControls(), AMBeamline::bl()->exposedDetectors());
 }
 
 QString AMGenericStepScanConfiguration::technique() const

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -165,13 +165,13 @@ void BioXASAppController::addCommissioningScanConfigurationView(AMGenericStepSca
 		QString scanName = "Commissioning Tool";
 		QString iconName = ":/utilities-system-monitor.png";
 
-		AMGenericStepScanConfigurationView *view = new AMGenericStepScanConfigurationView(configuration);
+		AMGenericStepScanConfigurationView *view = new AMGenericStepScanConfigurationView(configuration, AMBeamline::bl()->exposedControls(), AMBeamline::bl()->exposedDetectors());
 		AMScanConfigurationViewHolder3 *viewHolder = new AMScanConfigurationViewHolder3(scanName, true, true, view, iconName);
 
 		connect( configuration, SIGNAL(totalTimeChanged(double)), viewHolder, SLOT(updateOverallScanTime(double)) );
 		viewHolder->updateOverallScanTime(configuration->totalTime());
 
-		mw_->addPane(new AMScanConfigurationViewHolder3(scanName, true, true, new AMGenericStepScanConfigurationView(configuration), iconName), "Scans", scanName, iconName);
+		mw_->addPane(viewHolder, "Scans", scanName, iconName);
 	}
 }
 

--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.h
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.h
@@ -3,11 +3,15 @@
 
 #include "ui/acquaman/AMScanConfigurationView.h"
 #include "acquaman/AMGenericStepScanConfiguration.h"
+#include "beamline/AMControlSet.h"
+#include "beamline/AMDetectorSet.h"
 
 #include <QLabel>
 #include <QLineEdit>
 #include <QComboBox>
 #include <QDoubleSpinBox>
+#include <QButtonGroup>
+#include <QLayout>
 
 class QAbstractButton;
 
@@ -17,12 +21,23 @@ class AMGenericStepScanConfigurationView : public AMScanConfigurationView
 
 public:
 	/// Constructor.
-	AMGenericStepScanConfigurationView(AMGenericStepScanConfiguration *configuration, QWidget *parent = 0);
+	AMGenericStepScanConfigurationView(AMGenericStepScanConfiguration *configuration, AMControlSet *controls, AMDetectorSet *detectors, QWidget *parent = 0);
 	/// Destructor.
 	~AMGenericStepScanConfigurationView(){}
 
 	/// Getter for the configuration.
 	const AMScanConfiguration *configuration() const { return configuration_; }
+
+	/// Returns the list of displayed controls.
+	AMControlSet* controls() const { return controls_; }
+	/// Returns the list of displayed detectors.
+	AMDetectorSet* detectors() const { return detectors_; }
+
+public slots:
+	/// Sets the list of displayed controls.
+	void setControls(AMControlSet *newControls);
+	/// Sets the list of displayed detectors.
+	void setDetectors(AMDetectorSet *newDetectors);
 
 protected slots:
 	/// Sets the axis 1 start position.
@@ -102,6 +117,20 @@ protected:
 	QLabel *scanInformation_;
 	/// Label holding the current estimated time for the scan to complete.  Takes into account extra time per point based on experience on the beamline.
 	QLabel *estimatedTime_;
+
+	/// The controls being displayed.
+	AMControlSet *controls_;
+	/// The mapping between control and control name.
+	QMap<QString, AMControl*> controlNameMap_;
+
+	/// The detectors being displayed.
+	AMDetectorSet *detectors_;
+	/// The detectors button group.
+	QButtonGroup *detectorGroup_;
+	/// The detectors widget layout.
+	QVBoxLayout *detectorLayout_;
+	/// The mapping between detector and detector button.
+	QMap<AMDetector*, QAbstractButton*> detectorButtonMap_;
 };
 
 #endif // AMGENERICSTEPSCANCONFIGURATIONVIEW_H


### PR DESCRIPTION
AMGenericStepScanConfigurationView:
- [x] Modify constructor arguments.
- [x] Add member variables: control set, detector set, control name map, detector button map, detector button group, detector layout.
- [x] Add getters for the controls and detectors.
- [x] Move constructor elements into dedicated setControls and setDetectors setters.

BioXASAppController:
- [x] Update creation of the configuration view to include new constructor arguments.

AMGenericStepScanConfiguration:
- [x] Update creation of the configuration view to include new constructor arguments.

Played with the view in a running application and ran a test scan--view functionality doesn't appear to have changed.