### PR TITLE
Pull Request for Issue1648: Create action for calibrating controls

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -428,7 +428,9 @@ HEADERS += \
     source/ui/dataman/AMScanViewPlotSelectedToolsView.h \
     source/dataman/AMScanViewPlotTools.h \
     source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.h \
-    $$PWD/source/analysis/AMAdditionAB.h
+    $$PWD/source/analysis/AMAdditionAB.h \
+    source/actions3/actions/AMControlCalibrateActionInfo.h \
+    source/actions3/actions/AMControlCalibrateAction.h
 
 FORMS += \
 
@@ -818,7 +820,9 @@ SOURCES += \
     source/ui/dataman/AMScanViewPlotSelectedToolsView.cpp \
     source/dataman/AMScanViewPlotTools.cpp \
     source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp \
-    $$PWD/source/analysis/AMAdditionAB.cpp
+    $$PWD/source/analysis/AMAdditionAB.cpp \
+    source/actions3/actions/AMControlCalibrateActionInfo.cpp \
+    source/actions3/actions/AMControlCalibrateAction.cpp
 
 RESOURCES *= source/icons/icons.qrc \
 		source/configurationFiles/configurationFiles.qrc \

--- a/source/actions3/AMActionSupport.h
+++ b/source/actions3/AMActionSupport.h
@@ -27,6 +27,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/actions/AMControlMoveAction3.h"
 #include "actions3/actions/AMControlWaitAction.h"
 #include "actions3/actions/AMChangeToleranceAction.h"
+#include "actions3/actions/AMControlCalibrateAction.h"
 
 /// This namespace provides some convenience methods for using AMActions.
 namespace AMActionSupport
@@ -81,6 +82,15 @@ namespace AMActionSupport
 		info.setTolerance(tolerance);
 		AMChangeToleranceActionInfo *actionInfo = new AMChangeToleranceActionInfo(info, tolerance);
 		AMChangeToleranceAction *action = new AMChangeToleranceAction(actionInfo, control);
+		return action;
+	}
+
+	/// Helper method that takes an AMCOntrol and two values (oldValue, newValue), and returna a valid AMControlCalibrateAction. Caller is responsible for memory.
+	inline AMAction3 *buildControlCalibrateAction(AMControl *control, double oldValue, double newValue)
+	{
+		AMControlInfo info = control->toInfo();
+		AMControlCalibrateActionInfo *actionInfo = new AMControlCalibrateActionInfo(info, oldValue, newValue);
+		AMControlCalibrateAction *action = new AMControlCalibrateAction(actionInfo, control);
 		return action;
 	}
 }

