### PR TITLE
Pull Request for Issue1632: Add command line argument to exclude the 13-element detector

### DIFF
--- a/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
@@ -13,6 +13,9 @@
 #include "dataman/export/AMSMAKExporter.h"
 #include "dataman/export/AMExporterOptionSMAK.h"
 
+#include <QApplication>
+
+
 IDEAS2DScanActionController::IDEAS2DScanActionController(IDEAS2DScanConfiguration *configuration, QObject *parent)
 	: AMStepScanActionController(configuration, parent)
 {
@@ -67,7 +70,7 @@ IDEAS2DScanActionController::IDEAS2DScanActionController(IDEAS2DScanConfiguratio
 		detectors.addDetectorInfo(detector->toInfo());
 	}
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element)){
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13")){
 
 		AMDetector *detector = AMBeamline::bl()->exposedDetectorByName("13-el Ge");
 		detector->setIsVisible(false);
@@ -109,7 +112,7 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
 	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element))
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13"))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
 
 	if (detector){

--- a/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
@@ -69,7 +69,7 @@ IDEAS2DScanActionController::IDEAS2DScanActionController(IDEAS2DScanConfiguratio
 		detectors.addDetectorInfo(detector->toInfo());
 	}
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()){
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected()){
 
 		AMDetector *detector = AMBeamline::bl()->exposedDetectorByName("13-el Ge");
 		detector->setIsVisible(false);
@@ -111,7 +111,7 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
 	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element())
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
 
 	if (detector){

--- a/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
@@ -13,7 +13,6 @@
 #include "dataman/export/AMSMAKExporter.h"
 #include "dataman/export/AMExporterOptionSMAK.h"
 
-#include <QApplication>
 
 
 IDEAS2DScanActionController::IDEAS2DScanActionController(IDEAS2DScanConfiguration *configuration, QObject *parent)
@@ -70,7 +69,7 @@ IDEAS2DScanActionController::IDEAS2DScanActionController(IDEAS2DScanConfiguratio
 		detectors.addDetectorInfo(detector->toInfo());
 	}
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13")){
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()){
 
 		AMDetector *detector = AMBeamline::bl()->exposedDetectorByName("13-el Ge");
 		detector->setIsVisible(false);
@@ -112,7 +111,7 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
 	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13"))
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element())
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
 
 	if (detector){

--- a/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
@@ -86,7 +86,7 @@ IDEASXASScanActionController::IDEASXASScanActionController(IDEASXASScanConfigura
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("dwellTime")->toInfo());
 	}
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element)){
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13")){
 
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("13-el Ge")->toInfo());
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("13E_dwellTime")->toInfo());
@@ -150,7 +150,7 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element))
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13"))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
 
 	if (detector){

--- a/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
@@ -86,7 +86,7 @@ IDEASXASScanActionController::IDEASXASScanActionController(IDEASXASScanConfigura
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("dwellTime")->toInfo());
 	}
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()){
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected()){
 
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("13-el Ge")->toInfo());
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("13E_dwellTime")->toInfo());
@@ -150,7 +150,7 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element())
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
 
 	if (detector){

--- a/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
@@ -86,7 +86,7 @@ IDEASXASScanActionController::IDEASXASScanActionController(IDEASXASScanConfigura
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("dwellTime")->toInfo());
 	}
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13")){
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()){
 
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("13-el Ge")->toInfo());
 		ideasDetectors.addDetectorInfo(AMBeamline::bl()->exposedDetectorByName("13E_dwellTime")->toInfo());
