### PR TITLE
Pull Request for Issue 1743: Fix Energy Scanning

### DIFF
--- a/db/BL1611-ID-1-EnergyAddon.db
+++ b/db/BL1611-ID-1-EnergyAddon.db
@@ -38,16 +38,7 @@ record( ao, "AM1611-4-I10:energy:stop")
 
 # ENERGY TRAJECTORY
 #####################################
-record( ao, "AM1611-4-I10:energy:trajectory:startpoint:eV" )
-{
-	field( VAL, "0" )
-	field( DRVH, "2000.0001" )
-	field( DRVL, "200.0000" )
-	field( EGU, "eV" )
-	field( MDEL, "-1" )
-}
-
-record( ao, "AM1611-4-I10:energy:trajectory:endpoint:eV" )
+record( ao, "AM1611-4-I10:energy:trajectory:target:eV" )
 {
 	field( VAL, "0" )
 	field( DRVH, "2000.0001" )

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -340,13 +340,11 @@ void AMPseudoMotorControl::setSetpoint(double newValue)
 		emit setpointChanged(setpoint_);
 	}
 }
-#include <QDebug>
+
 void AMPseudoMotorControl::setMoveInProgress(bool isMoving)
 {
 	if (moveInProgress_ != isMoving) {
-		moveInProgress_ = isMoving;
-		//qDebug() << "movingChanged("<<isMoving<<") in setMoveInProgress";
-		//emit movingChanged(moveInProgress_);
+		moveInProgress_ = isMoving;		
 	}
 }
 
@@ -354,7 +352,6 @@ void AMPseudoMotorControl::setIsMoving(bool isMoving)
 {
 	if (isMoving_ != isMoving) {
 		isMoving_ = isMoving;
-		qDebug() << "movingChanged("<<isMoving<<") in setIsMoving";
 		emit movingChanged(isMoving_);
 	}
 }
@@ -382,14 +379,12 @@ void AMPseudoMotorControl::setCalibrationInProgress(bool isCalibrating)
 		emit calibratingChanged(calibrationInProgress_);
 	}
 }
-#include <QDebug>
+
 void AMPseudoMotorControl::updateStates()
 {
 	updateConnected();
 	updateValue();
-	qDebug() << "Update moving in AMPseudoMotorControl::updateStates() for" << name();
 	updateMoving();
-	qDebug() << "After update moving in AMPseudoMotorControl::updateStates() for" << name();
 }
 
 void AMPseudoMotorControl::onMoveStarted(QObject *action)
@@ -467,9 +462,7 @@ AMAction3* AMPseudoMotorControl::createCalibrateAction(double oldValue, double n
 void AMPseudoMotorControl::moveActionCleanup(QObject *action)
 {
 	setMoveInProgress(false);
-	qDebug() << "\tUpdate moving in AMPseudoMotorControl::moveActionCleanup() for"<<name();
 	updateMoving();
-	qDebug() << "\tDone updating moving in AMPseudoMotorControl::moveActionCleanup() for"<<name();
 	if (action) {
 		startedMapper_->removeMappings(action);
 		cancelledMapper_->removeMappings(action);

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -340,12 +340,13 @@ void AMPseudoMotorControl::setSetpoint(double newValue)
 		emit setpointChanged(setpoint_);
 	}
 }
-
+#include <QDebug>
 void AMPseudoMotorControl::setMoveInProgress(bool isMoving)
 {
 	if (moveInProgress_ != isMoving) {
 		moveInProgress_ = isMoving;
-		emit movingChanged(moveInProgress_);
+		//qDebug() << "movingChanged("<<isMoving<<") in setMoveInProgress";
+		//emit movingChanged(moveInProgress_);
 	}
 }
 
@@ -353,6 +354,7 @@ void AMPseudoMotorControl::setIsMoving(bool isMoving)
 {
 	if (isMoving_ != isMoving) {
 		isMoving_ = isMoving;
+		qDebug() << "movingChanged("<<isMoving<<") in setIsMoving";
 		emit movingChanged(isMoving_);
 	}
 }
@@ -380,12 +382,14 @@ void AMPseudoMotorControl::setCalibrationInProgress(bool isCalibrating)
 		emit calibratingChanged(calibrationInProgress_);
 	}
 }
-
+#include <QDebug>
 void AMPseudoMotorControl::updateStates()
 {
 	updateConnected();
 	updateValue();
+	qDebug() << "Update moving in AMPseudoMotorControl::updateStates() for" << name();
 	updateMoving();
+	qDebug() << "After update moving in AMPseudoMotorControl::updateStates() for" << name();
 }
 
 void AMPseudoMotorControl::onMoveStarted(QObject *action)