--- a/source/actions3/actions/AMControlCalibrateAction.cpp
+++ b/source/actions3/actions/AMControlCalibrateAction.cpp
@@ -1,0 +1,121 @@
+#include "AMControlCalibrateAction.h"
+#include "beamline/AMControl.h"
+#include "beamline/AMBeamline.h"
+#include "util/AMErrorMonitor.h"
+
+AMControlCalibrateAction::AMControlCalibrateAction(AMControlCalibrateActionInfo *info, AMControl *control, QObject *parent) :
+	AMAction3(info, parent)
+{
+	// Initialize class variables.
+
+	control_ = 0;
+
+	// Current settings.
+
+	setControl(control);
+}
+
+AMControlCalibrateAction::AMControlCalibrateAction(const AMControlCalibrateAction &original) :
+	AMAction3(original)
+{
+	setControl(original.control());
+}
+
+AMControlCalibrateAction::~AMControlCalibrateAction()
+{
+
+}
+
+void AMControlCalibrateAction::setControl(AMControl *control)
+{
+	if (control)
+		control_ = control;
+	else
+		control_ = AMBeamline::bl()->exposedControlByInfo(controlCalibrateInfo()->controlInfo());
+}
+
+void AMControlCalibrateAction::onCalibrateStarted()
+{
+	// Set action as started.
+
+	setStarted();
+
+	// Start progress timer updates.
+
+	connect( &progressTimer_, SIGNAL(timeout()), this, SLOT(onProgressTick()) );
+	progressTimer_.start(250);
+}
+
+void AMControlCalibrateAction::onCalibrateFailed()
+{
+	// Disconnect from the control.
+
+	disconnect(control_, 0, this, 0);
+
+	// End progress timer updates.
+
+	progressTimer_.stop();
+	disconnect(&progressTimer_, 0, this, 0);
+
+	// Create failure message and set action as failed.
+
+	QString fundamentalFailureMessage = QString("There was an error calibrating the control '%1' such that %2 becomes %3.").arg(control_->name()).arg(controlCalibrateInfo()->oldValue()).arg(controlCalibrateInfo()->newValue());
+	setFailed(fundamentalFailureMessage);
+}
+
+void AMControlCalibrateAction::onCalibrateSucceeded()
+{
+	// Disconnect from the control.
+
+	disconnect( control_, 0, this, 0 );
+
+	// End progress timer updates.
+
+	progressTimer_.stop();
+	disconnect( &progressTimer_, 0, this, 0 );
+	setProgress(100, 100);
+
+	// Set action as succeeded.
+
+	setSucceeded();
+}
+
+void AMControlCalibrateAction::startImplementation()
+{
+	// Must have a control, and it must support calibration.
+
+	if(!control_) {
+		QString fundamentalFailureMessage = QString("There was an error calibrating the control '%1', because the control was not found.").arg(controlCalibrateInfo()->controlInfo().name());
+		AMErrorMon::alert(this, AMCONTROLCALIBRATEACTION_CONTROL_NOT_VALID, QString("%1. Please report this problem to the Acquaman developers.").arg(fundamentalFailureMessage));
+		setFailed(fundamentalFailureMessage);
+		return;
+	}
+
+	if(!control_->canCalibrate()) {
+		QString fundamentalFailureMessage = QString("There was an error calibrating the control '%1', because the control reported it cannot calibrate.").arg(control_->name());
+		AMErrorMon::alert(this, AMCONTROLCALIBRATEACTION_CONTROL_CANT_CALIBRATE, QString("%1. Please report this problem to the beamline staff.").arg(fundamentalFailureMessage));
+		setFailed(fundamentalFailureMessage);
+		return;
+	}
+
+	// Check that the calibration values are valid.
+
+	if (controlCalibrateInfo()->oldValue() == controlCalibrateInfo()->newValue()) {
+		QString fundamentalFailureMessage = QString("There was an error calibrating the control '%1', because the calibration values are identical. No calibration needed.").arg(control_->name());
+		AMErrorMon::alert(this, AMCONTROLCALIBRATEACTION_VALUES_NOT_VALID, fundamentalFailureMessage);
+		setFailed(fundamentalFailureMessage);
+		return;
+	}
+
+	// Make connections.
+
+	connect( control_, SIGNAL(calibrationStarted()), this, SLOT(onCalibrateStarted()) );
+	connect( control_, SIGNAL(calibrationFailed(int)), this, SLOT(onCalibrateFailed()) );
+	connect( control_, SIGNAL(calibrationSucceeded()), this, SLOT(onCalibrateSucceeded()) );
+
+	// Start the calibration.
+
+	int failureExplanation = control_->calibrate(controlCalibrateInfo()->oldValue(), controlCalibrateInfo()->newValue());
+	if (failureExplanation != AMControl::NoFailure)
+		onCalibrateFailed();
+}

--- a/source/actions3/actions/AMControlCalibrateAction.h
+++ b/source/actions3/actions/AMControlCalibrateAction.h
@@ -1,0 +1,81 @@
+#ifndef AMCONTROLCALIBRATEACTION_H
+#define AMCONTROLCALIBRATEACTION_H
+
+#include <QTimer>
+
+#include "actions3/AMAction3.h"
+#include "actions3/actions/AMControlCalibrateActionInfo.h"
+
+#define AMCONTROLCALIBRATEACTION_CONTROL_NOT_VALID 7739
+#define AMCONTROLCALIBRATEACTION_CONTROL_CANT_CALIBRATE 7740
+#define AMCONTROLCALIBRATEACTION_VALUES_NOT_VALID 7741
+
+class AMControl;
+
+class AMControlCalibrateAction : public AMAction3
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit AMControlCalibrateAction(AMControlCalibrateActionInfo *info, AMControl *control, QObject *parent = 0);
+	/// Copy contructor.
+	AMControlCalibrateAction(const AMControlCalibrateAction &original);
+	/// Destructor.
+	virtual ~AMControlCalibrateAction();
+
+	/// Virtual copy constructor.
+	virtual AMAction3* createCopy() const { return new AMControlCalibrateAction(*this); }
+
+	/// Returns the control this action will calibrate.
+	AMControl* control() const { return control_; }
+
+	/// Specify that we cannot pause (since AMControl cannot pause).  If we wanted to get fancy, we might check if the control could stop, (and stop it for pause, and then start it again to resume). But this is much simpler for now.
+	virtual bool canPause() const { return false; }
+	/// This action cannot skip.
+	virtual bool canSkip() const { return false; }
+
+	/// Virtual function that denotes that this action has children underneath it or not.
+	virtual bool hasChildren() const { return false; }
+	/// Virtual function that returns the number of children for this action.
+	virtual int numberOfChildren() const { return 0; }
+
+	/// Returns the action info specific for this action.
+	const AMControlCalibrateActionInfo* controlCalibrateInfo() const { return qobject_cast<const AMControlCalibrateActionInfo*>(info()); }
+	/// Returns the action info specific for this action.
+	AMControlCalibrateActionInfo* controlCalibrateInfo() { return qobject_cast<AMControlCalibrateActionInfo*>(info()); }
+
+signals:
+
+public slots:
+	/// Sets the control used by this action.
+	void setControl(AMControl *control);
+
+protected slots:
+	/// Handles emitting the appropriate signals when the control calibration has started.
+	void onCalibrateStarted();
+	/// Handles emitting the appropriate signals when the control calibration has failed.
+	void onCalibrateFailed();
+	/// Handles emitting the appropriate signals when the control calibration has succeeded.
+	void onCalibrateSucceeded();
+
+protected:
+	/// This function is called from the Starting state when the implementation should initiate the action.
+	virtual void startImplementation();
+	/// For actions which support pausing, this function is called from the Pausing state when the implementation should pause the action.
+	virtual void pauseImplementation() { setPaused(); }
+	/// For actions that support resuming, this function is called from the Paused state when the implementation should resume the action.
+	virtual void resumeImplementation() { setResumed(); }
+	/// All implementations must support cancelling. This function will be called from the Cancelling state when the implementation should cancel the action.
+	virtual void cancelImplementation() { setCancelled(); }
+	/// The function is called from the Skipping state when the implementation should skip the action. This implementation does not support skipping.
+	virtual void skipImplementation(const QString &command) { Q_UNUSED(command); }
+
+protected:
+	/// The control being calibrated.
+	AMControl *control_;
+	/// The timer used to issue progress updates.
+	QTimer progressTimer_;
+};
+
+#endif // AMCONTROLCALIBRATEACTION_H

