### PR TITLE
Pull Request for Issue1647: Implementing AMControl::hasChild().

### DIFF
--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -69,6 +69,31 @@ void BioXASSideAppController::setupUserInterface()
 	mw_->setWindowTitle("Acquaman - BioXAS Side");
 
 	addPersistentView(new BioXASSidePersistentView());
+
+	// Testing for AMControl::hasChildControl().
+
+	if (BioXASSideBeamline::bioXAS()->jjSlits()->verticalGapControl()->hasChildControl(0))
+		qDebug() << "\n\nThe JJ slit vertical gap has null child control. :(";
+	else
+		qDebug() << "\n\nThe JJ slit vertical gap does NOT have null child control. :)";
+
+
+	if (BioXASSideBeamline::bioXAS()->jjSlits()->verticalGapControl()->hasChildControl(BioXASSideBeamline::bioXAS()->jjSlits()->upperBladeControl()))
+		qDebug() << "\n\nThe JJ slit vertical gap has upper blade as child control. :)";
+	else
+		qDebug() << "\n\nThe JJ slit vertical gap does NOT have the upper blade as child control. :(";
+
+
+	if (BioXASSideBeamline::bioXAS()->jjSlits()->verticalGapControl()->hasChildControl(BioXASSideBeamline::bioXAS()->carbonFilterFarm()->filterControl()))
+		qDebug() << "\n\nThe JJ slit vertical gap control has the carbon filter farm control as a child. :(";
+	else
+		qDebug() << "\n\nThe JJ slit vertical gap control does NOT have the carbon filter farm control as child. :)";
+
+
+	if (BioXASSideBeamline::bioXAS()->carbonFilterFarm()->filterControl()->hasChildControl(BioXASSideBeamline::bioXAS()->carbonFilterFarm()->upstreamPositionControl()))
+		qDebug() <<  "\n\nThe carbon filter farm filter control has the upstream position control as a child. :)";
+	else
+		qDebug() << "\n\nThe carbon filter farm filter control does NOT have the upstream position control as a child. :(";
 }
 
 bool BioXASSideAppController::setupDataFolder()

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -69,31 +69,6 @@ void BioXASSideAppController::setupUserInterface()
 	mw_->setWindowTitle("Acquaman - BioXAS Side");
 
 	addPersistentView(new BioXASSidePersistentView());
-
-	// Testing for AMControl::hasChildControl().
-
-	if (BioXASSideBeamline::bioXAS()->jjSlits()->verticalGapControl()->hasChildControl(0))
-		qDebug() << "\n\nThe JJ slit vertical gap has null child control. :(";
-	else
-		qDebug() << "\n\nThe JJ slit vertical gap does NOT have null child control. :)";
-
-
-	if (BioXASSideBeamline::bioXAS()->jjSlits()->verticalGapControl()->hasChildControl(BioXASSideBeamline::bioXAS()->jjSlits()->upperBladeControl()))
-		qDebug() << "\n\nThe JJ slit vertical gap has upper blade as child control. :)";
-	else
-		qDebug() << "\n\nThe JJ slit vertical gap does NOT have the upper blade as child control. :(";
-
-
-	if (BioXASSideBeamline::bioXAS()->jjSlits()->verticalGapControl()->hasChildControl(BioXASSideBeamline::bioXAS()->carbonFilterFarm()->filterControl()))
-		qDebug() << "\n\nThe JJ slit vertical gap control has the carbon filter farm control as a child. :(";
-	else
-		qDebug() << "\n\nThe JJ slit vertical gap control does NOT have the carbon filter farm control as child. :)";
-
-
-	if (BioXASSideBeamline::bioXAS()->carbonFilterFarm()->filterControl()->hasChildControl(BioXASSideBeamline::bioXAS()->carbonFilterFarm()->upstreamPositionControl()))
-		qDebug() <<  "\n\nThe carbon filter farm filter control has the upstream position control as a child. :)";
-	else
-		qDebug() << "\n\nThe carbon filter farm filter control does NOT have the upstream position control as a child. :(";
 }
 
 bool BioXASSideAppController::setupDataFolder()

--- a/source/beamline/AMControl.cpp
+++ b/source/beamline/AMControl.cpp
@@ -31,7 +31,7 @@ AMControl::AMControl(const QString& name, const QString& units, QObject* parent,
 	displayPrecision_ = 3;
 }
 
-bool AMControl::hasChildControl(AMControl *control)
+bool AMControl::hasChildControl(AMControl *control) const
 {
 	bool result = false;
 

--- a/source/beamline/AMControl.cpp
+++ b/source/beamline/AMControl.cpp
@@ -30,3 +30,27 @@ AMControl::AMControl(const QString& name, const QString& units, QObject* parent,
 	allowsMovesWhileMoving_ = false;
 	displayPrecision_ = 3;
 }
+
+bool AMControl::hasChildControl(AMControl *control)
+{
+	bool result = false;
+
+	if (control && !children_.isEmpty()) {
+		bool controlFound = false;
+
+		for (int i = 0, count = children_.count(); i < count && !controlFound; i++) {
+			AMControl *child = children_.at(i);
+
+			if (child) {
+				if (child == control)
+					controlFound = true;
+				else
+					controlFound = child->hasChildControl(control);
+			}
+		}
+
+		result = controlFound;
+	}
+
+	return result;
+}

--- a/source/beamline/AMControl.h
+++ b/source/beamline/AMControl.h
@@ -308,6 +308,8 @@ public:
 			return children_.at(index);
 		return NULL;
 	}
+	/// Returns true if this control has children and if one of them (or one of their children) matches the given control. Returns false otherwise.
+	bool hasChildControl(AMControl *control);
 	/// Add a subcontrol to the control group. Subclasses can reimplement this if they need to connect to the child's signals, etc.
 	virtual void addChildControl(AMControl* control) { children_ << control; }
 	//@}

--- a/source/beamline/AMControl.h
+++ b/source/beamline/AMControl.h
@@ -309,7 +309,7 @@ public:
 		return NULL;
 	}
 	/// Returns true if this control has children and if one of them (or one of their children) matches the given control. Returns false otherwise.
-	bool hasChildControl(AMControl *control);
+	bool hasChildControl(AMControl *control) const;
 	/// Add a subcontrol to the control group. Subclasses can reimplement this if they need to connect to the child's signals, etc.
 	virtual void addChildControl(AMControl* control) { children_ << control; }
 	//@}


### PR DESCRIPTION
Added new method hasChild(AMControl*) to AMControl. 

Tested on BioXAS using the JJ slits and the carbon filter farm:
- controls were correctly able to return true when asked about one of their children, false for not a child.
- controls were correctly able to return true when asked for a child of one of their children.