### PR TITLE
Pull Request for Issue1619: Implementing calibration for CLSMAXvMotor.

### DIFF
--- a/source/beamline/AMControl.h
+++ b/source/beamline/AMControl.h
@@ -356,6 +356,10 @@ public:
 	virtual bool canStop() const { return false; }
 	/// Indicates that this control \em shoule (assuming it's connected) be able to issue stop() commands while moves are in progress.
 	virtual bool shouldStop() const { return false; }
+	/// Indicates that this control \em can currently be calibrated.
+	virtual bool canCalibrate() const { return false; }
+	/// Indicates that this control \em should (assuming it's connected) be calibrated.
+	virtual bool shouldCalibrate() const { return false; }
 	/// Indicates that this control should accept move() requests while it is already isMoving(). Some hardware can handle this. If this is false, move() requests will be ignored when the control is already in motion.
 	bool allowsMovesWhileMoving() const { return allowsMovesWhileMoving_; }
 	//@}

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -245,7 +245,7 @@ AMControl::FailureExplanation AMPseudoMotorControl::calibrate(double oldValue, d
 		return AMControl::NotConnectedFailure;
 	}
 
-	if (!canMove()) {
+	if (!canCalibrate()) {
 		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_CANNOT_MOVE, QString("Failed to calibrate %1: control cannot move.").arg(name()));
 		return AMControl::OtherFailure;
 	}

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -19,21 +19,20 @@ BioXASSSRLMonochromator::BioXASSSRLMonochromator(const QString &name, QObject *p
 	paddleStatus_ = 0;
 	keyStatus_ = 0;
 	brakeStatus_ = 0;
-	encoderBragg_ = 0;
 	braggAtCrystalChangePositionStatus_ = 0;
 	crystalChange_ = 0;
 	crystalChangeCWLimitStatus_ = 0;
 	crystalChangeCCWLimitStatus_ = 0;
 	regionAStatus_ = 0;
 	regionBStatus_ = 0;
-	m1Pitch_ = 0;
 
-	braggSetPosition_ = 0;
+	m1Pitch_ = 0;
 
 	upperSlitMotor_ = 0;
 	lowerSlitMotor_ = 0;
 	paddleMotor_ = 0;
-	braggMotor_ = 0;
+	stepsBraggMotor_ = 0;
+	encoderBraggMotor_ = 0;
 	verticalMotor_ = 0;
 	lateralMotor_ = 0;
 	crystalChangeMotor_ = 0;
@@ -62,7 +61,6 @@ bool BioXASSSRLMonochromator::isConnected() const
 		paddleStatus_ && paddleStatus_->isConnected() &&
 		keyStatus_ && keyStatus_->isConnected() &&
 		brakeStatus_ && brakeStatus_->isConnected() &&
-		encoderBragg_ && encoderBragg_->isConnected() &&
 		braggAtCrystalChangePositionStatus_ && braggAtCrystalChangePositionStatus_->isConnected() &&
 		crystalChange_ && crystalChange_->isConnected() &&
 		crystalChangeCWLimitStatus_ && crystalChangeCWLimitStatus_->isConnected() &&
@@ -70,10 +68,13 @@ bool BioXASSSRLMonochromator::isConnected() const
 		regionAStatus_ && regionAStatus_->isConnected() &&
 		regionBStatus_ && regionBStatus_->isConnected() &&
 
+		m1Pitch_ && m1Pitch_->isConnected() &&
+
 		upperSlitMotor_ && upperSlitMotor_->isConnected() &&
 		lowerSlitMotor_ && lowerSlitMotor_->isConnected() &&
 		paddleMotor_ && paddleMotor_->isConnected() &&
-		braggMotor_ && braggMotor_->isConnected() &&
+		encoderBraggMotor_ && encoderBraggMotor_->isConnected() &&
+		stepsBraggMotor_ && stepsBraggMotor_->isConnected() &&
 		verticalMotor_ && verticalMotor_->isConnected() &&
 		lateralMotor_ && lateralMotor_->isConnected() &&
 		crystalChangeMotor_ && crystalChangeMotor_->isConnected() &&
@@ -107,15 +108,11 @@ void BioXASSSRLMonochromator::setSettlingTime(double newTimeSeconds)
 	}
 }
 
