### PR TITLE
Pull Request for Issue1579: Crash on saving in IDEASXRFDetailedDetectorView

### DIFF
--- a/source/ui/IDEAS/IDEASXRFDetailedDetectorView.cpp
+++ b/source/ui/IDEAS/IDEASXRFDetailedDetectorView.cpp
@@ -39,6 +39,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 IDEASXRFDetailedDetectorView::IDEASXRFDetailedDetectorView(AMXRFDetector *detector, QWidget *parent)
 	: AMXRFDetailedDetectorView(detector, parent)
 {
+	chooseScanDialog_ = 0;
 	setMaximumHeight(885);
 }
 


### PR DESCRIPTION
The view was doing lazy loading of the choose scans dialog, without first initializing the reference to zero in the constructor. 

- Made it do that thing.
- Made sure VESPERS and XSRMB XRF Detailed Detector Views also did that thing (they did do that thing).