### PR TITLE
Pull Request for Issue1577: Update MPlot to take advantage of the range in a data source.

### DIFF
--- a/source/dataman/datasource/AMDataSourceImageData.cpp
+++ b/source/dataman/datasource/AMDataSourceImageData.cpp
@@ -66,7 +66,15 @@ void AMDataSourceImageData::setDataSource(const AMDataSource* dataSource) {
 	}
 
     onSizeChanged();
-	onDataChanged(AMnDIndex(0,0), AMnDIndex(xSize_-1, ySize_-1));
+    onDataChanged(AMnDIndex(0,0), AMnDIndex(xSize_-1, ySize_-1));
+}
+
+MPlotRange AMDataSourceImageData::range() const
+{
+	if (cacheUpdateRequired_)
+		updateCachedValues();
+
+	return range_;
 }
 
 double AMDataSourceImageData::x(int index) const

--- a/source/dataman/datasource/AMDataSourceImageData.h
+++ b/source/dataman/datasource/AMDataSourceImageData.h
@@ -43,9 +43,6 @@ public:
 	/// Access the underlying data source
 	const inline AMDataSource* dataSource() const { return source_; }
 
-	/// Returns the range.  Reimplmented to use the caching scheme used in this class.
-	MPlotRange range() const;
-
 	/// Return the x (data value) corresponding an (x,y) \c index.
 	virtual double x(int index) const;
 	/// Copy an entire block of x values from \c startIndex to \c endIndex into \c outputValues.
@@ -67,13 +64,13 @@ public:
 
 protected slots:
 	/// Handles updating the axis values associated with the given index (will be 0 or 1).
-    void onAxisValuesChanged();
+	void onAxisValuesChanged();
 	/// Handles updating the data values from the given index to the end index.
 	void onDataChanged(const AMnDIndex &start, const AMnDIndex &end);
 	/// Handles updating the size of the given axis.  Will invalidate the axis values of that axis.
-    void onSizeChanged();
+	void onSizeChanged();
 	/// Recomputes the bounding rect. Called if the size or axis values change.  Only updates the corresponding size if specified.
-    void recomputeBoundingRect();
+	void recomputeBoundingRect();
 
 	/// ensure that we don't keep trying to read data from a source that has been deleted.
 	void onDataSourceDeleted();
@@ -98,9 +95,9 @@ protected:
 	/// The cached y-axis values.
 	QVector<double> yAxis_;
 	/// The cached z-values.
-	mutable QVector<double> data_;
+	mutable QVector<double> cachedData_;
 	/// Flag used for knowing when to recache the data in the model.
-    mutable bool updateCacheRequired_;
+	mutable bool cacheUpdateRequired_;
 };
 
 

--- a/source/dataman/datasource/AMDataSourceImageData.h
+++ b/source/dataman/datasource/AMDataSourceImageData.h
@@ -43,6 +43,9 @@ public:
 	/// Access the underlying data source
 	const inline AMDataSource* dataSource() const { return source_; }
 
+	/// Returns the range.  Reimplmented to use the caching scheme used in this class.
+	virtual MPlotRange range() const;
+
 	/// Return the x (data value) corresponding an (x,y) \c index.
 	virtual double x(int index) const;
 	/// Copy an entire block of x values from \c startIndex to \c endIndex into \c outputValues.

--- a/source/dataman/datasource/AMDataSourceImageDatawDefault.cpp
+++ b/source/dataman/datasource/AMDataSourceImageDatawDefault.cpp
@@ -20,6 +20,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "AMDataSourceImageDatawDefault.h"
 
+#include "util/AMUtility.h"
+
 AMDataSourceImageDatawDefault::AMDataSourceImageDatawDefault(double defaultValue, QObject *parent)
 	: AMDataSourceImageData(parent)
 {
@@ -39,32 +41,13 @@ void AMDataSourceImageDatawDefault::setDefaultValue(double value)
 
 void AMDataSourceImageDatawDefault::updateCachedValues() const
 {
-    AMnDIndex start = AMnDIndex(0, 0);
-    AMnDIndex end = AMnDIndex(xSize_-1, ySize_-1);
-    QVector<double> newData = QVector<double>(start.totalPointsTo(end));
+	AMnDIndex start = AMnDIndex(0, 0);
+	AMnDIndex end = AMnDIndex(xSize_-1, ySize_-1);
 
-    if (source_->values(start, end, newData.data())){
+	if (source_->values(start, end, cachedData_.data())){
 
-		double rangeMinimum = newData.first();
-		double rangeMaximum = newData.first();
-
-        for (int j = 0, jSize = end.j()-start.j()+1; j < jSize; j++){
-
-            for (int i = 0, iSize = end.i()-start.i()+1; i < iSize; i++){
-
-				double newValue = newData.at(i*jSize+j);
-
-				if (newValue > rangeMaximum && newValue != defaultValue_)
-					rangeMaximum = newValue;
-
-				if (newValue < rangeMinimum && newValue != defaultValue_)
-					rangeMinimum = newValue;
-
-                data_[i*ySize_ + j] = newValue;
-			}
-		}
-
-        range_ = MPlotRange(rangeMinimum, rangeMaximum);
-		updateCacheRequired_ = false;
+		AMRange dataSourceRange = AMUtility::rangeFinder(cachedData_, defaultValue_);
+		range_ = MPlotRange(dataSourceRange.minimum(), dataSourceRange.maximum());
+		cacheUpdateRequired_ = false;
 	}
 }

--- a/source/dataman/datasource/AMDataSourceSeriesData.h
+++ b/source/dataman/datasource/AMDataSourceSeriesData.h
@@ -84,11 +84,11 @@ protected:
 	/// The cached independent axis data.
 	QVector<qreal> axis_;
 	/// The cached dependent data.
-	mutable QVector<qreal> data_;
+	mutable QVector<qreal> cachedData_;
 	/// Flag for when to update the cached data.
-	mutable bool updateCacheRequired_;
-    /// Holds the data range of the dependent values.
-    mutable AMRange dataRange_;
+	mutable bool cacheUpdateRequired_;
+	/// Holds the data range of the dependent values.
+	mutable AMRange range_;
 };
 
 #endif // AMDATASOURCESERIESDATA_H


### PR DESCRIPTION
From #1577.
> As it turns out, with the new caching of the other data sources, it doesn't appear that there are any changes to MPlot since all the changes happen inside of AMDataSourceSeriesData, AMDataSourceImageData, and AMDataSourceImageDatawDefault (which is technically a model class for MPlot).

Therefore, this was actually much more straight forward as all the work was done inside the previous issues (and using the new AMUtility class again).

Assigned to @helfrij.