### PR TITLE
Pull request for Issue 1719: Moved AMDSClientApp from SGMBeamline to SGMAppController

### DIFF
--- a/source/application/SGM/SGMAppController.h
+++ b/source/application/SGM/SGMAppController.h
@@ -34,6 +34,10 @@ class AMScanConfigurationViewHolder3;
 class CLSAmptekDetailedDetectorView;
 class SGMLaddersView;
 
+/// acquaman data server
+#include "source/appController/AMDSClientAppController.h"
+#include "source/Connection/AMDSServer.h"
+#include "source/DataElement/AMDSConfigurationDef.h"
 /*!
   * A class which acts as the central application for SGM Acquaman. Holds the
   * main window which is displayed to users, as well as performs the application
@@ -87,7 +91,18 @@ protected slots:
 	  * Resizes the main window to its minimum size hint
 	  */
 	void resizeToMinimum();
+
+	/// helper function to initialize the AcquamanDataServer
+	/// ideally, this should be called in super class when Acquaman Data server is a generalized feature for all BLs using Acquaman
+	void connectAMDSServers();
+
+	void onAMDSServerConnected(const QString &hostIdentifier);
 protected:
+
+	/*!
+	  * Initializes the Acquaman Data Server client app scontroller.
+	  */
+	void setupAMDSClientAppController();
 
 	/*!
 	  * Handles cases where a scan action has started in the Workflow3 system.
@@ -127,6 +142,9 @@ protected:
 	  * SGMAppController.
 	  */
 	void makeConnections();
+
+
+	QMap<QString, AMDSServerConfiguration> AMDSServerDefs_;
 
 	/// Commissioning step scan configuration.
 	AMGenericStepScanConfiguration* commissioningStepConfiguration_;

--- a/source/beamline/SGM/SGMBeamline.h
+++ b/source/beamline/SGM/SGMBeamline.h
@@ -36,8 +36,6 @@ class SGMXPSLadder;
 class SGMBypassLadder;
 class SGMXASLadder;
 
-class AMDSServerConfiguration;
-
 /*!
   * A singleton class which represents the SGM beamline. The beamline class can
   * be accessed through the SGMBeamline::sgm() function.
@@ -141,6 +139,12 @@ public:
 	 */
 	virtual SGMXASLadder* xasLadder() const;
 
+	/*!
+	  * Configures the beamline components which require an AMDS.
+	  * \param hostIdentifier ~ The ip address and port of the AMDS which controls
+	  * are to be configured for.
+	  */
+	void configAMDSServer(const QString& hostIdentifier);
 public slots:
 
 signals:
@@ -152,18 +156,7 @@ protected slots:
 	  */
 	void onConnectionStateChanged(bool);
 
-	/// helper function to initialize the AcquamanDataServer
-	/// ideally, this should be called in super class when Acquaman Data server is a generalized feature for all BLs using Acquaman
-	void connectAMDSServers();
-
-	void onAMDSServerConnected(const QString &hostIdentifier);
-
 protected:
-
-	/*!
-	  * Initializes the Acquaman Data Server client app scontroller.
-	  */
-	void setupAMDSClientAppController();
 
 	/*!
 	  * Initializes the beamline controls (energy, exit slit etc.).
@@ -197,7 +190,6 @@ protected:
 	SGMBeamline();
 
 protected:
-	QMap<QString, AMDSServerConfiguration> AMDSServerDefs_;
 
 	// New Energy Controls
 	SGMEnergyControlSet* energyControlSet_;


### PR DESCRIPTION
Moved the initialization code of the AMDSClientAppController from SGMBeamline to SGMAppController. This necessitated the creation of a function in SGMBeamline `configAMDSServer(const QString &hostIdentifier)` which performs the AMDS config on all the beamline controls which rely on the data server with the provided hostname. The app controller can then make this call each time a data server is connected.