--- a/source/actions3/actions/AMControlCalibrateActionInfo.cpp
+++ b/source/actions3/actions/AMControlCalibrateActionInfo.cpp
@@ -1,0 +1,65 @@
+#include "AMControlCalibrateActionInfo.h"
+
+AMControlCalibrateActionInfo::AMControlCalibrateActionInfo(const AMControlInfo &controlInfo, double oldValue, double newValue, QObject *parent) :
+	AMActionInfo3(QString(), QString(), QString(), parent)
+{
+	controlInfo_.setValuesFrom(controlInfo);
+	oldValue_ = oldValue;
+	newValue_ = newValue;
+}
+
+AMControlCalibrateActionInfo::AMControlCalibrateActionInfo(const AMControlCalibrateActionInfo &original) :
+	AMActionInfo3(original)
+{
+	controlInfo_.setValuesFrom(original.controlInfo());
+	oldValue_ = original.oldValue();
+	newValue_ = original.newValue();
+}
+
+AMControlCalibrateActionInfo::~AMControlCalibrateActionInfo()
+{
+
+}
+
+AMActionInfo3* AMControlCalibrateActionInfo::createCopy() const
+{
+	AMActionInfo3 *info = new AMControlCalibrateActionInfo(*this);
+	info->dissociateFromDb(true);
+	return info;
+}
+
+void AMControlCalibrateActionInfo::setControlInfo(const AMControlInfo &newInfo)
+{
+	controlInfo_.setValuesFrom(newInfo);
+	setModified(true);
+
+	updateDescriptionText();
+}
+
+void AMControlCalibrateActionInfo::setOldValue(double newValue)
+{
+	oldValue_ = newValue;
+	setModified(true);
+
+	updateDescriptionText();
+}
+
+void AMControlCalibrateActionInfo::setNewValue(double newValue)
+{
+	newValue_ = newValue;
+	setModified(true);
+
+	updateDescriptionText();
+}
+
+void AMControlCalibrateActionInfo::updateDescriptionText()
+{
+	QString controlName = (controlInfo_.description().isEmpty() ? controlInfo_.name() : controlInfo_.description());
+	QString oldValue = QString::number(oldValue_);
+	QString newValue = QString::number(newValue_);
+
+	QString newText = QString("Calibrating %1 such that %2 becomes %3").arg(controlName).arg(oldValue).arg(newValue);
+
+	setShortDescription(newText);
+	setLongDescription(newText);
+}

