### PR TITLE
Pull request for Issue1623: Rename variables used in SGM energy calculation

### DIFF
--- a/source/beamline/SGM/monochromator/SGMGratingSupport.h
+++ b/source/beamline/SGM/monochromator/SGMGratingSupport.h
@@ -18,12 +18,12 @@ enum GratingTranslation {
 };
 
 /*!
-  * Spacing value for each of the grating translations used in the calculation
+  * The space between two consecutive rulings on a grating. Used in the calculation
   * of the energy produced.
   * \param translationSelection ~ The grating whose spacing value is to be
   * returned.
   */
-inline static double spacing(GratingTranslation translationSelection)
+inline static double gratingSpacing(GratingTranslation translationSelection)
 {
     switch(translationSelection) {
     case LowGrating:
@@ -38,52 +38,34 @@ inline static double spacing(GratingTranslation translationSelection)
 }
 
 /*!
-  * Correction value used in the calculation of the energy produced by a given
-  * grating translation.
+  * Correction value used to fit the theoretical energy values at a given grating
+  * setting to the observed actual values.
   * \param translationSelection ~ The grating whose correction value is to be
   * returned.
   */
-inline static double c1(GratingTranslation translationSelection)
+inline static double curveFitCorrection(GratingTranslation translationSelection)
 {
     switch(translationSelection) {
     case LowGrating:
-        return 2.454768e-5;
+        return -3.912711175e-5;
     case MediumGrating:
-        return 2.462036e-5;
+        return -3.915784549e-5;
     case HighGrating:
-        return 2.456910e-5;
+        return -3.916344023e-5;
     default:
         return 0;
     }
 }
 
 /*!
-  * Correction value used in the calculation of the energy produced by a given
-  * grating translation.
-  * \param translationSelection ~ The grating whose correction value is to be
+  * The angle between the incident beam and the defracted beam. This value is
+  * used in the calculation of the energy produced by the grating, as well as in
+  * the calculation to determine the optimized exit slit position for a given
+  * energy.
+  * \param translationSelection ~ The grating whose included angle is to be
   * returned.
   */
-inline static double c2(GratingTranslation translationSelection)
-{
-    switch(translationSelection) {
-    case LowGrating:
-        return -1.593923;
-    case MediumGrating:
-        return -1.590466;
-    case HighGrating:
-        return -1.594012;
-    default:
-        return 0;
-    }
-}
-
-/*!
-  * Correction value used in the calculation of the energy produced by a given
-  * grating translation.
-  * \param translationSelection ~ The grating whose correction value is to be
-  * returned.
-  */
-inline static double thetaM(GratingTranslation translationSelection)
+inline static double includedAngle(GratingTranslation translationSelection)
 {
     switch(translationSelection) {
     case LowGrating:

--- a/source/beamline/SGM/monochromator/SGMMonochromatorInfo.cpp
+++ b/source/beamline/SGM/monochromator/SGMMonochromatorInfo.cpp
@@ -304,24 +304,22 @@ SGMGratingSupport::GratingTranslation SGMMonochromatorInfo::optimizedGrating(dou
 
 double SGMMonochromatorInfo::energyFromGrating(SGMGratingSupport::GratingTranslation gratingTranslationSelection, double gratingAngleEncoderTarget) const
 {
-    double spacing = SGMGratingSupport::spacing(gratingTranslationSelection);
-    double c1 = SGMGratingSupport::c1(gratingTranslationSelection);
-    double c2 = SGMGratingSupport::c2(gratingTranslationSelection);
+    double gratingSpacing = SGMGratingSupport::gratingSpacing(gratingTranslationSelection);
+    double curveFitCorrection = SGMGratingSupport::curveFitCorrection(gratingTranslationSelection);
     double radiusCurvatureOffset = SGMGratingSupport::radiusCurvatureOffset(gratingTranslationSelection);
-    double thetaM = SGMGratingSupport::thetaM(gratingTranslationSelection);
+    double includedAngle = SGMGratingSupport::includedAngle(gratingTranslationSelection);
 
-    return 1e-9 * 1239.842 / ((2 * spacing * c1 * c2 * gratingAngleEncoderTarget) / radiusCurvatureOffset * cos(thetaM / 2));
+    return 1e-9 * 1239.842 / ((2 * gratingSpacing * curveFitCorrection * gratingAngleEncoderTarget) / radiusCurvatureOffset * cos(includedAngle / 2));
 }
 
 double SGMMonochromatorInfo::gratingAngleFromEnergy(SGMGratingSupport::GratingTranslation gratingTranslationSelection, double energy) const
 {
-    double spacing = SGMGratingSupport::spacing(gratingTranslationSelection);
-    double c1 = SGMGratingSupport::c1(gratingTranslationSelection);
-    double c2 = SGMGratingSupport::c2(gratingTranslationSelection);
+    double gratingSpacing = SGMGratingSupport::gratingSpacing(gratingTranslationSelection);
+    double curveFitCorrection = SGMGratingSupport::curveFitCorrection(gratingTranslationSelection);
     double radiusCurvatureOffset = SGMGratingSupport::radiusCurvatureOffset(gratingTranslationSelection);
-    double thetaM = SGMGratingSupport::thetaM(gratingTranslationSelection);
+    double includedAngle = SGMGratingSupport::includedAngle(gratingTranslationSelection);
 
-    return 1e-9 * 1239.842 / ((2 * spacing * c1 * c2 * energy) / radiusCurvatureOffset * cos(thetaM / 2));
+    return 1e-9 * 1239.842 / ((2 * gratingSpacing * curveFitCorrection * energy) / radiusCurvatureOffset * cos(includedAngle / 2));
 }
 
 void SGMMonochromatorInfo::optimizeForEnergy()
@@ -344,14 +342,14 @@ double SGMMonochromatorInfo::optimizedUndulatorPosition(double energy, SGMUndula
 
 double SGMMonochromatorInfo::optimizedExitSlitPosition(SGMGratingSupport::GratingTranslation gratingTranslationSelection, double energy) const
 {
-    double spacing = SGMGratingSupport::spacing(gratingTranslationSelection);
-    double thetaM = SGMGratingSupport::thetaM(gratingTranslationSelection);
-    double xOffset = 4546; // Need to research this value. Seems to have been altered over time.
-    double lambda = (1239.842 / energy) * 1.0e-9;
-    double thetaI = asin((lambda / (2*spacing)) / cos(thetaM/2)) + (thetaM/2);
-    double thetaD = -thetaM + thetaI;
+    double gratingSpacing = SGMGratingSupport::gratingSpacing(gratingTranslationSelection);
+    double includedAngle = SGMGratingSupport::includedAngle(gratingTranslationSelection);
+    double gratingEncoderOffset = 4546; // Distance between the grating and the zero position of the encoder
+    double wavelength = (1239.842 / energy) * 1.0e-9;
+    double angleOfIncidence = asin((wavelength / (2*gratingSpacing)) / cos(includedAngle/2)) + (includedAngle/2);
+    double angleOfDefraction = -includedAngle + angleOfIncidence;
 
-    return -xOffset + (pow(cos(thetaD),2)) / (((cos(thetaD + thetaM) + cos(thetaD)) / 70480) - (pow(cos(thetaD + thetaM),2))/1500);
+    return -gratingEncoderOffset + (pow(cos(angleOfDefraction),2)) / (((cos(angleOfDefraction + includedAngle) + cos(angleOfDefraction)) / 70480) - (pow(cos(angleOfDefraction + includedAngle),2))/1500);
 }
 
 SGMUndulatorSupport::UndulatorHarmonic SGMMonochromatorInfo::optimizedUndulatorHarmonic(SGMGratingSupport::GratingTranslation gratingTranslationSelection, double energy) const


### PR DESCRIPTION
- Merged c1 and c2 into curveFitCorrection variable (=c1*c2) as they were only ever used together.
- Renamed the variables based on what they represent from information gathered from Tom and the SGM Wiki.