### PR TITLE
Pull Request for Issue 1718: Added default region to Continuous Scan

### DIFF
--- a/compositeCommon/AMAcquamanDataServer.pri
+++ b/compositeCommon/AMAcquamanDataServer.pri
@@ -33,6 +33,7 @@ HEADERS *= \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.h \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.h \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientContinuousDataRequest.h \
+	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientConfigurationRequest.h \
 	$$PATH_TO_AMDS/source/Connection/AMDSPacketStats.h \
 	$$PATH_TO_AMDS/source/Connection/AMDSServer.h \
 	$$PATH_TO_AMDS/source/Connection/AMDSClientTCPSocket.h \
@@ -45,6 +46,7 @@ HEADERS *= \
 	$$PATH_TO_AMDS/source/DataElement/AMDSFlatArray.h \
 	$$PATH_TO_AMDS/source/DataElement/AMDSBufferGroupInfo.h \
 	$$PATH_TO_AMDS/source/DataElement/AMDSDwellStatusData.h \
+	$$PATH_TO_AMDS/source/DataElement/AMDSCommandManager.h \
 	$$PATH_TO_AMDS/source/DataHolder/AMDSDataHolder.h \
 	$$PATH_TO_AMDS/source/DataHolder/AMDSDataHolderSupport.h \
 	$$PATH_TO_AMDS/source/DataHolder/AMDSGenericFlatArrayDataHolder.h \
@@ -66,6 +68,7 @@ SOURCES *= \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientStartTimeToEndTimeDataRequest.cpp \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientMiddleTimePlusCountBeforeAndAfterDataRequest.cpp \
 	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientContinuousDataRequest.cpp \
+	$$PATH_TO_AMDS/source/ClientRequest/AMDSClientConfigurationRequest.cpp \
 	$$PATH_TO_AMDS/source/Connection/AMDSPacketStats.cpp \
 	$$PATH_TO_AMDS/source/Connection/AMDSServer.cpp \
 	$$PATH_TO_AMDS/source/Connection/AMDSClientTCPSocket.cpp \
@@ -76,6 +79,7 @@ SOURCES *= \
 	$$PATH_TO_AMDS/source/DataElement/AMDSFlatArray.cpp \
 	$$PATH_TO_AMDS/source/DataElement/AMDSBufferGroupInfo.cpp \
 	$$PATH_TO_AMDS/source/DataElement/AMDSDwellStatusData.cpp \