-void BioXASSSRLMonochromator::calibrateBraggPosition(double newBraggPosition)
-{
-	if (braggMotor_ && braggMotor_->isConnected()) {
-		braggMotor_->setEGUSetPosition(newBraggPosition);
-	}
-}
-
 void BioXASSSRLMonochromator::updateMotorSettlingTime()
 {
-	if (braggMotor_)
-		braggMotor_->setSettlingTime(settlingTime_);
+	if (encoderBraggMotor_)
+		encoderBraggMotor_->setSettlingTime(settlingTime_);
+
+	if (stepsBraggMotor_)
+		stepsBraggMotor_->setSettlingTime(settlingTime_);
 }

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.h
@@ -64,12 +64,6 @@ public:
 	AMControl* keyStatusControl() const { return keyStatus_; }
 	/// Returns the brake status control.
 	AMControl* brakeStatusControl() const { return brakeStatus_; }
-	/// Returns the step-based bragg position control.
-	AMControl* stepBraggControl() const { return braggMotor_; }
-	/// Returns the encoder-based bragg position control.
-	AMControl* encoderBraggControl() const { return encoderBragg_; }
-	/// Returns the bragg's 'set current position' control.
-	AMControl* braggSetPositionControl() const { return braggSetPosition_; }
 	/// Returns the bragg motor at crystal change position status control.
 	AMControl* braggAtCrystalChangePositionStatusControl() const { return braggAtCrystalChangePositionStatus_; }
 	/// Returns the crystal change control.
@@ -91,8 +85,12 @@ public:
 	CLSMAXvMotor* lowerSlitBladeMotor() const { return lowerSlitMotor_; }
 	/// Returns the phosphor paddle motor.
 	CLSMAXvMotor* paddleMotor() const { return paddleMotor_; }
-	/// Returns the bragg motor.
-	CLSMAXvMotor* braggMotor() const { return braggMotor_; }
+	/// Returns the preferred bragg motor.
+	CLSMAXvMotor* braggMotor() const { return stepsBraggMotor_; }
+	/// Returns the step-based bragg position control.
+	CLSMAXvMotor* stepBraggControl() const { return stepsBraggMotor_; }
+	/// Returns the encoder-based bragg position control.
+	CLSMAXvMotor* encoderBraggControl() const { return encoderBraggMotor_; }
 	/// Returns the vertical motor.
 	CLSMAXvMotor* verticalMotor() const { return verticalMotor_; }
 	/// Returns the lateral motor.
@@ -108,9 +106,6 @@ public:
 	/// Returns the crystal 2 roll motor.
 	CLSMAXvMotor* crystal2RollMotor() const { return crystal2RollMotor_; }
 
-	/// Creates and returns an energy calibration action.
-	AMAction3* createEnergyCalibrationAction(double oldEnergy, double newEnergy);
-
 signals:
 	/// Notifier that the m1 mirror pitch control has changed.
 	void m1MirrorPitchControlChanged(AMControl *newControl);
@@ -122,9 +117,6 @@ public slots:
 	void setM1MirrorPitchControl(AMControl* newControl);
 	/// Sets the mono move settling time.
 	void setSettlingTime(double newTimeSeconds);
-
-	/// Sets the calibrated bragg position.
-	void calibrateBraggPosition(double newPosition);
 
 protected slots:
 	/// Handles updating the motors necessary to produce the desired mono move settling time.
@@ -153,8 +145,6 @@ protected:
 	AMControl *paddleStatus_;
 	/// The key status control.
 	AMControl *keyStatus_;
-	/// The bragg motor control.
-	AMControl *encoderBragg_;
 	/// The bragg motor at crystal change position status control.
 	AMControl *braggAtCrystalChangePositionStatus_;
 	/// The brake status control.
@@ -170,8 +160,6 @@ protected:
 	/// The region B status control.
 	AMControl *regionBStatus_;
 
-	/// The bragg motor set position control.
-	AMControl *braggSetPosition_;
 	/// The m1 mirror pitch control.
 	AMControl *m1Pitch_;
 
@@ -181,8 +169,10 @@ protected:
 	CLSMAXvMotor *lowerSlitMotor_;
 	/// Paddle motor.
 	CLSMAXvMotor *paddleMotor_;
