### PR TITLE
Pull Request for Issue1603: Name not updating in VESPERS endstation motor group view

### DIFF
--- a/source/beamline/VESPERS/VESPERSEndstation.cpp
+++ b/source/beamline/VESPERS/VESPERSEndstation.cpp
@@ -41,9 +41,9 @@ VESPERSEndstation::VESPERSEndstation(QObject *parent)
 
 	// The controls used for the control window.
 	ccdControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-18:mm:fbk", "SMTR1607-2-B21-18:mm", "SMTR1607-2-B21-18:status", "SMTR1607-2-B21-18:stop", this, 1.0, 2.0);
-	microscopeControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-17:mm:sp", "SMTR1607-2-B21-17:mm", "SMTR1607-2-B21-17:status", "SMTR1607-2-B21-17:stop", this, 1.0, 2.0);
-	fourElControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-27:mm:fbk", "SMTR1607-2-B21-27:mm", "SMTR1607-2-B21-27:status", "SMTR1607-2-B21-27:stop", this, 1.0, 2.0);
-	singleElControl_ = new AMPVwStatusControl("CCD motor", "SMTR1607-2-B21-15:mm:fbk", "SMTR1607-2-B21-15:mm", "SMTR1607-2-B21-15:status", "SMTR1607-2-B21-15:stop", this, 1.0, 2.0);
+	microscopeControl_ = new AMPVwStatusControl("Microscope motor", "SMTR1607-2-B21-17:mm:sp", "SMTR1607-2-B21-17:mm", "SMTR1607-2-B21-17:status", "SMTR1607-2-B21-17:stop", this, 1.0, 2.0);
+	fourElControl_ = new AMPVwStatusControl("4-Element Vortex motor", "SMTR1607-2-B21-27:mm:fbk", "SMTR1607-2-B21-27:mm", "SMTR1607-2-B21-27:status", "SMTR1607-2-B21-27:stop", this, 1.0, 2.0);
+	singleElControl_ = new AMPVwStatusControl("1-Element Vortex motor", "SMTR1607-2-B21-15:mm:fbk", "SMTR1607-2-B21-15:mm", "SMTR1607-2-B21-15:status", "SMTR1607-2-B21-15:stop", this, 1.0, 2.0);
 
 	laserPositionControl_ = new AMReadOnlyPVControl("Laser Position", "PSD1607-2-B20-01:OUT1:fbk", this);
 	laserPositionStatusControl_ = new AMReadOnlyPVControl("Laser Position Status", "PSD1607-2-B20-01:OUT1:fbk:status", this);


### PR DESCRIPTION
Turns out some previous iteration of code with what I presume is copy and paste error got the names of the controls screwed up.  I have now fixed them and the system works as it is supposed to.