@@ -463,8 +467,9 @@ AMAction3* AMPseudoMotorControl::createCalibrateAction(double oldValue, double n
 void AMPseudoMotorControl::moveActionCleanup(QObject *action)
 {
 	setMoveInProgress(false);
+	qDebug() << "\tUpdate moving in AMPseudoMotorControl::moveActionCleanup() for"<<name();
 	updateMoving();
-
+	qDebug() << "\tDone updating moving in AMPseudoMotorControl::moveActionCleanup() for"<<name();
 	if (action) {
 		startedMapper_->removeMappings(action);
 		cancelledMapper_->removeMappings(action);

--- a/source/beamline/SGM/SGMEnergyCoordinator.cpp
+++ b/source/beamline/SGM/SGMEnergyCoordinator.cpp
@@ -577,16 +577,16 @@ void SGMEnergyCoordinator::onEnergyStopPVChanged(double)
 	}
 }
 
-void SGMEnergyCoordinator::onEnergyTrajectoryStartPVChanged(double value)
+void SGMEnergyCoordinator::onEnergyTrajectoryStartPVChanged(double /*value*/)
 {
 	if(newControls_->energyTrajectoryStart()->withinTolerance(1.0)) {
 
-		double startpoint = newControls_->energyTrajectoryStartpoint()->value();
-		double endpoint = newControls_->energyTrajectoryEndpoint()->value();
+		qDebug() << "Forwarding start trajectory move instruction to energy control";
+		double target = newControls_->energyTrajectoryTarget()->value();
 		double time = newControls_->energyTrajectoryTime()->value();
 
-		if(energyControlCoordinator_->move(startpoint, endpoint, time) == AMControl::NoFailure) {
-			qDebug() << "Moving energy from" << startpoint << "to" << endpoint << "in" << time << "s";
+		if(energyControlCoordinator_->move(target, time) == AMControl::NoFailure) {
+			qDebug() << "Moving energy to" << target << "in" << time << "s";
 		}
 	}
 

--- a/source/beamline/SGM/SGMNewEnergyPVSet.cpp
+++ b/source/beamline/SGM/SGMNewEnergyPVSet.cpp
@@ -29,13 +29,8 @@ SGMNewEnergyPVSet::SGMNewEnergyPVSet(QObject *parent) :
 	                                              this,
 	                                              0.5));
 
-	controlSet_->addControl(new AMSinglePVControl("EnergyTrajectoryStartpoint",
-	                                              "AM1611-4-I10:energy:trajectory:startpoint:eV",
-	                                              this,
-	                                              0.1));
-
-	controlSet_->addControl(new AMSinglePVControl("EnergyTrajectoryEndpoint",
-	                                              "AM1611-4-I10:energy:trajectory:endpoint:eV",
+	controlSet_->addControl(new AMSinglePVControl("EnergyTrajectoryTarget",
+						      "AM1611-4-I10:energy:trajectory:target:eV",
 	                                              this,
 	                                              0.1));
 
@@ -192,14 +187,9 @@ AMControl * SGMNewEnergyPVSet::energyStatus() const
 	return controlSet_->controlNamed("EnergyStatus");
 }
 
-AMControl * SGMNewEnergyPVSet::energyTrajectoryStartpoint() const
+AMControl * SGMNewEnergyPVSet::energyTrajectoryTarget() const
 {
-	return controlSet_->controlNamed("EnergyTrajectoryStartpoint");
-}
-
-AMControl * SGMNewEnergyPVSet::energyTrajectoryEndpoint() const
-{
-	return controlSet_->controlNamed("EnergyTrajectoryEndpoint");
+	return controlSet_->controlNamed("EnergyTrajectoryTarget");
 }
 
 AMControl * SGMNewEnergyPVSet::energyTrajectoryTime() const

--- a/source/beamline/SGM/SGMNewEnergyPVSet.h
+++ b/source/beamline/SGM/SGMNewEnergyPVSet.h
@@ -35,11 +35,8 @@ public:
 	/// The energy status PV ~ AM1611-4-I10:energy:status
 	AMControl* energyStatus() const;
 
-	/// The energy trajectory start PV ~ AM1611-4-I10:energy:trajectory:startpoint:eV
-	AMControl* energyTrajectoryStartpoint() const;
-
-	/// The energy trajectory end PV ~ AM1611-4-I10:energy:trajectory:endpoint:eV
-	AMControl* energyTrajectoryEndpoint() const;
+	/// The energy trajectory target PV ~ AM1611-4-I10:energy:trajectory:target:eV
+	AMControl* energyTrajectoryTarget() const;
 
 	/// The energy trajectory time PV ~ AM1611-4-I10:energy:trajectory:time:s"
 	AMControl* energyTrajectoryTime() const;

--- a/source/beamline/SGM/energy/SGMEnergyControlSet.cpp
+++ b/source/beamline/SGM/energy/SGMEnergyControlSet.cpp
@@ -18,14 +18,8 @@ SGMEnergyControlSet::SGMEnergyControlSet(QObject *parent) :
 					   this));
 	controlNamed("Energy Status")->setTolerance(0.5);
 
