### PR TITLE
Pull Request for Issue1578: IDEAS Ketek view has duplicate rate/res drop down controls

### DIFF
--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorView.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorView.cpp
@@ -59,16 +59,7 @@ void IDEASXRFDetailedDetectorView::buildScanSaveViews()
 {
 	deadTimeCheckButton = new QPushButton("Check Dead Time");
 
-	peakingTimeBox = new QComboBox();
-	peakingTimeBox->setObjectName(QString::fromUtf8("peakingTimeBox"));
-	peakingTimeBox->addItem("Setting Unknown");
-	peakingTimeBox->addItem("High Rate / Low Res");
-	peakingTimeBox->addItem("High Res / Low Rate");
-	peakingTimeBox->addItem("Ultra Res / Slow Rate");
-
 	rightLayout_->addWidget(deadTimeCheckButton);
-
-	rightLayout_->addWidget(peakingTimeBox);
 
 	rightLayout_->addStretch();
 

--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorView.h
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorView.h
@@ -83,8 +83,6 @@ protected:
 	/// button to trigger a 0.1s XRF acquitisition to check to too-high count rates.
 	QPushButton *deadTimeCheckButton;
 
-	QComboBox *peakingTimeBox;
-
 };
 
 #endif // IDEASXRFDETAILEDDETECTORVIEW_H


### PR DESCRIPTION
Removed vestigial peakingTime comboBox from IDEASXRFDetailedDetectorView since it has been moved to IDEASKETEKDetailedDetectorView