### PR TITLE
PullRequest for Issue1705: Generalize the usage AMDSClientAppController

### DIFF
--- a/compositeCommon/AMAcquamanDataServer.pri
+++ b/compositeCommon/AMAcquamanDataServer.pri
@@ -20,6 +20,7 @@ INCLUDEPATH *= $$PATH_TO_AMDS $$PATH_TO_AMDS/source
 VPATH *= $$PATH_TO_AMDS
 
 HEADERS *= \
+	$$PATH_TO_AMDS/source/appController/AMDSAppController.h \
 	$$PATH_TO_AMDS/source/appController/AMDSClientAppController.h \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientRequest.h \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientRequestSupport.h \
@@ -52,6 +53,7 @@ HEADERS *= \
 	$$PATH_TO_AMDS/source/util/AMDSMetaObjectSupport.h
 
 SOURCES *= \
+	$$PATH_TO_AMDS/source/appController/AMDSAppController.cpp \
 	$$PATH_TO_AMDS/source/appController/AMDSClientAppController.cpp \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientRequest.cpp \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientRequestSupport.cpp \

--- a/compositeCommon/AMAcquamanDataServer.pri
+++ b/compositeCommon/AMAcquamanDataServer.pri
@@ -36,6 +36,7 @@ HEADERS *= \
 	$$PATH_TO_AMDS/source/Connection/AMDSServer.h \
 	$$PATH_TO_AMDS/source/Connection/AMDSClientTCPSocket.h \
 	$$PATH_TO_AMDS/source/DataElement/AMDSDataTypeDefinitions.h \
+	$$PATH_TO_AMDS/source/DataElement/AMDSConfigurationDef.h \
 	$$PATH_TO_AMDS/source/DataElement/AMDSAxisInfo.h \
 	$$PATH_TO_AMDS/source/DataElement/AMDSnDIndex.h \
 	$$PATH_TO_AMDS/source/DataElement/AMDSEventData.h \

--- a/source/beamline/AMBeamline.cpp
+++ b/source/beamline/AMBeamline.cpp
@@ -49,7 +49,7 @@ void AMBeamline::releaseBl() {
 	if(instance_) {
 		instance_->deleteLater();
 		instance_ = 0;
-		}
+	}
 
 }
 

--- a/source/beamline/CLS/CLSAmptekSDD123DetectorNew.cpp
+++ b/source/beamline/CLS/CLSAmptekSDD123DetectorNew.cpp
@@ -25,12 +25,10 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ui/CLS/CLSAmptekSDD123DetailedDetectorView.h"
 
-
-
+#include "source/appController/AMDSClientAppController.h"
 #include "source/ClientRequest/AMDSClientRequestSupport.h"
 #include "source/DataElement/AMDSEventDataSupport.h"
 #include "source/DataHolder/AMDSDataHolderSupport.h"
-#include "source/appController/AMDSClientAppController.h"
 #include "source/Connection/AMDSServer.h"
 #include "source/ClientRequest/AMDSClientDataRequest.h"
 #include "source/ClientRequest/AMDSClientRelativeCountPlusCountDataRequest.h"