-	/// Bragg motor.
-	CLSMAXvMotor *braggMotor_;
+	/// Bragg motor, not using encoder (using steps).
+	CLSMAXvMotor *stepsBraggMotor_;
+	/// Bragg motor, using the encoder.
+	CLSMAXvMotor *encoderBraggMotor_;
 	/// Vertical motor.
 	CLSMAXvMotor *verticalMotor_;
 	/// Lateral motor.

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
@@ -70,6 +70,12 @@ bool BioXASSSRLMonochromatorEnergyControl::canStop() const
 	return false;
 }
 
+bool BioXASSSRLMonochromatorEnergyControl::canCalibrate() const
+{
+	bool result = (isConnected() && bragg_->canCalibrate());
+	return result;
+}
+
 void BioXASSSRLMonochromatorEnergyControl::setBraggControl(AMControl *newControl)
 {
 	if (bragg_ != newControl) {

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
@@ -25,7 +25,6 @@ BioXASSSRLMonochromatorEnergyControl::BioXASSSRLMonochromatorEnergyControl(const
 	regionOffset_ = 180;
 
 	bragg_ = 0;
-	braggSetPosition_ = 0;
 	region_ = 0;
 	m1MirrorPitch_ = 0;
 
@@ -76,7 +75,7 @@ bool BioXASSSRLMonochromatorEnergyControl::canCalibrate() const
 	return result;
 }
 
-void BioXASSSRLMonochromatorEnergyControl::setBraggControl(AMControl *newControl)
+void BioXASSSRLMonochromatorEnergyControl::setBraggControl(CLSMAXvMotor *newControl)
 {
 	if (bragg_ != newControl) {
 
@@ -91,24 +90,6 @@ void BioXASSSRLMonochromatorEnergyControl::setBraggControl(AMControl *newControl
 		updateStates();
 
 		emit braggControlChanged(bragg_);
-	}
-}
-
-void BioXASSSRLMonochromatorEnergyControl::setBraggSetPositionControl(AMControl *newControl)
-{
-	if (braggSetPosition_ != newControl) {
-
-		if (braggSetPosition_)
-			removeChildControl(braggSetPosition_);
-
-		braggSetPosition_ = newControl;
-
-		if (braggSetPosition_)
-			addChildControl(braggSetPosition_);
-
-		updateStates();
-
-		emit braggSetPositionControlChanged(braggSetPosition_);
 	}
 }
 
@@ -152,7 +133,6 @@ void BioXASSSRLMonochromatorEnergyControl::updateConnected()
 {
 	bool isConnected = (
 				bragg_ && bragg_->isConnected() &&
-				braggSetPosition_ && braggSetPosition_->isConnected() &&
 				region_ && region_->isConnected() &&
 				m1MirrorPitch_ && m1MirrorPitch_->isConnected()
 				);
@@ -196,19 +176,14 @@ AMAction3* BioXASSSRLMonochromatorEnergyControl::createCalibrateAction(double ol
 
 	if (isConnected()) {
 
-		AMListAction3 *calibrationAction = new AMListAction3(new AMListActionInfo3("Energy Calibration Action", "Energy Calibration Action"), AMListAction3::Sequential);
-
 		// Calculate the corresponding old and new bragg positions.
+
 		double oldPosition = calculateBraggPositionFromEnergy(hc_, crystal2D_, oldEnergy, region_->value(), m1MirrorPitch_->value(), thetaBraggOffset_, regionOffset_);
 		double newPosition = calculateBraggPositionFromEnergy(hc_, crystal2D_, newEnergy, region_->value(), m1MirrorPitch_->value(), thetaBraggOffset_, regionOffset_);
 
-		// Move to the old energy position.
-		calibrationAction->addSubAction(AMActionSupport::buildControlMoveAction(bragg_, oldPosition));
+		// Create calibration action for the bragg motor.
 
-		// Set the bragg motor position to be the new position.
-		calibrationAction->addSubAction(AMActionSupport::buildControlMoveAction(braggSetPosition_, newPosition));
-
-		result = calibrationAction;
+		result = bragg_->createCalibrationAction(oldPosition, newPosition);
 	}
 
 	return result;

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.h
@@ -25,6 +25,8 @@ public:
 	virtual bool shouldMove() const { return true; }
 	/// Returns true if a control stop is always possible, provided it is connected. False otherwise.
 	virtual bool shouldStop() const { return true; }
+	/// Returns true if a calibration is always possible, provided this control is connected. False otherwise.
+	virtual bool shouldCalibrate() const { return true; }
 
 	/// Returns true if this control's value can be measured right now. False otherwise.
 	virtual bool canMeasure() const;
@@ -32,6 +34,8 @@ public:
 	virtual bool canMove() const;
 	/// Returns true if this control can stop right now. False otherwise.
 	virtual bool canStop() const;
+	/// Returns true if this control can be calibrated right now. False otherwise.
+	virtual bool canCalibrate() const;
 
 	/// Returns the hc constant.
 	double hc() const { return hc_; }

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.h
@@ -48,17 +48,10 @@ public:
 
 	/// Returns the bragg motor control.
 	AMControl* braggControl() const { return bragg_; }
-	/// Returns the bragg motor set position control.
-	AMControl* braggSetPositionControl() const { return braggSetPosition_; }
 	/// Returns the region control.
 	AMControl* regionControl() const { return region_; }
 	/// Returns the m1 mirror pitch control.
 	AMControl* m1MirrorPitchControl() const { return m1MirrorPitch_; }
-
-	/// Returns true if the given value is a valid value for this control. False otherwise.
-	virtual bool validValue(double value) const { Q_UNUSED(value) return true; }
-	/// Returns true if the given value is a valid setpoint for this control. False otherwise.
-	virtual bool validSetpoint(double value) const { return (value > 0); }
 
 signals:
 	/// Notifier that the bragg control has changed.
@@ -72,9 +65,7 @@ signals:
 
 public slots:
 	/// Sets the bragg control.
-	void setBraggControl(AMControl *newControl);
-	/// Sets the bragg set position control.
-	void setBraggSetPositionControl(AMControl *newControl);
+	void setBraggControl(CLSMAXvMotor *newControl);
 	/// Sets the region control.
 	void setRegionControl(AMControl *newControl);
 	/// Sets the m1 mirror control.
@@ -124,10 +115,8 @@ protected:
 	/// The region offset (deg).
 	double regionOffset_;
 
-	/// The goniometer bragg motor control.
-	AMControl *bragg_;
-	/// The goniometer bragg motor, set position control.
-	AMControl *braggSetPosition_;
+	/// The goniometer motor control.
+	CLSMAXvMotor *bragg_;
 	/// The region control.
 	AMControl *region_;
 	/// The m1 mirror pitch control.

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -12,7 +12,6 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	paddleStatus_ = new AMReadOnlyPVControl("PaddleStatus", "BL1607-5-I22:Mono:PaddleExtracted", this);
 	keyStatus_ = new AMReadOnlyPVControl("KeyStatus", "BL1607-5-I22:Mono:KeyStatus", this);
 	brakeStatus_ = new AMReadOnlyPVControl("BrakeStatus", "BL1607-5-I22:Mono:BrakeOff", this);
-	encoderBragg_ = new AMReadOnlyPVwStatusControl("Bragg", "SMTR1607-5-I22-12:deg:fbk", "SMTR1607-5-I22-12:status", this);
 	braggAtCrystalChangePositionStatus_ = new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I22:Mono:XtalChangePos", this);
 	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I22-22:mm:fbk", "SMTR1607-5-I22-22:mm", "SMTR1607-5-I22-22:status", "SMTR1607-5-I22-22:stop", this);
 	crystalChangeCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCWStatus", "SMTR1607-5-I22-22:cw", this);
@@ -20,13 +19,11 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	regionAStatus_ = new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I22:Mono:Region:A", this);
 	regionBStatus_ = new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I22:Mono:Region:B", this);
 
-	braggSetPosition_ = new AMSinglePVControl("BraggSetPositionControl", "SMTR1607-5-I22-12:deg:setPosn", this);
-	braggSetPosition_->setTolerance(0.001);
-
 	upperSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this);
 	lowerSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
 	paddleMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I22-11"), QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), true, 0.05, 2.0, this);
-	braggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg"));
+	encoderBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg"));
+	stepsBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg"));
 	verticalMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this);
 	lateralMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this);
 	crystalChangeMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHAGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this);
@@ -45,7 +42,7 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	region_->setPaddleStatusControl(paddleStatus_);
 	region_->setKeyStatusControl(keyStatus_);
 	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(braggMotor_);
+	region_->setBraggControl(braggMotor());
 	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
 	region_->setCrystalChangeControl(crystalChange_);
 	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);