-	addControl(new AMSinglePVControl("Energy Trajectory Startpoint",
-	                                 baseGroupPV + ":trajectory:startpoint:eV",
-	                                 this,
-	                                 0.5,
-	                                 2));
-
-	addControl(new AMSinglePVControl("Energy Trajectory Endpoint",
-	                                 baseGroupPV + ":trajectory:endpoint:eV",
+	addControl(new AMSinglePVControl("Energy Trajectory Target",
+					 baseGroupPV + ":trajectory:target:eV",
 	                                 this,
 	                                 0.5,
 	                                 2));
@@ -137,15 +131,9 @@ AMControl * SGMEnergyControlSet::energy() const
 	return controlNamed("Energy");
 }
 
-
-AMControl * SGMEnergyControlSet::energyTrajectoryStartpoint() const
+AMControl * SGMEnergyControlSet::energyTrajectoryTarget() const
 {
-	return controlNamed("Energy Trajectory Startpoint");
-}
-
-AMControl * SGMEnergyControlSet::energyTrajectoryEndpoint() const
-{
-	return controlNamed("Energy Trajectory Endpoint");
+	return controlNamed("Energy Trajectory Target");
 }
 
 AMControl * SGMEnergyControlSet::energyTrajectoryTime() const
@@ -360,7 +348,4 @@ void SGMEnergyControlSet::onExitSlitTrackingPVValueChanged(double)
 {
 	energyPositionValidator_->setExitSlitPositionTracking(!exitSlitPositionTracking()->withinTolerance(0));
 }
-
-
-
 

--- a/source/beamline/SGM/energy/SGMEnergyControlSet.h
+++ b/source/beamline/SGM/energy/SGMEnergyControlSet.h
@@ -25,22 +25,17 @@ public:
 	AMControl* energy() const;
 
 	/*!
-	  * The control for the start energy of a continuous energy motion.
+	  * The control for the target energy of a continuous energy motion.
 	  */
-	AMControl* energyTrajectoryStartpoint() const;
+	AMControl* energyTrajectoryTarget() const;
 
 	/*!
-	  * The control for the end energy of a continuous energy motion.
-	  */
-	AMControl* energyTrajectoryEndpoint() const;
-
-	/*!
-	  * The control for the time a continuous motion should take.
+	  * The control for the time of a continuous motion should take.
 	  */
 	AMControl* energyTrajectoryTime() const;
 
 	/*!
-	  * The control which commences a continous motion.
+	  * The control for commencing a continuous motion.
 	  */
 	AMControl* energyTrajectoryStart() const;
 

--- a/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.cpp
+++ b/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.cpp
@@ -163,33 +163,29 @@ AMControl *SGMEnergyCoordinatorControl::exitSlitPositionControl() const
 	return exitSlitPositionControl_;
 }
 
-AMControl::FailureExplanation SGMEnergyCoordinatorControl::move(double startSetpoint, double finalSetpoint, double time)
+AMControl::FailureExplanation SGMEnergyCoordinatorControl::move(double targetSetpoint, double time)
 {
 	// Check that this control is connected and able to move before proceeding.
 
 	if (!isConnected()) {
-		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_NOT_CONNECTED, QString("Failed to move %1: control is not connected.").arg(name()));
+		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_NOT_CONNECTED, QString("Failed to coordinated move %1: control is not connected.").arg(name()));
 		return AMControl::NotConnectedFailure;
 	}
 
 	if (!canMove()) {
-		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_CANNOT_MOVE, QString("Failed to move %1: control cannot move.").arg(name()));
+		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_CANNOT_MOVE, QString("Failed to coordinated move %1: control cannot move.").arg(name()));
 		return AMControl::OtherFailure;
 	}
 
 	if (isMoving() && !allowsMovesWhileMoving()) {
-		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_ALREADY_MOVING, QString("Failed to move %1: control is already moving.").arg(name()));
+		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_ALREADY_MOVING, QString("Failed to coordinated move %1: control is already moving.").arg(name()));
 		return AMControl::AlreadyMovingFailure;
 	}
 