@@ -133,20 +131,21 @@ CLSAmptekSDD123DetectorNew::CLSAmptekSDD123DetectorNew(const QString &name, cons
 
 	lastContinuousDataRequest_ = 0;
 	lastReadMode_ = AMDetectorDefinitions::SingleRead;
-
-	/// ==== initialize the app controller ==============
-	clientAppController_ = new AMDSClientAppController();
-	connect(clientAppController_, SIGNAL(networkSessionOpening()), this, SLOT(onNetworkSessionOpening()));
-	connect(clientAppController_, SIGNAL(networkSessionOpened()), this, SLOT(onNetworkSessionOpened()));
-	connect(clientAppController_, SIGNAL(newServerConnected(QString)), this, SLOT(onNewServerConnected(QString)));
-	connect(clientAppController_, SIGNAL(serverError(int,bool,QString,QString)), this, SLOT(onServerError(int,bool,QString,QString)));
-	connect(clientAppController_, SIGNAL(requestDataReady(AMDSClientRequest*)), this, SLOT(onRequestDataReady(AMDSClientRequest*)));
-
-	clientAppController_->openNetworkSession();
 }
 
 CLSAmptekSDD123DetectorNew::~CLSAmptekSDD123DetectorNew()
 {
+}
+
+void CLSAmptekSDD123DetectorNew::configAMDSServer(const QString &amptekAMDSServerIdentifier)
+{
+	amptekAMDSServerIdentifier_ = amptekAMDSServerIdentifier;
+
+	AMDSServer *amptekAMDSServer = AMDSClientAppController::clientAppController()->getServerByServerIdentifier(amptekAMDSServerIdentifier);
+	if (amptekAMDSServer) {
+		connect(amptekAMDSServer, SIGNAL(requestDataReady(AMDSClientRequest*)), this, SLOT(onRequestDataReady(AMDSClientRequest*)));
+		connect(amptekAMDSServer, SIGNAL(serverError(int,bool,QString,QString)), this, SLOT(onServerError(int,bool,QString,QString)));
+	}
 }
 
 QString CLSAmptekSDD123DetectorNew::synchronizedDwellKey() const{
@@ -438,23 +437,6 @@ void CLSAmptekSDD123DetectorNew::onHighIndexValueChanged(int index){
 
 
 /// ============= SLOTs to handle AMDSClientAppController signals =========
-void CLSAmptekSDD123DetectorNew::onNetworkSessionOpening()
-{
-}
-
-void CLSAmptekSDD123DetectorNew::onNetworkSessionOpened()
-{
-	clientAppController_->connectToServer("10.52.48.40", 28044);
-}
-
-void CLSAmptekSDD123DetectorNew::onNewServerConnected(const QString &serverIdentifier)
-{
-	qDebug() << "Amptek Successfully Connected to Server";
-	QStringList bufferNames = clientAppController_->getBufferNamesByServer(serverIdentifier);
-	qDebug() << "Buffer Names:";
-	qDebug() << bufferNames;
-}
-
 void CLSAmptekSDD123DetectorNew::onRequestDataReady(AMDSClientRequest* clientRequest)
 {
 	AMDSClientRelativeCountPlusCountDataRequest *relativeCountPlusCountDataRequst = qobject_cast<AMDSClientRelativeCountPlusCountDataRequest*>(clientRequest);
@@ -467,6 +449,8 @@ void CLSAmptekSDD123DetectorNew::onRequestDataReady(AMDSClientRequest* clientReq
 
 void CLSAmptekSDD123DetectorNew::onServerError(int errorCode, bool removeServer, const QString &serverIdentifier, const QString &errorMessage)
 {
+	Q_UNUSED(errorCode) 	Q_UNUSED(removeServer)	Q_UNUSED(serverIdentifier)	Q_UNUSED(errorMessage)
+
 //	if (serverIdentifier.length() > 0) {
 //		if (removeServer)
 //			activeServerComboBox_->removeItem(activeServerComboBox_->findText(serverIdentifier));
@@ -484,11 +468,15 @@ bool CLSAmptekSDD123DetectorNew::acquireImplementation(AMDetectorDefinitions::Re
 {
 	if(readMode == AMDetectorDefinitions::ContinuousRead){
 		lastReadMode_ = AMDetectorDefinitions::ContinuousRead;
-		AMDSServer * server = clientAppController_->getServerByServerIdentifier("10.52.48.40:28044");
-		if (!server)
+
+		AMDSClientAppController *clientAppController = AMDSClientAppController::clientAppController();
+		AMDSServer *amptekAMDSServer = clientAppController->getServerByServerIdentifier(amptekAMDSServerIdentifier_);
+		if (amptekAMDSServer) {
+			QString bufferName = "Amptek SDD 240";
+			return clientAppController->requestClientData(amptekAMDSServer->hostName(), amptekAMDSServer->portNumber(), bufferName, 400, 400, true, false);
+		} else {
 			return false;
-		QString bufferName = "Amptek SDD 240";
-		clientAppController_->requestClientData(server->hostName(), server->portNumber(), bufferName, 400, 400, true, false);
+		}
 	}
 	else{
 		lastReadMode_ = AMDetectorDefinitions::SingleRead;

--- a/source/beamline/CLS/CLSAmptekSDD123DetectorNew.h
+++ b/source/beamline/CLS/CLSAmptekSDD123DetectorNew.h
@@ -43,6 +43,7 @@ public:
  	virtual ~CLSAmptekSDD123DetectorNew();
 	CLSAmptekSDD123DetectorNew(const QString &name, const QString &description, const QString &baseName, QObject *parent = 0);
 
+	void configAMDSServer(const QString &amptekAMDSServerIdentifier);
 	/// The Ampteks don't explicitly require powering on
 	virtual bool requiresPower() const { return false; }
 
@@ -206,12 +207,12 @@ protected slots:
 
 	/// ============= SLOTs to handle AMDSClientAppController signals =========
 	/// slot to handle the signal of networkSessionOpening
-	void onNetworkSessionOpening();
+//	void onNetworkSessionOpening();
 	/// slot to handle the signal of networkSessionOpened
-	void onNetworkSessionOpened();
+//	void onNetworkSessionOpened();
 
 	/// slot to handle the signal of newServerConnected (add the serverIdentifier to the combox and update the ui displays -- buffernames and active connections)
-	void onNewServerConnected(const QString &serverIdentifier);
+//	void onNewServerConnected(const QString &serverIdentifier);
 	/// slot to handle the signal of request data ready
 	void onRequestDataReady(AMDSClientRequest* clientRequest);
 	/// slot to handle the signal of socketEror
@@ -299,10 +300,9 @@ protected:
 	double eVPerBin_;
 
 
+	/// the AMDS Amptek Server identifier
+	QString amptekAMDSServerIdentifier_;
 
-
-	/// The handler of the clientAppController
-	AMDSClientAppController *clientAppController_;
 	/// The data returned from the last acquire(AMDetectorDefinitions::ContinuousMode) call
 	AMDSClientRelativeCountPlusCountDataRequest *lastContinuousDataRequest_;
 	/// The read mode type of the last acquire call

--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -21,15 +21,21 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "SGMBeamline.h"
 
-#include "beamline/SGM/SGMMAXvMotor.h"
 #include "util/AMErrorMonitor.h"
-#include "beamline/CLS/CLSSR570.h"
 #include "beamline/AMMotorGroup.h"
+#include "beamline/AMBasicControlDetectorEmulator.h"
+#include "beamline/CLS/CLSSR570.h"
 #include "beamline/CLS/CLSAdvancedScalerChannelDetector.h"
 #include "beamline/CLS/CLSAmptekSDD123DetectorNew.h"
+#include "beamline/SGM/SGMMAXvMotor.h"
 #include "beamline/SGM/SGMHexapod.h"
-#include "beamline/AMBasicControlDetectorEmulator.h"
 #include "beamline/SGM/energy/SGMEnergyControlSet.h"
+
+/// acquaman data server
+#include "source/appController/AMDSClientAppController.h"
+#include "source/Connection/AMDSServer.h"
+#include "source/DataElement/AMDSConfigurationDef.h"
+
 SGMBeamline* SGMBeamline::sgm() {
 
 	if(instance_ == 0){
@@ -43,6 +49,7 @@ SGMBeamline* SGMBeamline::sgm() {
 
 SGMBeamline::~SGMBeamline()
 {
+	AMDSClientAppController::release();
 }
 
 bool SGMBeamline::isConnected() const
@@ -124,6 +131,25 @@ void SGMBeamline::onConnectionStateChanged(bool)
 	if(actualConnectedState != cachedConnectedState_) {
 		cachedConnectedState_ = actualConnectedState;
 		emit connected(actualConnectedState);
+	}
+}
+
+void SGMBeamline::connectAMDSServers()
+{
+	AMDSClientAppController *clientAppController = AMDSClientAppController::clientAppController();
+	foreach (AMDSServerConfiguration serverConfiguration, AMDSServerDefs_.values())
+		clientAppController->connectToServer(serverConfiguration);
+}
+
+void SGMBeamline::setupAMDSClientAppController()
+{
+	AMDSServerDefs_.insert(QString("AmptekServer"), AMDSServerConfiguration(QString("AmptekServer"), QString("10.52.48.40"), 28044));
+
+	// NOTE: it will be better to move this to CLSBeamline, when
+	AMDSClientAppController *AMDSClientController = AMDSClientAppController::clientAppController();
+	connect(AMDSClientController, SIGNAL(networkSessionOpened()), this, SLOT(connectAMDSServers()));
+	if (AMDSClientController->isSessionOpen()) {
+		connectAMDSServers();
 	}
 }
 
@@ -270,6 +296,7 @@ void SGMBeamline::setupDetectors()
 //	amptekSDD1_ = new CLSAmptekSDD123DetectorNew("AmptekSDD1", "Amptek SDD 1", "amptek:sdd1", this);
 	amptekSDD1_ = new CLSAmptekSDD123DetectorNew("AmptekSDD1", "Amptek SDD 1", "amptek:sdd2", this);
 	amptekSDD1_->setEVPerBin(2.25);
+	amptekSDD1_->configAMDSServer(AMDSServerDefs_.value("AmptekServer").serverIdentifier());
 }
 
 void SGMBeamline::setupExposedControls()
@@ -310,6 +337,7 @@ void SGMBeamline::setupExposedDetectors()
 SGMBeamline::SGMBeamline()
 	: CLSBeamline("SGMBeamline")
 {
+	setupAMDSClientAppController();
 	setupBeamlineComponents();
 	setupMotorGroups();
 	setupDetectors();

--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -49,7 +49,7 @@ SGMBeamline* SGMBeamline::sgm() {
 
 SGMBeamline::~SGMBeamline()
 {
-	AMDSClientAppController::release();
+	AMDSClientAppController::releaseAppController();
 }
 
 bool SGMBeamline::isConnected() const

--- a/source/beamline/SGM/SGMBeamline.h
+++ b/source/beamline/SGM/SGMBeamline.h
@@ -30,6 +30,9 @@ class CLSAdvancedScalerChannelDetector;
 class CLSAmptekSDD123DetectorNew;
 class SGMEnergyControlSet;
 class SGMHexapod;
+
+class AMDSServerConfiguration;
+
 /*!
   * A singleton class which represents the SGM beamline. The beamline class can
   * be accessed through the SGMBeamline::sgm() function.
@@ -124,7 +127,17 @@ protected slots:
 	  * beamline components has been altered.
 	  */
 	void onConnectionStateChanged(bool);
+
+	/// helper function to initialize the AcquamanDataServer
+	/// ideally, this should be called in super class when Acquaman Data server is a generalized feature for all BLs using Acquaman
+	void connectAMDSServers();
+
 protected:
+
+	/*!
+	  * Initializes the Acquaman Data Server client app scontroller.
+	  */
+	void setupAMDSClientAppController();
 
 	/*!
 	  * Initializes the beamline controls (energy, exit slit etc.).
@@ -156,6 +169,9 @@ protected:
 	  * Protected constructor for the SGMBeamline to ensure singleton structure.
 	  */
 	SGMBeamline();
+
+protected:
+	QMap<QString, AMDSServerConfiguration> AMDSServerDefs_;
 
 	// New Energy Controls
 	SGMEnergyControlSet* energyControlSet_;

--- a/source/util/AMBiHash.h
+++ b/source/util/AMBiHash.h
@@ -61,6 +61,12 @@ public:
 		return fwd_.count();
 	}
 
+	/// clear the data
+	void clear() {
+		fwd_.clear();
+		rev_.clear();
+	}
+
 	/// add or overwrite a keyValue-keyValue pair
 	void set(const T1& key1, const T2& key2) {
 		fwd_[key1] = key2;


### PR DESCRIPTION
Make AMDSClientAppController singleton so that the individual detectors only need to know about the specific server it wants to talk with.

https://github.com/acquaman/acquaman/issues/1705