--- a/source/actions3/actions/AMControlCalibrateActionInfo.h
+++ b/source/actions3/actions/AMControlCalibrateActionInfo.h
@@ -1,0 +1,61 @@
+#ifndef AMCONTROLCALIBRATEACTIONINFO_H
+#define AMCONTROLCALIBRATEACTIONINFO_H
+
+#include "actions3/AMActionInfo3.h"
+#include "dataman/info/AMControlInfo.h"
+
+class AMControlCalibrateActionInfo : public AMActionInfo3
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit AMControlCalibrateActionInfo(const AMControlInfo &control = AMControlInfo(), double oldValue = 0, double newValue = 0, QObject *parent = 0);
+	/// Copy constructor.
+	AMControlCalibrateActionInfo(const AMControlCalibrateActionInfo &original);
+	/// Destructor.
+	virtual ~AMControlCalibrateActionInfo();
+
+	/// Virtual copy constructor.
+	virtual AMActionInfo3* createCopy() const;
+
+	/// Returns a description of this action.
+	virtual QString typeDescription() const { return "Control Calibrate"; }
+
+	/// Returns the control info.
+	const AMControlInfo& controlInfo() const { return controlInfo_; }
+	/// Returns the control's old value.
+	double oldValue() const { return oldValue_; }
+	/// Returns the control's new info.
+	double newValue() const { return newValue_; }
+
+signals:
+
+
+public slots:
+	/// Sets the control info.
+	void setControlInfo(const AMControlInfo &newInfo);
+	/// Sets the control's old value.
+	void setOldValue(double newValue);
+	/// Sets the control's new value.
+	void setNewValue(double newValue);
+
+protected:
+	/// Updates the description.
+	void updateDescriptionText();
+
+	/// For database storing only.
+	AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
+	/// For database loading only.
+	void dbLoadControlInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
+
+protected:
+	/// The control info.
+	AMControlInfo controlInfo_;
+	/// The control's old value.
+	double oldValue_;
+	/// The control's new value.
+	double newValue_;
+};
+
+#endif // AMCONTROLCALIBRATEACTIONINFO_H

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorEnergyControl.cpp
@@ -183,7 +183,7 @@ AMAction3* BioXASSSRLMonochromatorEnergyControl::createCalibrateAction(double ol
 
 		// Create calibration action for the bragg motor.
 
-		result = bragg_->createCalibrationAction(oldPosition, newPosition);
+		result = AMActionSupport::buildControlCalibrateAction(bragg_, oldPosition, newPosition);
 	}
 
 	return result;

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -246,27 +246,33 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 
 void BioXASSSRLMonochromatorConfigurationView::onCalibrateEnergyButtonClicked()
 {
-	if (mono_ && mono_->energyControl()) {
-		bool inputOK = false;
+	if (mono_) {
+		AMControl *energyControl = mono_->energyControl();
 
-		double newEnergy = QInputDialog::getDouble(this, "Energy Calibration", "Enter calibrated energy:", mono_->energyControl()->value(), ENERGY_MIN, ENERGY_MAX, 2, &inputOK);
+		if (energyControl) {
+			bool inputOK = false;
+			double oldEnergy = energyControl->value();
+			double newEnergy = QInputDialog::getDouble(this, "Energy Calibration", "Enter calibrated energy:", oldEnergy, ENERGY_MIN, ENERGY_MAX, 2, &inputOK);
 
-		if (inputOK) {
-			AMControl *energy = mono_->energyControl();
-			energy->calibrate(energy->value(), newEnergy);
+			if (inputOK)
+				energyControl->calibrate(oldEnergy, newEnergy);
 		}
 	}
 }
 
 void BioXASSSRLMonochromatorConfigurationView::onCalibrateGoniometerButtonClicked()
 {
-	if (mono_ && mono_->braggMotor()) {
-		bool inputOK = false;
+	if (mono_) {
+		AMControl *braggMotor = mono_->braggMotor();
 
-		double newPosition = QInputDialog::getDouble(this, "Goniometer Calibration", "Enter calibrated goniometer position:", mono_->braggMotor()->value(), BRAGG_POSITION_MIN, BRAGG_POSITION_MAX, 2, &inputOK);
+		if (braggMotor) {
+			bool inputOK = false;
+			double oldPosition = braggMotor->value();
+			double newPosition = QInputDialog::getDouble(this, "Goniometer Calibration", "Enter calibrated goniometer position:", oldPosition, BRAGG_POSITION_MIN, BRAGG_POSITION_MAX, 2, &inputOK);
 
-		if (inputOK)
-			mono_->braggMotor()->calibrate(mono_->braggMotor()->value(), newPosition);
+			if (inputOK)
+				braggMotor->calibrate(oldPosition, newPosition);
+		}
 	}
 }
 


### PR DESCRIPTION
Created new action classes for calibrating controls. These classes are based heavily off of existing AMControlMoveAction/Info.
- [x] AMControlCalibrateActionInfo
- [x] AMControlCalibrateAction

Added an inline function to AMActionSupport that creates and returns a calibration action when supplied with a control and two values to calibrate with (oldValue, newValue).

Implemented the change in BioXASSSRLMonochromatorEnergyControl::createCalibrateAction(), where the AMActionSupport version of getting the bragg motor calibration action is now used. 

The goal of testing is to make sure that existing functionality is not affected by the new changes. Making small changes to the bragg motor calibration and the energy control calibration through the BioXASSSRLMonochromatorConfigurationView seem to show that no changes have occurred.