-	SGMEnergyPosition* energyPositionHelper = energyPositionController_->clone();
-	energyPositionHelper->requestEnergy(startSetpoint);
-
-
-	SGMEnergyTrajectory trajectoryHelper(startSetpoint,
-	                                     finalSetpoint,
+	SGMEnergyTrajectory trajectoryHelper(value(),
+					     targetSetpoint,
 	                                     time,
-	                                     energyPositionHelper->gratingTranslation(),
+					     SGMGratingSupport::encoderCountToEnum(gratingTranslationControl()->value()),
 	                                     gratingAngleControl_->stepAccelerationControl()->value(),
 	                                     gratingAngleControl_->stepsPerEncoderCount(),
 	                                     undulatorControl_->stepAccelerationControl()->value(),
@@ -198,26 +194,23 @@ AMControl::FailureExplanation SGMEnergyCoordinatorControl::move(double startSetp
 
 	if(trajectoryHelper.hasErrors()) {
 		AMErrorMon::alert(this, SGMENERGYCONTROL_INVALID_STATE, QString("Failed to move %1: \n%2").arg(name()).arg(trajectoryHelper.errorValidator()->fullFailureMessage()));
-		energyPositionHelper->deleteLater();
 		return AMControl::OtherFailure;
 	}
 
-	if (!validSetpoint(startSetpoint) || !validSetpoint(finalSetpoint)) {
+	if (!validSetpoint(targetSetpoint)) {
 		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_INVALID_SETPOINT, QString("Failed to move %1: one of the provided setpoints is invalid.").arg(name()));
-		energyPositionHelper->deleteLater();
 		return AMControl::LimitFailure;
 	}
 
 	// Update the setpoint.
-	setSetpoint(finalSetpoint);
+	setSetpoint(targetSetpoint);
 
 	// I guess there's a chance that someone might perform a trajectory move from
 	// out current position, to our current position. In which case we fake the
 	// move.
-	if (withinTolerance(startSetpoint) && withinTolerance(finalSetpoint)) {
+	if (withinTolerance(targetSetpoint) && !attemptMoveWhenWithinTolerance()) {
 		onMoveStarted(0);
 		onMoveSucceeded(0);
-		energyPositionHelper->deleteLater();
 		return AMControl::NoFailure;
 	}
 
@@ -232,7 +225,6 @@ AMControl::FailureExplanation SGMEnergyCoordinatorControl::move(double startSetp
 		AMErrorMon::alert(this, AMPSEUDOMOTORCONTROL_INVALID_MOVE_ACTION, QString("Did not move %1: invalid move action generated.").arg(name()));
 		onMoveStarted(0);
 		onMoveFailed(0);
-		energyPositionHelper->deleteLater();
 		return AMControl::LimitFailure;
 	}
 
@@ -314,15 +306,17 @@ void SGMEnergyCoordinatorControl::updateConnected()
 
 	setConnected(nowConnected);
 }
-
+#include <QDebug>
 void SGMEnergyCoordinatorControl::updateMoving()
 {
+	qDebug() << "Change to child control moving status:\nGrating Angle:" <<gratingAngleControl_->isMoving() <<"\nGrating Translation:"<<gratingTranslationControl()->isMoving()<<"\nUndulator:"<<undulatorPositionControl()->isMoving()<<"\nExit Slit:"<<exitSlitPositionControl_->isMoving();
 	if(isConnected()) {
 		setIsMoving(gratingAngleControl_->isMoving() ||
 		            gratingTranslationStepControl_->isMoving() ||
 		            undulatorControl_->isMoving() ||
 		            exitSlitPositionControl_->isMoving());
 	}
+	qDebug() << "Energy:"<<isMoving();
 }
 
 void SGMEnergyCoordinatorControl::updateValue()
@@ -476,7 +470,7 @@ AMAction3 *SGMEnergyCoordinatorControl::createMoveAction(double setpoint)
 			// Create list action to wait for component motions to complete.
 			AMListAction3* componentWaitAction = new AMListAction3(new AMListActionInfo3("Waiting for energy components",
 			                                                                             "Waiting for energy components to complete motions"),
-			                                                       AMListAction3::Parallel);
+									       AMListAction3::Parallel);
 
 			componentWaitAction->addSubAction(AMActionSupport::buildControlWaitAction(gratingTranslationStepControl_, gratingTranslationNewValue, 60, AMControlWaitActionInfo::MatchWithinTolerance));
 			componentWaitAction->addSubAction(AMActionSupport::buildControlWaitAction(gratingAngleControl_, gratingAngleNewValue, 60, AMControlWaitActionInfo::MatchWithinTolerance));
@@ -511,10 +505,8 @@ AMAction3 *SGMEnergyCoordinatorControl::createMoveAction(SGMEnergyTrajectory* en
 {
 	AMListAction3* continuousMoveAction = 0;
 
-	double startSetpoint = energyTrajectory->startEnergy();
-	double velocity = energyTrajectory->energyVelocity();
-
-	if(velocity != 0) {
+	qDebug() << "Start energy:"<<energyTrajectory->startEnergy()<<"End energy:"<<energyTrajectory->endEnergy()<<"Velocity:"<<energyTrajectory->energyVelocity();
+	if(energyTrajectory->energyVelocity() != 0) {
 		if(energyPositionController_) {
 
 			if(!energyTrajectory->hasErrors()) {
@@ -527,33 +519,6 @@ AMAction3 *SGMEnergyCoordinatorControl::createMoveAction(SGMEnergyTrajectory* en
 				                                         AMListAction3::Sequential);
 
 				continuousMoveAction->addSubAction(gratingAngleControl_->createDefaultsAction());
-				// Moving to start position and set exit slit position:
-				AMListAction3* initializationActions = new AMListAction3(new AMListActionInfo3("Setting up movement",
-				                                                                               "Setting up movement"),
-				                                                         AMListAction3::Parallel);
-
-				bool savedExitSlitTracking = energyPositionController_->isExitSlitPositionTracking();
-
-				energyPositionController_->blockSignals(true);
-				energyPositionController_->setExitSlitPositionTracking(false);
-				energyPositionController_->blockSignals(false);
-				initializationActions->addSubAction(createMoveAction(startSetpoint));
-				energyPositionController_->setExitSlitPositionTracking(savedExitSlitTracking);
-				continuousMoveAction->addSubAction(initializationActions);
-
-				if(energyPositionController_->isExitSlitPositionTracking()) {
-					// Move Exit Slit to mean position
-					double meanExitSlitPosition = (energyTrajectory->startExitSlitPosition() + energyTrajectory->endExitSlitPosition()) / 2;
-					initializationActions->addSubAction(AMActionSupport::buildControlMoveAction(exitSlitPositionControl_,
-					                                                                            meanExitSlitPosition));
-
-					continuousMoveAction->addSubAction(AMActionSupport::buildControlWaitAction(exitSlitPositionControl_,
-					                                                                           meanExitSlitPosition,
-					                                                                           10,
-					                                                                           AMControlWaitActionInfo::MatchWithinTolerance));
-				}
-
-				continuousMoveAction->addSubAction(AMActionSupport::buildControlWaitAction(this, startSetpoint, 60, AMControlWaitActionInfo::MatchWithinTolerance));
 
 				// Set motion properties (velocities, accelerations, coordinated tolerance etc)
 				AMListAction3* setMotionPropertiesAction = new AMListAction3(new AMListActionInfo3("Set motion properties",

--- a/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.cpp
+++ b/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.cpp
@@ -306,17 +306,15 @@ void SGMEnergyCoordinatorControl::updateConnected()
 
 	setConnected(nowConnected);
 }
-#include <QDebug>
+
 void SGMEnergyCoordinatorControl::updateMoving()
 {
-	qDebug() << "Change to child control moving status:\nGrating Angle:" <<gratingAngleControl_->isMoving() <<"\nGrating Translation:"<<gratingTranslationControl()->isMoving()<<"\nUndulator:"<<undulatorPositionControl()->isMoving()<<"\nExit Slit:"<<exitSlitPositionControl_->isMoving();
 	if(isConnected()) {
 		setIsMoving(gratingAngleControl_->isMoving() ||
 		            gratingTranslationStepControl_->isMoving() ||
 		            undulatorControl_->isMoving() ||
 		            exitSlitPositionControl_->isMoving());
 	}
-	qDebug() << "Energy:"<<isMoving();
 }
 
 void SGMEnergyCoordinatorControl::updateValue()
@@ -505,7 +503,6 @@ AMAction3 *SGMEnergyCoordinatorControl::createMoveAction(SGMEnergyTrajectory* en
 {
 	AMListAction3* continuousMoveAction = 0;
 
-	qDebug() << "Start energy:"<<energyTrajectory->startEnergy()<<"End energy:"<<energyTrajectory->endEnergy()<<"Velocity:"<<energyTrajectory->energyVelocity();
 	if(energyTrajectory->energyVelocity() != 0) {
 		if(energyPositionController_) {
 
@@ -616,9 +613,9 @@ AMAction3 *SGMEnergyCoordinatorControl::createMoveAction(SGMEnergyTrajectory* en
 
 
 				trajectoryWait->addSubAction(AMActionSupport::buildControlWaitAction(gratingAngleControl_,
-				                                                                     gratingAngleTarget,
-				                                                                     60,
-				                                                                     AMControlWaitActionInfo::MatchWithinTolerance));
+												     gratingAngleTarget,
+												     60,
+												     AMControlWaitActionInfo::MatchWithinTolerance));
 
 				if(energyPositionController_->isUndulatorTracking()) {
 					trajectoryWait->addSubAction(AMActionSupport::buildControlWaitAction(undulatorControl_->stepControl(),

--- a/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.h
+++ b/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.h
@@ -146,10 +146,10 @@ public slots:
 	/*!
 	  * Moves the controls in a coordinated manner in order to arrive at the
 	  * setpoint energy at the target velocity.
-	  * \param finalSetpoint ~ The final position which the energy will move to.
+	  * \param targetSetpoint ~ The position which the energy will move to.
 	  * \param time ~ The time for the motion to take
 	  */
-	virtual FailureExplanation move(double startSetpoint, double finalSetpoint, double time);
+	virtual FailureExplanation move(double targetSetpoint, double time);
 
 	/*!
 	 * Sets the undulator harmonic to use in calculating the control positions.

--- a/source/beamline/SGM/energy/SGMEnergyPVControl.cpp
+++ b/source/beamline/SGM/energy/SGMEnergyPVControl.cpp
@@ -20,17 +20,11 @@ SGMEnergyPVControl::SGMEnergyPVControl(QObject *parent) :
                        new CLSMAXvControlStatusChecker())
 {
 
-	 coordinatedStartPoint_ = new AMSinglePVControl("Energy Trajectory Startpoint",
-	                                                "AM1611-4-I10:energy:trajectory:startpoint:eV",
+	 coordinatedTarget_ = new AMSinglePVControl("Energy Trajectory Target",
+							"AM1611-4-I10:energy:trajectory:target:eV",
 	                                                this,
 	                                                0.5,
 	                                                2);
-
-	 coordinatedEndPoint_ = new AMSinglePVControl("Energy Trajectory Endpoint",
-	                                              "AM1611-4-I10:energy:trajectory:endpoint:eV",
-	                                              this,
-	                                              0.5,
-	                                              2);
 
 	 coordinatedDeltaTime_ = new AMSinglePVControl("Energy Trajectory Time",
 	                                               "AM1611-4-I10:energy:trajectory:time:s",
@@ -66,26 +60,12 @@ AMAction3 * SGMEnergyPVControl::createSetParametersActions(double startPoint, do
 	                                                                             "Set energy trajectory parameters"),
 	                                                       AMListAction3::Sequential);
 
-	AMListAction3* moveParametersActions = new AMListAction3(new AMListActionInfo3("Move energy trajectory parameter controls",
-	                                                                        "Move energy trajectory parameter controls"),
-	                                                  AMListAction3::Parallel);
+	setParameterActions->addSubAction(AMActionSupport::buildControlMoveAction(coordinatedTarget_, endPoint));
+	setParameterActions->addSubAction(AMActionSupport::buildControlMoveAction(coordinatedDeltaTime_, deltaTime));
+	setParameterActions->addSubAction(AMActionSupport::buildControlWaitAction(coordinatedTarget_, endPoint, 2, AMControlWaitActionInfo::MatchWithinTolerance));
+	setParameterActions->addSubAction(AMActionSupport::buildControlWaitAction(coordinatedDeltaTime_, deltaTime, 2, AMControlWaitActionInfo::MatchWithinTolerance));
 
 
-	moveParametersActions->addSubAction(AMActionSupport::buildControlMoveAction(coordinatedStartPoint_, startPoint));
-	moveParametersActions->addSubAction(AMActionSupport::buildControlMoveAction(coordinatedEndPoint_, endPoint));
-	moveParametersActions->addSubAction(AMActionSupport::buildControlMoveAction(coordinatedDeltaTime_, deltaTime));
-
-	setParameterActions->addSubAction(moveParametersActions);
-
-	AMListAction3* waitParametersActions = new AMListAction3(new AMListActionInfo3("Wait for energy trajectory parameter controls",
-	                                                                               "Wait for energy trajectory parameter controls"),
-	                                                         AMListAction3::Parallel);
-
-	waitParametersActions->addSubAction(AMActionSupport::buildControlWaitAction(coordinatedStartPoint_, startPoint, 2, AMControlWaitActionInfo::MatchWithinTolerance));
-	waitParametersActions->addSubAction(AMActionSupport::buildControlWaitAction(coordinatedEndPoint_, endPoint, 2, AMControlWaitActionInfo::MatchWithinTolerance));
-	waitParametersActions->addSubAction(AMActionSupport::buildControlWaitAction(coordinatedDeltaTime_, deltaTime, 2, AMControlWaitActionInfo::MatchWithinTolerance));
-
-	setParameterActions->addSubAction(waitParametersActions);
 
 	return setParameterActions;
 }

--- a/source/beamline/SGM/energy/SGMEnergyPVControl.h
+++ b/source/beamline/SGM/energy/SGMEnergyPVControl.h
@@ -33,8 +33,7 @@ protected:
 	double savedEndpoint_;
 	double savedDeltaTime_;
 
-	AMControl* coordinatedStartPoint_;
-	AMControl* coordinatedEndPoint_;
+	AMControl* coordinatedTarget_;
 	AMControl* coordinatedDeltaTime_;
 	AMControl* coordinatedStart_;
 

--- a/source/beamline/SGM/energy/SGMGratingAngleControl.cpp
+++ b/source/beamline/SGM/energy/SGMGratingAngleControl.cpp
@@ -179,9 +179,10 @@ void SGMGratingAngleControl::updateValue()
 {
 	setValue(encoderControl_->value());
 }
-
+#include <QDebug>
 void SGMGratingAngleControl::updateMoving()
 {
+	qDebug() << "\tGrating angle is moving: " << encoderControl_->isMoving();
 	setIsMoving(encoderControl_->isMoving());
 }
 
@@ -200,7 +201,7 @@ AMAction3 * SGMGratingAngleControl::createMoveAction(double setpoint)
 	if(isClosedLoop()) {
 
 		moveAction->addSubAction(AMActionSupport::buildControlMoveAction(encoderControl_, setpoint));
-		moveAction->addSubAction(AMActionSupport::buildControlWaitAction(encoderControl_, setpoint, 20, AMControlWaitActionInfo::MatchWithinTolerance));
+		moveAction->addSubAction(AMActionSupport::buildControlWaitAction(encoderControl_, setpoint, 60, AMControlWaitActionInfo::MatchWithinTolerance));
 	} else {
 
 		// Get distance to move in terms of the encoder

--- a/source/beamline/SGM/energy/SGMGratingAngleControl.cpp
+++ b/source/beamline/SGM/energy/SGMGratingAngleControl.cpp
@@ -201,7 +201,6 @@ AMAction3 * SGMGratingAngleControl::createMoveAction(double setpoint)
 	if(isClosedLoop()) {
 
 		moveAction->addSubAction(AMActionSupport::buildControlMoveAction(encoderControl_, setpoint));
-		moveAction->addSubAction(AMActionSupport::buildControlWaitAction(encoderControl_, setpoint, 60, AMControlWaitActionInfo::MatchWithinTolerance));
 	} else {
 
 		// Get distance to move in terms of the encoder
@@ -220,7 +219,6 @@ AMAction3 * SGMGratingAngleControl::createMoveAction(double setpoint)
 
 		// Do the move
 		moveAction->addSubAction(AMActionSupport::buildControlMoveAction(stepMotorControl_, stepSetpoint));
-		moveAction->addSubAction(AMActionSupport::buildControlWaitAction(stepMotorControl_, stepSetpoint, 60, AMControlWaitActionInfo::MatchWithinTolerance));
 
 		// Set our tolerance back to normal
 		moveAction->addSubAction(new AMChangeToleranceAction(new AMChangeToleranceActionInfo(toInfo(), encoderControl_->tolerance()),this));

--- a/source/beamline/SGM/energy/SGMGratingAngleControl.cpp
+++ b/source/beamline/SGM/energy/SGMGratingAngleControl.cpp
@@ -136,11 +136,13 @@ double SGMGratingAngleControl::stepsPerEncoderCount() const
 	return stepsPerEncoderCountControl_->value();
 }
 
-AMAction3 * SGMGratingAngleControl::createDefaultsAction() const
+AMAction3 * SGMGratingAngleControl::createDefaultsAction()
 {
 	AMListAction3* returnAction = new AMListAction3(new AMListActionInfo3("Set Grating Angle Defaults",
 	                                                                      "Set Grating Angle Defaults"),
 	                                                AMListAction3::Sequential);
+
+	returnAction->addSubAction(new AMChangeToleranceAction(new AMChangeToleranceActionInfo(toInfo(), 5),this));
 
 	AMListAction3* moveAction = new AMListAction3(new AMListActionInfo3("Set Values",
 	                                                                    "Set Values"),
@@ -179,10 +181,9 @@ void SGMGratingAngleControl::updateValue()
 {
 	setValue(encoderControl_->value());
 }
-#include <QDebug>
+
 void SGMGratingAngleControl::updateMoving()
 {
-	qDebug() << "\tGrating angle is moving: " << encoderControl_->isMoving();
 	setIsMoving(encoderControl_->isMoving());
 }
 
@@ -220,8 +221,6 @@ AMAction3 * SGMGratingAngleControl::createMoveAction(double setpoint)
 		// Do the move
 		moveAction->addSubAction(AMActionSupport::buildControlMoveAction(stepMotorControl_, stepSetpoint));
 
-		// Set our tolerance back to normal
-		moveAction->addSubAction(new AMChangeToleranceAction(new AMChangeToleranceActionInfo(toInfo(), encoderControl_->tolerance()),this));
 	}
 
 	return moveAction;

--- a/source/beamline/SGM/energy/SGMGratingAngleControl.h
+++ b/source/beamline/SGM/energy/SGMGratingAngleControl.h
@@ -80,7 +80,7 @@ public:
 	  * Creates an action which returns the movement type, velocity and acceleration
 	  * to their default values.
 	  */
-	AMAction3* createDefaultsAction() const;
+	AMAction3* createDefaultsAction();
 signals:
 protected slots:
 	/// Updates the connected state.

--- a/source/beamline/SGM/energy/SGMGratingTranslationStepControl.cpp
+++ b/source/beamline/SGM/energy/SGMGratingTranslationStepControl.cpp
@@ -90,10 +90,5 @@ AMAction3 * SGMGratingTranslationStepControl::createMoveAction(double setpoint)
 	                                                                 setpoint,
 	                                                                 false));
 
-	moveAction->addSubAction(AMActionSupport::buildControlWaitAction(gratingTranslationStepPV_,
-	                                                                 setpoint,
-	                                                                 60,
-	                                                                 AMControlWaitActionInfo::MatchWithinTolerance));
-
 	return moveAction;
 }

--- a/source/beamline/SGM/energy/SGMUndulatorControl.cpp
+++ b/source/beamline/SGM/energy/SGMUndulatorControl.cpp
@@ -183,11 +183,6 @@ AMAction3 * SGMUndulatorControl::createMoveAction(double setpoint)
 	moveAction->addSubAction(AMActionSupport::buildControlMoveAction(encoderControl_,
 	                                                                 setpoint));
 
-	moveAction->addSubAction(AMActionSupport::buildControlWaitAction(encoderControl_,
-	                                                                 setpoint,
-	                                                                 60,
-	                                                                 AMControlWaitActionInfo::MatchWithinTolerance));
-
 	return moveAction;
 }
 

--- a/source/beamline/SGM/energy/SGMUndulatorControl.cpp
+++ b/source/beamline/SGM/energy/SGMUndulatorControl.cpp
@@ -114,7 +114,7 @@ AMControl * SGMUndulatorControl::stepControl() const
 	return stepControl_;
 }
 
-AMAction3 * SGMUndulatorControl::createDefaultsAction() const
+AMAction3 * SGMUndulatorControl::createDefaultsAction()
 {
 	AMListAction3* defaultsAction = new AMListAction3(new AMListActionInfo3("Setting Undulator defaults",
 	                                                                        "Setting Undulator defaults"),

--- a/source/beamline/SGM/energy/SGMUndulatorControl.h
+++ b/source/beamline/SGM/energy/SGMUndulatorControl.h
@@ -62,7 +62,7 @@ public:
 	  * Creates an action which returns the velocity and acceleration to their
 	  * default values.
 	  */
-	AMAction3* createDefaultsAction() const;
+	AMAction3* createDefaultsAction();
 signals:
 protected slots:
 	/// Updates the connected state.

--- a/source/tests/SGM/SGMEnergyControlTestView.cpp
+++ b/source/tests/SGM/SGMEnergyControlTestView.cpp
@@ -108,7 +108,7 @@ void SGMEnergyControlTestView::onStartTrajectoryButtonPushed()
 		double endEnergy = endEnergySpinBox_->value();
 
 		double velocity = qAbs(endEnergy - startEnergy) / timeTakenSpinBox_->value();
-		energyCoordinatorControl_->move(startEnergy, endEnergy, velocity);
+		energyCoordinatorControl_->move(endEnergy, velocity);
 	}
 }
 

--- a/source/ui/SGM/SGMEnergyTrajectoryView.cpp
+++ b/source/ui/SGM/SGMEnergyTrajectoryView.cpp
@@ -21,8 +21,7 @@ SGMEnergyTrajectoryView::SGMEnergyTrajectoryView(SGMEnergyControlSet* controlSet
 
 void SGMEnergyTrajectoryView::onStartPushButtonClicked()
 {
-	controlSet_->energyTrajectoryStartpoint()->move(startpointSpinBox_->value());
-	controlSet_->energyTrajectoryEndpoint()->move(endpointSpinBox_->value());
+	controlSet_->energyTrajectoryTarget()->move(targetSpinBox_->value());
 	controlSet_->energyTrajectoryTime()->move(timeSpinBox_->value());
 
 	controlSet_->energyTrajectoryStart()->move(1);
@@ -45,31 +44,24 @@ void SGMEnergyTrajectoryView::setupUi()
 	QGridLayout* gridLayout = new QGridLayout();
 	setLayout(gridLayout);
 
-	startpointSpinBox_ = new QDoubleSpinBox();
-	gridLayout->addWidget(new QLabel("Startpoint"), 0, 0);
-	gridLayout->addWidget(startpointSpinBox_, 0, 1);
-
-	endpointSpinBox_ = new QDoubleSpinBox();
-	gridLayout->addWidget(new QLabel("Endpoint"), 1, 0);
-	gridLayout->addWidget(endpointSpinBox_, 1, 1);
+	targetSpinBox_ = new QDoubleSpinBox();
+	gridLayout->addWidget(new QLabel("Target"), 0, 0);
+	gridLayout->addWidget(targetSpinBox_, 0, 1);
 
 	timeSpinBox_ = new QDoubleSpinBox();
-	gridLayout->addWidget(new QLabel("Time"), 2, 0);
-	gridLayout->addWidget(timeSpinBox_, 2, 1);
+	gridLayout->addWidget(new QLabel("Time"), 1, 0);
+	gridLayout->addWidget(timeSpinBox_, 1, 1);
 
 	startButton_ = new QPushButton("Start");
-	gridLayout->addWidget(startButton_, 3, 0, 1, 2);
+	gridLayout->addWidget(startButton_, 2, 0, 1, 2);
 }
 
 void SGMEnergyTrajectoryView::setupData()
 {
-	startpointSpinBox_->setRange(controlSet_->energyTrajectoryStartpoint()->minimumValue(),
-	                             controlSet_->energyTrajectoryStartpoint()->maximumValue());
-	startpointSpinBox_->setSuffix(controlSet_->energyTrajectoryStartpoint()->units());
 
-	endpointSpinBox_->setRange(controlSet_->energyTrajectoryEndpoint()->minimumValue(),
-	                           controlSet_->energyTrajectoryEndpoint()->maximumValue());
-	endpointSpinBox_->setSuffix(controlSet_->energyTrajectoryEndpoint()->units());
+	targetSpinBox_->setRange(controlSet_->energyTrajectoryTarget()->minimumValue(),
+				   controlSet_->energyTrajectoryTarget()->maximumValue());
+	targetSpinBox_->setSuffix(controlSet_->energyTrajectoryTarget()->units());
 
 	timeSpinBox_->setRange(controlSet_->energyTrajectoryTime()->minimumValue(),
 	                       controlSet_->energyTrajectoryTime()->maximumValue());

--- a/source/ui/SGM/SGMEnergyTrajectoryView.h
+++ b/source/ui/SGM/SGMEnergyTrajectoryView.h
@@ -57,8 +57,7 @@ protected:
 
 	SGMEnergyControlSet* controlSet_;
 
-	QDoubleSpinBox* startpointSpinBox_;
-	QDoubleSpinBox* endpointSpinBox_;
+	QDoubleSpinBox* targetSpinBox_;
 	QDoubleSpinBox* timeSpinBox_;
 	QPushButton* startButton_;
 


### PR DESCRIPTION
Changes made:
- Removed all the 'initialization' steps (moving to start, getting the exit slit into position) for a continuous move from within the energy coordinator, as this is now done in the acquaman side.
- Altered the pseudo motor so it now doesn't emit the movingChanged(false) signal whenever its move actions completed (whether or not its child controls are still moving)
- Changed all the createDefaultsAction() functions in the various pseudo-motors to to non const (was required for setting the tolerance of the grating angle, and I wanted them all to be consistent).

Sorry, no laptop today.
Will set this properly tonight, but for now:
Estimate: 1