+	$$PATH_TO_AMDS/source/DataElement/AMDSCommandManager.cpp \
 	$$PATH_TO_AMDS/source/DataHolder/AMDSDataHolder.cpp \
 	$$PATH_TO_AMDS/source/DataHolder/AMDSDataHolderSupport.cpp \
 	$$PATH_TO_AMDS/source/DataHolder/AMDSGenericFlatArrayDataHolder.cpp \

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -158,7 +158,8 @@ void SGMAppController::onAMDSServerConnected(const QString &hostIdentifier)
 
 void SGMAppController::setupAMDSClientAppController()
 {
-	AMDSServerDefs_.insert(QString("AmptekServer"), AMDSServerConfiguration(QString("AmptekServer"), QString("10.52.48.40"), 28044));
+//	AMDSServerDefs_.insert(QString("AmptekServer"), AMDSServerConfiguration(QString("AmptekServer"), QString("10.52.48.40"), 28044));
+	AMDSServerDefs_.insert(QString("ScalerServer"), AMDSServerConfiguration(QString("ScalerServer"), QString("10.52.48.1"), 28044));
 
 	// NOTE: it will be better to move this to CLSBeamline, when
 	AMDSClientAppController *AMDSClientController = AMDSClientAppController::clientAppController();

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -223,7 +223,7 @@ void SGMAppController::setupUserInterface()
 	commissioningStepConfigurationView_ = new AMGenericStepScanConfigurationView(commissioningStepConfiguration_, SGMBeamline::sgm()->exposedControls(), SGMBeamline::sgm()->exposedDetectors());
 	commissioningStepConfigurationViewHolder_ = new AMScanConfigurationViewHolder3("Commissioning Tool", false, true, commissioningStepConfigurationView_);
 
-	commissioningContinuousConfiguration_ = new AMGenericContinuousScanConfiguration;
+	commissioningContinuousConfiguration_ = new AMGenericContinuousScanConfiguration;	
 	commissioningContinuousConfiguration_->setAutoExportEnabled(false);
 	commissioningContinuousConfiguration_->addDetector(SGMBeamline::sgm()->exposedDetectorByName("TEY")->toInfo());
 	commissioningContinuousConfiguration_->addDetector(SGMBeamline::sgm()->exposedDetectorByName("TFY")->toInfo());
@@ -241,6 +241,11 @@ void SGMAppController::setupUserInterface()
 	commissioningContinuousConfiguration_->addDetector(SGMBeamline::sgm()->exposedDetectorByName("AmptekSDD2")->toInfo());
 	commissioningContinuousConfiguration_->addDetector(SGMBeamline::sgm()->exposedDetectorByName("AmptekSDD3")->toInfo());
 	commissioningContinuousConfiguration_->addDetector(SGMBeamline::sgm()->exposedDetectorByName("AmptekSDD4")->toInfo());
+	commissioningContinuousConfiguration_->setControl(0, SGMBeamline::sgm()->energyControlSet()->energy()->toInfo());
+	commissioningContinuousConfiguration_->scanAxisAt(0)->regionAt(0)->setRegionStart(270);
+	commissioningContinuousConfiguration_->scanAxisAt(0)->regionAt(0)->setRegionEnd(320);
+	commissioningContinuousConfiguration_->scanAxisAt(0)->regionAt(0)->setRegionTime(10);
+	commissioningContinuousConfiguration_->scanAxisAt(0)->regionAt(0)->setRegionStep(0.1);
 	commissioningContinuousConfigurationView_ = new AMGenericContinuousScanConfigurationView(commissioningContinuousConfiguration_, SGMBeamline::sgm()->exposedControls(), SGMBeamline::sgm()->exposedDetectors());
 	commissioningContinuousConfigurationViewHolder_ = new AMScanConfigurationViewHolder3("Continuous Tool", false, true, commissioningContinuousConfigurationView_);
 

--- a/source/beamline/AM3DCoordinatedSystemControl.h
+++ b/source/beamline/AM3DCoordinatedSystemControl.h
@@ -107,7 +107,7 @@ public:
 	  * \param globalVector ~ A vector in the global coordinate system which will
 	  * be tranformed into the arbitrary transformed system.
 	  */
-	virtual QVector3D globalAxisToPrime(const QVector3D& globalVector) const = 0;
+	virtual QVector3D globalAxisToPrime(const QVector3D& globalVector) const { return globalVector; }
 
 	/*!
 	  * Virtual function which performs the calculation required to transform a
@@ -115,7 +115,7 @@ public:
 	  * \param primeVector ~ A vector in the arbitrary coordinate system which
 	  * will be transformed into the global system.
 	  */
-	virtual QVector3D primeAxisToGlobal(const QVector3D& primeVector) const = 0;
+	virtual QVector3D primeAxisToGlobal(const QVector3D& primeVector) const { return primeVector; }
 signals:
 
 public slots:

--- a/source/beamline/AMControl.h
+++ b/source/beamline/AMControl.h
@@ -31,7 +31,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <float.h>
 
 #include "dataman/info/AMControlInfo.h"
-#include "source/actions3/AMAction3.h"
+#include "actions3/AMAction3.h"
 /**
  * \defgroup control Beamline Control with AMControl and AMProcessVariable
  @{

--- a/source/beamline/CLS/CLSAmptekSDD123DetectorNew.cpp
+++ b/source/beamline/CLS/CLSAmptekSDD123DetectorNew.cpp
@@ -456,7 +456,7 @@ void CLSAmptekSDD123DetectorNew::onRequestDataReady(AMDSClientRequest* clientReq
 	if(introspectionRequest){
 		qDebug() << "Got an introspection request response";
 
-		qDebug() << "All buffer names: " << introspectionRequest->getAllBufferNames();
+		qDebug() << "Amptek: All buffer names: " << introspectionRequest->getAllBufferNames();
 	}
 
 	AMDSClientRelativeCountPlusCountDataRequest *relativeCountPlusCountDataRequst = qobject_cast<AMDSClientRelativeCountPlusCountDataRequest*>(clientRequest);

--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -132,8 +132,10 @@ void CLSSIS3820Scaler::configAMDSServer(const QString &amdsServerIdentifier)
 {
 	amdsServerIdentifier_ = amdsServerIdentifier;
 
+	qDebug() << "Looking for scaler server by identifier " << amdsServerIdentifier;
 	AMDSServer *scalerAMDSServer = AMDSClientAppController::clientAppController()->getServerByServerIdentifier(amdsServerIdentifier_);
 	if (scalerAMDSServer) {
+		qDebug() << "Returned a valid server, connect to it " << scalerAMDSServer->hostName();
 		connect(scalerAMDSServer, SIGNAL(requestDataReady(AMDSClientRequest*)), this, SLOT(onRequestDataReady(AMDSClientRequest*)));
 		connect(AMDSClientAppController::clientAppController(), SIGNAL(serverError(int,bool,QString,QString)), this, SLOT(onServerError(int,bool,QString,QString)));
 	}
@@ -568,11 +570,12 @@ void CLSSIS3820Scaler::onDwellTimeSourceSetDwellTime(double dwellSeconds){
 /// ============= SLOTs to handle AMDSClientAppController signals =========
 void CLSSIS3820Scaler::onRequestDataReady(AMDSClientRequest* clientRequest)
 {
+	qDebug() << "Scaler sees a clientRequest";
 	AMDSClientIntrospectionRequest *introspectionRequest = qobject_cast<AMDSClientIntrospectionRequest*>(clientRequest);
 	if(introspectionRequest){
 		qDebug() << "Got an introspection request response";
 
-		qDebug() << "All buffer names: " << introspectionRequest->getAllBufferNames();
+		qDebug() << "Scaler: All buffer names: " << introspectionRequest->getAllBufferNames();
 	}
 
 	AMDSClientRelativeCountPlusCountDataRequest *relativeCountPlusCountDataRequst = qobject_cast<AMDSClientRelativeCountPlusCountDataRequest*>(clientRequest);

--- a/source/beamline/SGM/SGMBeamline.cpp
+++ b/source/beamline/SGM/SGMBeamline.cpp
@@ -165,7 +165,8 @@ void SGMBeamline::configAMDSServer(const QString &hostIdentifier)
 		amptekSDD4_->configAMDSServer(hostIdentifier);
 	}
 
-	if(hostIdentifier == "10.52.48.40:28044" && scaler_) {
+	if(hostIdentifier == "10.52.48.4:28044" && scaler_) {
+		qDebug() << "\n\nHost identified for scaler\n\n";
 		scaler_->configAMDSServer(hostIdentifier);
 	}
 }

--- a/source/ui/acquaman/AMGenericContinuousScanConfigurationView.cpp
+++ b/source/ui/acquaman/AMGenericContinuousScanConfigurationView.cpp
@@ -62,6 +62,10 @@ AMGenericContinuousScanConfigurationView::AMGenericContinuousScanConfigurationVi
 	axisStep1_ = createPositionDoubleSpinBox("Step: ", "", configuration_->scanAxes().size() > 0 ? double(configuration_->scanAxisAt(0)->regionAt(0)->regionStep()) : -1.0, 3);
 	axisEnd1_ = createPositionDoubleSpinBox("End: ", "", configuration_->scanAxes().size() > 0 ? double(configuration_->scanAxisAt(0)->regionAt(0)->regionEnd()) : -1.0, 3);
 
+	if(configuration_->scanAxes().count() > 0) {
+		// In cases where the scan axis has already been added we need to do set ourselves up
+		onScanAxisAdded(configuration_->scanAxes().at(0));
+	}
 	connect(configuration_, SIGNAL(scanAxisAdded(AMScanAxis*)), this, SLOT(onScanAxisAdded(AMScanAxis*)));
 
 	QHBoxLayout *axis1Layout = new QHBoxLayout;
@@ -327,6 +331,7 @@ void AMGenericContinuousScanConfigurationView::setDwellTime(const AMNumber &valu
 
 void AMGenericContinuousScanConfigurationView::onScanAxisAdded(AMScanAxis *axis)
 {
+	qDebug() << "\t\tScan Axes Size = " << configuration_->scanAxes().size();
 	if (configuration_->scanAxes().size() == 1){
 
 		connect(axisStart1_, SIGNAL(editingFinished()), this, SLOT(onStart1Changed()));


### PR DESCRIPTION
Added a default region to the continuous scan configuration in SGMAppController from 270 to 320 over 10 seconds, and made the default control for the scan 'energy'. Also fixed a bug in the view which meant the signals for the widgets weren't being wired up in cases where the config already had an axis when passed in.

**NOTE:** This branch also contains a number of changes related to include paths performed by David last (Wed) night.