### PR TITLE
Pull Request for Issue1626: Binning analysis block editors may be unstable

### DIFF
--- a/source/analysis/AM2DSummingAB.cpp
+++ b/source/analysis/AM2DSummingAB.cpp
@@ -193,7 +193,7 @@ void AM2DSummingAB::reviewState()
 
 	int s = inputSource_->size(sumAxis_);
 
-	if(sumRangeMin_ >= s || sumRangeMax_ >= s) {
+	if(sumRangeMin_ >= s || sumRangeMax_ >= s || sumRangeMin_ > sumRangeMax_) {
 		setState(AMDataSource::InvalidFlag);
 	}
 	else

--- a/source/analysis/AM3DBinningAB.cpp
+++ b/source/analysis/AM3DBinningAB.cpp
@@ -224,7 +224,7 @@ void AM3DBinningAB::reviewState()
 
     int s = inputSource_->size(sumAxis_);
 
-    if(sumRangeMin_ >= s || sumRangeMax_ >= s) {
+    if(sumRangeMin_ >= s || sumRangeMax_ >= s || sumRangeMin_ > sumRangeMax_) {
 	setState(AMDataSource::InvalidFlag);
     }
     else
@@ -472,8 +472,8 @@ void AM3DBinningAB::setSumRangeMin(int sumRangeMin)
     cacheUpdateRequired_ = true;
     dirtyIndices_.clear();
     reviewState();
-    emitValuesChanged();
     setModified(true);
+    emitValuesChanged();
 }
 
 void AM3DBinningAB::setSumRangeMax(int sumRangeMax)
@@ -485,8 +485,8 @@ void AM3DBinningAB::setSumRangeMax(int sumRangeMax)
     cacheUpdateRequired_ = true;
     dirtyIndices_.clear();
     reviewState();
-    emitValuesChanged();
     setModified(true);
+    emitValuesChanged();
 }
 
 // Connected to be called when the values of the input data source change

--- a/source/analysis/AM4DBinningAB.cpp
+++ b/source/analysis/AM4DBinningAB.cpp
@@ -244,7 +244,7 @@ void AM4DBinningAB::reviewState()
 
     int s = inputSource_->size(sumAxis_);
 
-    if(sumRangeMin_ >= s || sumRangeMax_ >= s) {
+    if(sumRangeMin_ >= s || sumRangeMax_ >= s || sumRangeMin_ > sumRangeMax_) {
 	setState(AMDataSource::InvalidFlag);
     }
     else
@@ -513,8 +513,8 @@ void AM4DBinningAB::setSumRangeMin(int sumRangeMin)
 	cacheUpdateRequired_ = true;
 	dirtyIndices_.clear();
 	reviewState();
-	emitValuesChanged();
 	setModified(true);
+	emitValuesChanged();
 }
 
 void AM4DBinningAB::setSumRangeMax(int sumRangeMax)
@@ -526,8 +526,8 @@ void AM4DBinningAB::setSumRangeMax(int sumRangeMax)
 	cacheUpdateRequired_ = true;
 	dirtyIndices_.clear();
 	reviewState();
-	emitValuesChanged();
 	setModified(true);
+	emitValuesChanged();
 }
 
 // Connected to be called when the values of the input data source change

--- a/source/analysis/AMRegionOfInterestAB.cpp
+++ b/source/analysis/AMRegionOfInterestAB.cpp
@@ -262,10 +262,9 @@ void AMRegionOfInterestAB::setInputDataSourcesImplementation(const QList<AMDataS
 
 void AMRegionOfInterestAB::reviewState()
 {
-	if (spectrum_ == 0 || !spectrum_->isValid()){
+	if (spectrum_ == 0 || !spectrum_->isValid() || !binningRange_.isValid()){
 
 		setState(AMDataSource::InvalidFlag);
-		return;
 	}
 	else
 		setState(0);


### PR DESCRIPTION
I found the issue with crashing when the low binning value is greater than the higher binning value.  Fixed by invalidating the analysis block.  

I was unable to reproduce the database bug, so I will have to double check that to make sure there isn't something I'm missing.

@helfrij, could you do the pull request for me on this one?  I am going to assume it's done until I get confirmation on the database bug.