@@ -56,14 +53,12 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	// Create energy control.
 
 	encoderEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name_+"EncoderEnergyControl", this);
-	encoderEnergy_->setBraggControl(encoderBragg_);
-	encoderEnergy_->setBraggSetPositionControl(braggSetPosition_);
+	encoderEnergy_->setBraggControl(encoderBraggMotor_);
 	encoderEnergy_->setRegionControl(region_);
 	encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
 
 	stepEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name_+"StepEnergyControl", this);
-	stepEnergy_->setBraggControl(braggMotor_);
-	stepEnergy_->setBraggSetPositionControl(braggSetPosition_);
+	stepEnergy_->setBraggControl(stepsBraggMotor_);
 	stepEnergy_->setRegionControl(region_);
 	stepEnergy_->setM1MirrorPitchControl(m1Pitch_);
 
@@ -76,7 +71,6 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	connect( paddleStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( keyStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( brakeStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( encoderBragg_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( braggAtCrystalChangePositionStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( crystalChangeCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
@@ -87,7 +81,8 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	connect( upperSlitMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( lowerSlitMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( paddleMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( braggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	connect( encoderBraggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	connect( stepsBraggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( verticalMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( lateralMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( crystalChangeMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );

--- a/source/beamline/CLS/CLSMAXvMotor.cpp
+++ b/source/beamline/CLS/CLSMAXvMotor.cpp
@@ -23,6 +23,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "actions3/AMActionSupport.h"
 #include "actions3/actions/AMControlStopAction.h"
+#include "actions3/AMListAction3.h"
+#include "util/AMErrorMonitor.h"
 
 CLSMAXvMotor::~CLSMAXvMotor(){}
 CLSMAXvMotor::CLSMAXvMotor(const QString &name, const QString &baseName, const QString &description, bool hasEncoder, double tolerance, double moveStartTimeoutSeconds, QObject *parent, QString pvUnitFieldName) :
@@ -775,6 +777,61 @@ AMAction3 *CLSMAXvMotor::createCWLimitWaitAction(CLSMAXvMotor::Limit cwLimitStat
 
 	return AMActionSupport::buildControlWaitAction(cwLimit_, cwLimitState);
 
+}
+
+AMAction3 *CLSMAXvMotor::createCalibrationAction(double oldPosition, double newPosition)
+{
+	AMAction3 *result = 0;
+
+	if (isConnected()) {
+		AMListAction3 *calibrationAction = new AMListAction3(new AMListActionInfo3("Motor calibration", "Motor calibration"), AMListAction3::Sequential);
+		calibrationAction->addSubAction(AMActionSupport::buildControlMoveAction(this, oldPosition));
+		calibrationAction->addSubAction(AMActionSupport::buildControlMoveAction(EGUSetPosition_, newPosition));
+
+		result = calibrationAction;
+	}
+
+	return result;
+}
+
+AMControl::FailureExplanation CLSMAXvMotor::calibrate(double oldValue, double newValue)
+{
+	// Check that this motor is connected and able to be calibrated before proceeding.
+
+	if (!isConnected()) {
+		AMErrorMon::alert(this, CLSMAXVMOTOR_NOT_CONNECTED, QString("Failed to calibrate %1: motor is not connected.").arg(name()));
+		return AMControl::NotConnectedFailure;
+	}
+
+	if (!canCalibrate()) {
+		AMErrorMon::alert(this, CLSMAXVMOTOR_CANNOT_CALIBRATE, QString("Failed to calibrate %1: motor cannot currently be calibrated.").arg(name()));
+		return AMControl::OtherFailure;
+	}
+
+	// Proceed with creating calibration action.
+
+	AMAction3 *action = createCalibrationAction(oldValue, newValue);
+
+	// Check that a valid calibration action was generated.
+	// If an invalid calibration action was generated, abort the calibration.
+
+	if (!action) {
+		AMErrorMon::alert(this, CLSMAXVMOTOR_INVALID_CALIBRATION_ACTION, QString("Did not calibrate %1: invalid calibration action generated.").arg(name()));
+		return AMControl::LimitFailure;
+	}
+
+	// Proceed with initializing the calibration action.
+	// Connect it's final-state signals to its deleteLater() slot to prevent memory leak.
+
+	connect( action, SIGNAL(cancelled()), action, SLOT(deleteLater()) );
+	connect( action, SIGNAL(failed()), action, SLOT(deleteLater()) );
+	connect( action, SIGNAL(succeeded()), action, SLOT(deleteLater()) );
+
+	// Run action.
+
+	action->start();
+
+	return AMControl::NoFailure;
 }
 
 void CLSMAXvMotor::setEGUVelocity(double velocity){

--- a/source/beamline/CLS/CLSMAXvMotor.h
+++ b/source/beamline/CLS/CLSMAXvMotor.h
@@ -25,6 +25,12 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/AMPVControl.h"
 #include "actions3/AMAction3.h"
 
+#define CLSMAXVMOTOR_NOT_CONNECTED 638989
+#define CLSMAXVMOTOR_CANNOT_CALIBRATE 638990
+#define CLSMAXVMOTOR_ALREADY_CALIBRATING 638991
+#define CLSMAXVMOTOR_INVALID_CALIBRATION_ACTION 638992
+#define CLSMAXVMOTOR_CALIBRATION_FAILED 638993
+
 /// This function object provides the moving check for the CLSMAXvMotors
 class CLSMAXvControlStatusChecker : public AMAbstractControlStatusChecker {
 public:
@@ -98,6 +104,11 @@ public:
 
 	/// Indicates that all process variables for this motor are connected
 	virtual bool isConnected() const;
+
+	/// Indicates that this motor \em can currently be calibrated.
+	virtual bool canCalibrate() const { return canMove(); }
+	/// Indicates that this motor \em should (assuming it's connected) be calibrated.
+	virtual bool shouldCalibrate() const { return true; }
 
 	/// Returns the basename of the MAXvMotor PVs
 	QString pvBaseName() const;
@@ -300,8 +311,13 @@ public:
 	/// Returns a newly created action to alert when CW is at limit
 	AMAction3 *createCWLimitWaitAction(CLSMAXvMotor::Limit ccwLimitState);
 
+	/// Returns a newly created action to calibrate this motor. Moves this motor to the oldPosition and sets it as the newPosition.
+	AMAction3 *createCalibrationAction(double oldPosition, double newPosition);
 
 public slots:
+	/// Calibrates the motor. Moves to old position and the sets that position to the new position.
+	virtual FailureExplanation calibrate(double oldValue, double newValue);
+
 	/// Sets the (EGU) velocity setting for the velocity profile
 	void setEGUVelocity(double EGUVelocity);
 	/// Sets the (EGU) base velocity setting for the velocity profile

--- a/source/beamline/CLS/CLSMAXvMotor.h
+++ b/source/beamline/CLS/CLSMAXvMotor.h
@@ -107,7 +107,7 @@ public:
 
 	/// Indicates that this motor \em can currently be calibrated.
 	virtual bool canCalibrate() const { return canMove(); }
-	/// Indicates that this motor \em should (assuming it's connected) be calibrated.
+	/// Indicates that this motor \em should (assuming it's connected) be able to be calibrated.
 	virtual bool shouldCalibrate() const { return true; }
 
 	/// Returns the basename of the MAXvMotor PVs

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -266,7 +266,7 @@ void BioXASSSRLMonochromatorConfigurationView::onCalibrateGoniometerButtonClicke
 		double newPosition = QInputDialog::getDouble(this, "Goniometer Calibration", "Enter calibrated goniometer position:", mono_->braggMotor()->value(), BRAGG_POSITION_MIN, BRAGG_POSITION_MAX, 2, &inputOK);
 
 		if (inputOK)
-			mono_->braggMotor()->setEGUSetPosition(newPosition);
+			mono_->braggMotor()->calibrate(mono_->braggMotor()->value(), newPosition);
 	}
 }
 


### PR DESCRIPTION
Reimplement public functions from AMControl in CLSMAXvMotor:
- [x] shouldCalibrate()
- [x] canCalibrate()
- [x] calibrate(double, double)

Replace old calibration procedures with new call to calibrate() in BioXAS:
- [x] BioXASSSRLMonochromatorEnergyControl
- [x] BioXASSSRLMonochromatorConfigurationView

Tested using the BioXAS Side mono--calibration appears to perform identically to the old calibration procedure.