### PR TITLE
Pull Request for Issue1645: Scans not always added to loop actions when using loop mode

### DIFF
--- a/source/ui/acquaman/AMScanConfigurationViewHolder3.cpp
+++ b/source/ui/acquaman/AMScanConfigurationViewHolder3.cpp
@@ -122,8 +122,13 @@ void AMScanConfigurationViewHolder3::setEnabled(bool enabled){
 
 AMAction3 * AMScanConfigurationViewHolder3::createScan()
 {
-	if(view_)
-		return new AMScanAction(new AMScanActionInfo(view_->configuration()->createCopy()));
+	if(view_){
+
+		const AMScanConfiguration *config = view_->configuration();
+
+		if (config)
+			return new AMScanAction(new AMScanActionInfo(view_->configuration()->createCopy()));
+	}
 
 	return 0;
 }
@@ -133,15 +138,13 @@ AMAction3* AMScanConfigurationViewHolder3::createMultipleScans()
 	if (view_){
 
 		const AMScanConfiguration *config = view_->configuration();
+
 		if (config) {
-			int iteration = iterationsBox_->value();
-			if (iteration > 1) {
-				AMLoopAction3 *loopAction = new AMLoopAction3(new AMLoopActionInfo3(iterationsBox_->value(), config->name(), config->description()));
-				loopAction->addSubAction(createScan());
-				return loopAction;
-			} else {
-				return createScan();
-			}
+
+			AMLoopAction3 *loopAction = new AMLoopAction3(new AMLoopActionInfo3(iterationsBox_->value(), config->name(), config->description()));
+			loopAction->addSubAction(createScan());
+
+			return loopAction;
 		}
 	}
 


### PR DESCRIPTION
Simple change to the method `createMultipleScans()`.