@@ -150,7 +150,7 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13"))
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element())
 		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
 
 	if (detector){

--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -67,6 +67,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/IDEAS/IDEASXRFDetailedDetectorView.h"
 #include "ui/IDEAS/IDEASSampleCameraPanel.h"
 
+#include <QApplication>
+
+
 IDEASAppController::IDEASAppController(QObject *parent)
 	: AMAppController(parent)
 {
@@ -192,6 +195,8 @@ void IDEASAppController::setupUserInterface()
 	ideasKETEKDetailedDetectorView_->addCombinationPileUpPeakNameFilter(QRegExp("(Ka1|La1|Ma1)"));
 	mw_->addPane(ideasKETEKDetailedDetectorView_, "XRF Detectors", "KETEK", ":/system-search.png");
 
+	if (QApplication::instance()->arguments().contains("--Ge13"))
+	{
 	ideas13ElementGeDetailedDetectorView_ = new IDEAS13ElementGeDetailedDetectorView(IDEASBeamline::ideas()->ge13Element());
 	ideas13ElementGeDetailedDetectorView_->buildDetectorView();
 	ideas13ElementGeDetailedDetectorView_->setEnergyRange(1000, 20480);
@@ -199,6 +204,7 @@ void IDEASAppController::setupUserInterface()
 	ideas13ElementGeDetailedDetectorView_->addPileUpPeakNameFilter(QRegExp("(K.1|L.1|Ma1)"));
 	ideas13ElementGeDetailedDetectorView_->addCombinationPileUpPeakNameFilter(QRegExp("(Ka1|La1|Ma1)"));
 	mw_->addPane(ideas13ElementGeDetailedDetectorView_, "XRF Detectors", "13-el Ge", ":/system-search.png");
+	}
 
 	mw_->insertHeading("Scans", 2);
 

--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -67,8 +67,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/IDEAS/IDEASXRFDetailedDetectorView.h"
 #include "ui/IDEAS/IDEASSampleCameraPanel.h"
 
-#include <QApplication>
-
 
 IDEASAppController::IDEASAppController(QObject *parent)
 	: AMAppController(parent)
@@ -195,7 +193,7 @@ void IDEASAppController::setupUserInterface()
 	ideasKETEKDetailedDetectorView_->addCombinationPileUpPeakNameFilter(QRegExp("(Ka1|La1|Ma1)"));
 	mw_->addPane(ideasKETEKDetailedDetectorView_, "XRF Detectors", "KETEK", ":/system-search.png");
 
-	if (QApplication::instance()->arguments().contains("--Ge13"))
+	if (IDEASBeamline::ideas()->ge13Element())
 	{
 	ideas13ElementGeDetailedDetectorView_ = new IDEAS13ElementGeDetailedDetectorView(IDEASBeamline::ideas()->ge13Element());
 	ideas13ElementGeDetailedDetectorView_->buildDetectorView();

--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -193,16 +193,7 @@ void IDEASAppController::setupUserInterface()
 	ideasKETEKDetailedDetectorView_->addCombinationPileUpPeakNameFilter(QRegExp("(Ka1|La1|Ma1)"));
 	mw_->addPane(ideasKETEKDetailedDetectorView_, "XRF Detectors", "KETEK", ":/system-search.png");
 
-	if (IDEASBeamline::ideas()->ge13Element())
-	{
-	ideas13ElementGeDetailedDetectorView_ = new IDEAS13ElementGeDetailedDetectorView(IDEASBeamline::ideas()->ge13Element());
-	ideas13ElementGeDetailedDetectorView_->buildDetectorView();
-	ideas13ElementGeDetailedDetectorView_->setEnergyRange(1000, 20480);
-	ideas13ElementGeDetailedDetectorView_->addEmissionLineNameFilter(QRegExp("1"));
-	ideas13ElementGeDetailedDetectorView_->addPileUpPeakNameFilter(QRegExp("(K.1|L.1|Ma1)"));
-	ideas13ElementGeDetailedDetectorView_->addCombinationPileUpPeakNameFilter(QRegExp("(Ka1|La1|Ma1)"));
-	mw_->addPane(ideas13ElementGeDetailedDetectorView_, "XRF Detectors", "13-el Ge", ":/system-search.png");
-	}
+	onGe13Connected(false);
 
 	mw_->insertHeading("Scans", 2);
 
@@ -225,7 +216,23 @@ void IDEASAppController::setupUserInterface()
 	mw_->addPane(sampleCameraPanel_, "Experiment Tools", "Sample Alignment",":/22x22/gnome-display-properties.png");
 
 	connect(IDEASBeamline::ideas()->monoEnergyControl(), SIGNAL(connected(bool)), this, SLOT(onEnergyConnected(bool)));
+	connect(IDEASBeamline::ideas()->ge13Element(), SIGNAL(connected(bool)), this, SLOT(onGe13Connected(bool)));
 	onEnergyConnected(false);
+}
+
+void IDEASAppController::onGe13Connected(bool connected)
+{
+	Q_UNUSED(connected)
+	if(IDEASBeamline::ideas()->ge13Element()->isConnected())
+	{
+		ideas13ElementGeDetailedDetectorView_ = new IDEAS13ElementGeDetailedDetectorView(IDEASBeamline::ideas()->ge13Element());
+		ideas13ElementGeDetailedDetectorView_->buildDetectorView();
+		ideas13ElementGeDetailedDetectorView_->setEnergyRange(1000, 20480);
+		ideas13ElementGeDetailedDetectorView_->addEmissionLineNameFilter(QRegExp("1"));
+		ideas13ElementGeDetailedDetectorView_->addPileUpPeakNameFilter(QRegExp("(K.1|L.1|Ma1)"));
+		ideas13ElementGeDetailedDetectorView_->addCombinationPileUpPeakNameFilter(QRegExp("(Ka1|La1|Ma1)"));
+		mw_->addPane(ideas13ElementGeDetailedDetectorView_, "XRF Detectors", "13-el Ge", ":/system-search.png");
+	}
 }
 
 void IDEASAppController::makeConnections()

--- a/source/application/IDEAS/IDEASAppController.h
+++ b/source/application/IDEAS/IDEASAppController.h
@@ -59,6 +59,8 @@ protected slots:
 
 	/// Wait until the energy is connected before making the scan views
 	void onEnergyConnected(bool connected);
+	/// Wait until the Ge13Element Detector is connected before creating it's UI elements
+	void onGe13Connected(bool connected);
 	/// Helper slot that connects generic scan editors that use the 2D scan view to the app controller so that it can enable quick configuration of scans.
 	void onScanEditorCreated(AMGenericScanEditor *editor);
 	/// Helper slot that handles checking out scans when they are added to a scan editor.  For now, all this does is choose which data source is visualized in AMSingleSpectrumView in AM2DScanView.

--- a/source/application/IDEAS/IDEASMain.cpp
+++ b/source/application/IDEAS/IDEASMain.cpp
@@ -22,7 +22,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 
-#include <QApplication>
 #include <QFile>
 #include "application/IDEAS/IDEASAppController.h"
 #include "application/AMCrashMonitorSupport.h"

--- a/source/application/IDEAS/IDEASMain.cpp
+++ b/source/application/IDEAS/IDEASMain.cpp
@@ -22,6 +22,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 
+#include <QApplication>
 #include <QFile>
 #include "application/IDEAS/IDEASAppController.h"
 #include "application/AMCrashMonitorSupport.h"

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -98,13 +98,10 @@ void IDEASBeamline::setupDetectors()
 	ketek_ = new IDEASKETEKDetector("KETEK", "Single Element XRF Detector", this);
 	addSynchronizedXRFDetector(ketek_);
 
-	if (QApplication::instance()->arguments().contains("--Ge13"))
-	{
 	ge13Element_ = new IDEAS13ElementGeDetector("13-el Ge", "The thirteen element Germanium Detector", this);
 	addSynchronizedXRFDetector(ge13Element_);
 	ge13ElementRealTimeControl_ = new AMReadOnlyPVControl("13-el Ge Real Time", "dxp1608-B21-13:ElapsedReal", this);
 	ge13ElementRealTime_ = new AMBasicControlDetectorEmulator("13E_dwellTime", "13-element Ge dwell time", ge13ElementRealTimeControl_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
-	}
 
 	ketekPeakingTime_ = new AMPVControl("XRF1E Peaking Time","dxp1608-1002:dxp1:PeakingTime_RBV","dxp1608-1002:dxp1:PeakingTime", QString(), this, AMCONTROL_TOLERANCE_DONT_CARE);
 	ketekTriggerLevel_ = new AMPVControl("XRF1E Trigger Level","dxp1608-1002:dxp1:TriggerThreshold_RBV","dxp1608-1002:dxp1:TriggerThreshold", QString(), this, AMCONTROL_TOLERANCE_DONT_CARE);
@@ -281,7 +278,7 @@ AMXRFDetector *IDEASBeamline::xrfDetector(IDEAS::FluorescenceDetectors detectorT
 	if (detectorType.testFlag(IDEAS::Ketek))
 		XRFDetector = IDEASBeamline::ideas()->ketek();
 
-	else if (detectorType.testFlag(IDEAS::Ge13Element) && QApplication::instance()->arguments().contains("--Ge13"))
+	else if (detectorType.testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
 		XRFDetector = IDEASBeamline::ideas()->ge13Element();
 
 	return XRFDetector;

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -27,10 +27,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "beamline/AMAdvancedControlDetectorEmulator.h"
 
-#include <QApplication>
-
-
-
 
 IDEASBeamline::IDEASBeamline()
 	: CLSBeamline("IDEAS Beamline")

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -91,6 +91,10 @@ void IDEASBeamline::setupMotorGroup()
 
 void IDEASBeamline::setupDetectors()
 {
+	ge13Element_ = 0;
+	ge13ElementRealTimeControl_ = 0;
+	ge13ElementRealTime_ = 0;
+
 	ketek_ = new IDEASKETEKDetector("KETEK", "Single Element XRF Detector", this);
 	addSynchronizedXRFDetector(ketek_);
 
@@ -191,7 +195,7 @@ void IDEASBeamline::setupExposedControls()
 	addExposedControl(monoCrystal_);
 	addExposedControl(monoAngleOffset_);
 
-	if (QApplication::instance()->arguments().contains("--Ge13"))
+	if (ge13Element_)
 		addExposedControl(ge13ElementRealTimeControl_);
 
 	addExposedControl(ketekRealTimeControl_);
@@ -219,7 +223,7 @@ void IDEASBeamline::setupExposedDetectors()
 	addExposedDetector(ketek_);
 	addExposedDetector(ketekRealTime_);
 
-	if (QApplication::instance()->arguments().contains("--Ge13"))
+	if (ge13Element_)
 	{
 	addExposedDetector(ge13Element_);
 	addExposedDetector(ge13ElementRealTime_);

--- a/source/beamline/IDEAS/IDEASBeamline.h
+++ b/source/beamline/IDEAS/IDEASBeamline.h
@@ -40,6 +40,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/IDEAS/IDEASKETEKDetector.h"
 #include "beamline/IDEAS/IDEAS13ElementGeDetector.h"
 
+#include <QApplication>
+
+
 /// This class is the master class that holds EVERY control inside the VESPERS beamline.
 class IDEASBeamline : public CLSBeamline
 {
@@ -116,9 +119,9 @@ public:
 	AMDetector *ketekDwellTime() const {return ketekRealTime_; }
 
 	/// Returns the 13-element Ge detector pointer.
-	IDEAS13ElementGeDetector *ge13Element() const { return ge13Element_; }
+	IDEAS13ElementGeDetector *ge13Element() const { if (QApplication::instance()->arguments().contains("--Ge13")) return ge13Element_; else return 0; }
 	/// Returns the real time for the Ge detector.
-	AMDetector *ge13ElementDwellTime() const { return ge13ElementRealTime_; }
+	AMDetector *ge13ElementDwellTime() const { if (QApplication::instance()->arguments().contains("--Ge13")) return ge13ElementRealTime_; else return 0; }
 
 	/// Returns the default I0 ion chamber.
 	CLSBasicScalerChannelDetector *i0() const {return i0IonChamberScaler_;}

--- a/source/beamline/IDEAS/IDEASBeamline.h
+++ b/source/beamline/IDEAS/IDEASBeamline.h
@@ -40,7 +40,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/IDEAS/IDEASKETEKDetector.h"
 #include "beamline/IDEAS/IDEAS13ElementGeDetector.h"
 
-#include <QApplication>
 
 
 /// This class is the master class that holds EVERY control inside the VESPERS beamline.

--- a/source/beamline/IDEAS/IDEASBeamline.h
+++ b/source/beamline/IDEAS/IDEASBeamline.h
@@ -119,9 +119,9 @@ public:
 	AMDetector *ketekDwellTime() const {return ketekRealTime_; }
 
 	/// Returns the 13-element Ge detector pointer.
-	IDEAS13ElementGeDetector *ge13Element() const { if (QApplication::instance()->arguments().contains("--Ge13")) return ge13Element_; else return 0; }
+	IDEAS13ElementGeDetector *ge13Element() const {return ge13Element_;}
 	/// Returns the real time for the Ge detector.
-	AMDetector *ge13ElementDwellTime() const { if (QApplication::instance()->arguments().contains("--Ge13")) return ge13ElementRealTime_; else return 0; }
+	AMDetector *ge13ElementDwellTime() const {return ge13ElementRealTime_;}
 
 	/// Returns the default I0 ion chamber.
 	CLSBasicScalerChannelDetector *i0() const {return i0IonChamberScaler_;}

--- a/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
@@ -436,7 +436,7 @@ QComboBox *IDEAS2DScanConfigurationView::createFluorescenceComboBox()
 	QComboBox *newComboBox = new QComboBox;
 	newComboBox->insertItem(0, "None");
 	newComboBox->insertItem(1, "Ketek");
-	if (QApplication::instance()->arguments().contains("--Ge13"))
+	if (IDEASBeamline::ideas()->ge13Element())
 		newComboBox->insertItem(2, "13-el Ge");
 
 	return newComboBox;

--- a/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
@@ -15,6 +15,7 @@
 #include <QSpinBox>
 #include <QMenu>
 #include <QStringBuilder>
+#include <QApplication>
 
 IDEAS2DScanConfigurationView::IDEAS2DScanConfigurationView(IDEAS2DScanConfiguration *configuration, QWidget *parent)
 	: AMScanConfigurationView(parent)
@@ -435,7 +436,8 @@ QComboBox *IDEAS2DScanConfigurationView::createFluorescenceComboBox()
 	QComboBox *newComboBox = new QComboBox;
 	newComboBox->insertItem(0, "None");
 	newComboBox->insertItem(1, "Ketek");
-	newComboBox->insertItem(2, "13-el Ge");
+	if (QApplication::instance()->arguments().contains("--Ge13"))
+		newComboBox->insertItem(2, "13-el Ge");
 
 	return newComboBox;
 }

--- a/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
@@ -15,7 +15,6 @@
 #include <QSpinBox>
 #include <QMenu>
 #include <QStringBuilder>
-#include <QApplication>
 
 IDEAS2DScanConfigurationView::IDEAS2DScanConfigurationView(IDEAS2DScanConfiguration *configuration, QWidget *parent)
 	: AMScanConfigurationView(parent)

--- a/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEAS2DScanConfigurationView.cpp
@@ -398,6 +398,18 @@ void IDEAS2DScanConfigurationView::onFluorescenceDetectorChanged(int detector)
 	configuration_->setFluorescenceDetector((IDEAS::FluorescenceDetectors)detector);
 }
 
+void IDEAS2DScanConfigurationView::updateFluorescenceDetectorComboBoxGe13Element(bool connected)
+{
+	int currentIndex = fluorescenceDetectorComboBox_->currentIndex();
+	fluorescenceDetectorComboBox_->removeItem((int)IDEAS::Ge13Element);
+
+	if (connected)
+		fluorescenceDetectorComboBox_->insertItem((int)IDEAS::Ge13Element, "13-el Ge");
+
+	updateFluorescenceDetectorComboBox((IDEAS::FluorescenceDetectors)currentIndex);
+}
+
+
 void IDEAS2DScanConfigurationView::checkScanAxisValidity()
 {
 	QString errorString = "";
@@ -436,10 +448,11 @@ QComboBox *IDEAS2DScanConfigurationView::createFluorescenceComboBox()
 	QComboBox *newComboBox = new QComboBox;
 	newComboBox->insertItem(0, "None");
 	newComboBox->insertItem(1, "Ketek");
-	if (IDEASBeamline::ideas()->ge13Element())
+	if (IDEASBeamline::ideas()->ge13Element()->isConnected())
 		newComboBox->insertItem(2, "13-el Ge");
 
 	return newComboBox;
+
 }
 
 QGroupBox *IDEAS2DScanConfigurationView::createAndLayoutDetectorSettings(IDEASScanConfiguration *configuration)
@@ -457,6 +470,7 @@ QGroupBox *IDEAS2DScanConfigurationView::createAndLayoutDetectorSettings(IDEASSc
 	detectorSettingGroupBox->setLayout(detectorBoxLayout);
 
 	connect(fluorescenceDetectorComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onFluorescenceDetectorChanged(int)));
+	connect(IDEASBeamline::ideas()->ge13Element(), SIGNAL(connected(bool)), this, SLOT(updateFluorescenceDetectorComboBoxGe13Element(bool)));
 	connect(configuration->dbObject(), SIGNAL(fluorescenceDetectorChanged(IDEAS::FluorescenceDetectors)), this, SLOT(updateFluorescenceDetectorComboBox(IDEAS::FluorescenceDetectors)));
 
 	// default using bruker

--- a/source/ui/IDEAS/IDEAS2DScanConfigurationView.h
+++ b/source/ui/IDEAS/IDEAS2DScanConfigurationView.h
@@ -80,6 +80,9 @@ protected slots:
 	void onFluorescenceDetectorChanged(int detector);
 	/// Slot that updates the fluorescence detector buttons.
 	void updateFluorescenceDetectorComboBox(IDEAS::FluorescenceDetectors detector);
+	/// Slot that updates the fluorescence detector comboBox items when the Ge13Elemet connects.
+	void updateFluorescenceDetectorComboBoxGe13Element(bool connected);
+
 
 	/// Helper slot that handles the setting the estimated time label.
 	void onEstimatedTimeChanged();

--- a/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
@@ -36,8 +36,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/dataman/AMEXAFSScanAxisView.h"
 #include "ui/util/AMPeriodicTableDialog.h"
 
-#include <QApplication>
-
 
 
 IDEASXASScanConfigurationView::IDEASXASScanConfigurationView(IDEASXASScanConfiguration *configuration, QWidget *parent) :
@@ -389,7 +387,7 @@ QComboBox *IDEASXASScanConfigurationView::createFluorescenceComboBox()
 	QComboBox *newComboBox = new QComboBox;
 	newComboBox->insertItem(0, "None");
 	newComboBox->insertItem(1, "KETEK");
-	if (QApplication::instance()->arguments().contains("--Ge13"))
+	if (IDEASBeamline::ideas()->ge13Element())
 		newComboBox->insertItem(2, "13-el Ge");
 
 	return newComboBox;

--- a/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
@@ -36,6 +36,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/dataman/AMEXAFSScanAxisView.h"
 #include "ui/util/AMPeriodicTableDialog.h"
 
+#include <QApplication>
+
+
 
 IDEASXASScanConfigurationView::IDEASXASScanConfigurationView(IDEASXASScanConfiguration *configuration, QWidget *parent) :
 	AMScanConfigurationView(parent)
@@ -386,7 +389,8 @@ QComboBox *IDEASXASScanConfigurationView::createFluorescenceComboBox()
 	QComboBox *newComboBox = new QComboBox;
 	newComboBox->insertItem(0, "None");
 	newComboBox->insertItem(1, "KETEK");
-	newComboBox->insertItem(2, "13-el Ge");
+	if (QApplication::instance()->arguments().contains("--Ge13"))
+		newComboBox->insertItem(2, "13-el Ge");
 
 	return newComboBox;
 }

--- a/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
@@ -70,7 +70,9 @@ IDEASXASScanConfigurationView::IDEASXASScanConfigurationView(IDEASXASScanConfigu
 	// The fluorescence detector setup
 	fluorescenceDetectorComboBox_  = createFluorescenceComboBox();
 	connect(fluorescenceDetectorComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onFluorescenceChoiceChanged(int)));
+	connect(IDEASBeamline::ideas()->ge13Element(), SIGNAL(connected(bool)), this, SLOT(updateFluorescenceDetectorComboBoxGe13Element(bool)));
 	connect(configuration_->dbObject(), SIGNAL(fluorescenceDetectorChanged(int)), this, SLOT(updateFluorescenceDetectorComboBox(int)));
+
 
 	// Energy (Eo) selection
 	energy_ = new QDoubleSpinBox;
@@ -361,7 +363,7 @@ void IDEASXASScanConfigurationView::onROIChange()
 	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
 		detector = IDEASBeamline::ideas()->ketek();
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element))
+	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
 		detector = IDEASBeamline::ideas()->ge13Element();
 
 	if (detector){
@@ -385,18 +387,29 @@ void IDEASXASScanConfigurationView::onROIChange()
 QComboBox *IDEASXASScanConfigurationView::createFluorescenceComboBox()
 {
 	QComboBox *newComboBox = new QComboBox;
-	newComboBox->insertItem(0, "None");
-	newComboBox->insertItem(1, "KETEK");
-	if (IDEASBeamline::ideas()->ge13Element())
-		newComboBox->insertItem(2, "13-el Ge");
-
+	newComboBox->insertItem((int)IDEAS::NoXRF, "None");
+	newComboBox->insertItem((int)IDEAS::Ketek, "KETEK");
+	if (IDEASBeamline::ideas()->ge13Element()->isConnected())
+		newComboBox->insertItem((int)IDEAS::Ge13Element, "13-el Ge");
 	return newComboBox;
 }
 
-void IDEASXASScanConfigurationView::updateFluorescenceDetectorComboBox(int detector)
+void IDEASXASScanConfigurationView::updateFluorescenceDetectorComboBox(IDEAS::FluorescenceDetectors detector)
 {
 	fluorescenceDetectorComboBox_->setCurrentIndex(detector);
 }
+
+void IDEASXASScanConfigurationView::updateFluorescenceDetectorComboBoxGe13Element(bool connected)
+{
+	int currentIndex = fluorescenceDetectorComboBox_->currentIndex();
+	fluorescenceDetectorComboBox_->removeItem((int)IDEAS::Ge13Element);
+
+	if (connected)
+		fluorescenceDetectorComboBox_->insertItem((int)IDEAS::Ge13Element, "13-el Ge");
+
+	updateFluorescenceDetectorComboBox((IDEAS::FluorescenceDetector)currentIndex);
+}
+
 
 void IDEASXASScanConfigurationView::onFluorescenceChoiceChanged(int id)
 {

--- a/source/ui/IDEAS/IDEASXASScanConfigurationView.h
+++ b/source/ui/IDEAS/IDEASXASScanConfigurationView.h
@@ -75,7 +75,9 @@ protected slots:
 	/// Handles updates of displayed detector ROIs
 	void onROIChange();
 	/// Slot that updates the fluorescence detector buttons.
-	void updateFluorescenceDetectorComboBox(int detector);
+	void updateFluorescenceDetectorComboBox(IDEAS::FluorescenceDetectors detector);
+	/// Slot that updates the fluorescence detector comboBox items when the Ge13Elemet connects.
+	void updateFluorescenceDetectorComboBoxGe13Element(bool connected);
 	/// Handles changes to the fluorescence detector choice.
 	void onFluorescenceChoiceChanged(int id);
 	/// Handles changes in peaking time from detector


### PR DESCRIPTION
Added command line argument for 13-element detector
"--Ge13" is required in the command line or the 13-element detector is
excluded through the application.

Tested and found expected behavior without --Ge13.  AM complains the same as it did before with --Ge13.  I believe this is adequate testing for now, but it may need to be revisited at a future date when the 13-element detector electronics are online on IDEAS.