### PR TITLE
Pull Request for Issue1754: No Exporter Registered for SGM XAS Scans

### DIFF
--- a/SGMAcquaman_internal.pro
+++ b/SGMAcquaman_internal.pro
@@ -21,7 +21,8 @@ HEADERS += \
     source/ui/SGM/SGMLineScanConfigurationView.h \
     source/acquaman/SGM/SGMMapScanConfiguration.h \
     source/acquaman/SGM/SGMMapScanController.h \
-    source/ui/SGM/SGMMapScanConfigurationView.h
+    source/ui/SGM/SGMMapScanConfigurationView.h \
+    source/application/SGM/SGM.h
 
 SOURCES += \
     source/application/SGM/SGMMain.cpp \

--- a/source/application/SGM/SGM.h
+++ b/source/application/SGM/SGM.h
@@ -1,0 +1,71 @@
+#ifndef SGM
+#define SGM
+
+#include "dataman/database/AMDbObjectSupport.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
+
+namespace SGM
+{
+	/// Builds the standard exporter option used for all exported scans.
+	inline AMExporterOptionXDIFormat *buildXDIFormatExporterOption(const QString &name, bool includeHigherOrderSources)
+	{
+		QList<int> matchIDs = AMDatabase::database("user")->objectsMatching(AMDbObjectSupport::s()->tableNameForClass<AMExporterOptionXDIFormat>(), "name", name);
+
+		AMExporterOptionXDIFormat *option = new AMExporterOptionXDIFormat();
+
+		if (matchIDs.count() != 0)
+			option->loadFromDb(AMDatabase::database("user"), matchIDs.at(0));
+
+		option->setName(name);
+		option->setFileName("$name_$number.dat");
+		option->setHeaderText("Scan: $name #$number\nDate: $dateTime\nSample: $sample\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
+		option->setHeaderIncluded(true);
+		option->setColumnHeader("$dataSetName $dataSetInfoDescription");
+		option->setColumnHeaderIncluded(true);
+		option->setColumnHeaderDelimiter("");
+		option->setSectionHeader("");
+		option->setSectionHeaderIncluded(true);
+		option->setIncludeAllDataSources(true);
+		option->setFirstColumnOnly(true);
+		option->setIncludeHigherDimensionSources(includeHigherOrderSources);
+		option->setSeparateHigherDimensionalSources(true);
+		option->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
+		option->setHigherDimensionsInRows(true);
+		option->storeToDb(AMDatabase::database("user"));
+
+		return option;
+	}
+
+	/// Builds the standard exporter option used for all exported scans.
+	inline AMExporterOptionGeneralAscii *buildAsciiFormatExporterOption(const QString &name, bool includeHigherOrderSources)
+	{
+		QList<int> matchIDs = AMDatabase::database("user")->objectsMatching(AMDbObjectSupport::s()->tableNameForClass<AMExporterOptionGeneralAscii>(), "name", name);
+
+		AMExporterOptionGeneralAscii *option = new AMExporterOptionGeneralAscii();
+
+		if (matchIDs.count() != 0)
+			option->loadFromDb(AMDatabase::database("user"), matchIDs.at(0));
+
+		option->setName(name);
+		option->setFileName("$name_$number.dat");
+		option->setHeaderText("Scan: $name #$number\nDate: $dateTime\nSample: $sample\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
+		option->setHeaderIncluded(true);
+		option->setColumnHeader("$dataSetName $dataSetInfoDescription");
+		option->setColumnHeaderIncluded(true);
+		option->setColumnHeaderDelimiter("");
+		option->setSectionHeader("");
+		option->setSectionHeaderIncluded(true);
+		option->setIncludeAllDataSources(true);
+		option->setFirstColumnOnly(true);
+		option->setIncludeHigherDimensionSources(includeHigherOrderSources);
+		option->setSeparateHigherDimensionalSources(true);
+		option->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
+		option->setHigherDimensionsInRows(true);
+		option->storeToDb(AMDatabase::database("user"));
+
+		return option;
+	}
+}
+
+#endif // SGM
+

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -20,19 +20,24 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "SGMAppController.h"
-#include "beamline/SGM/SGMBeamline.h"
-#include "beamline/CLS/CLSStorageRing.h"
 
 #include "acquaman/AMGenericStepScanConfiguration.h"
 #include "acquaman/SGM/SGMXASScanConfiguration.h"
 #include "acquaman/SGM/SGMLineScanConfiguration.h"
 #include "acquaman/SGM/SGMMapScanConfiguration.h"
+#include "application/AMAppControllerSupport.h"
+#include "application/SGM/SGM.h"
 #include "beamline/CLS/CLSAmptekSDD123DetectorNew.h"
 #include "beamline/CLS/CLSFacilityID.h"
+#include "beamline/CLS/CLSStorageRing.h"
+#include "beamline/SGM/SGMBeamline.h"
 #include "beamline/SGM/SGMHexapod.h"
 #include "beamline/SGM/energy/SGMEnergyPosition.h"
+#include "beamline/SGM/energy/SGMEnergyControlSet.h"
 #include "dataman/AMRun.h"
 #include "dataman/database/AMDbObjectSupport.h"
+#include "dataman/export/AMExporterXDIFormat.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
 #include "ui/AMMainWindow.h"
 #include "ui/acquaman/AMGenericStepScanConfigurationView.h"
 #include "ui/CLS/CLSAMDSScalerView.h"
@@ -194,8 +199,20 @@ void SGMAppController::registerClasses()
 
 void SGMAppController::setupExporterOptions()
 {
+	AMExporterOptionXDIFormat *sgmXASExportOptions = SGM::buildXDIFormatExporterOption("SGMXASDefault", true);
+	if(sgmXASExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<SGMXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(sgmXASExportOptions->id());
+
+	AMExporterOptionGeneralAscii *sgmLineExportOptions = SGM::buildAsciiFormatExporterOption("SGMLineDefault", true);
+	if(sgmLineExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<SGMLineScanConfiguration, AMExporterGeneralAscii, AMExporterOptionGeneralAscii>(sgmLineExportOptions->id());
+
+	AMExporterOptionGeneralAscii *sgmMapExportOptions = SGM::buildAsciiFormatExporterOption("SGMMapDefault", true);
+	if(sgmMapExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<SGMMapScanConfiguration, AMExporterGeneralAscii, AMExporterOptionGeneralAscii>(sgmMapExportOptions->id());
+
 }
-#include "beamline/SGM/energy/SGMEnergyControlSet.h"
+
 void SGMAppController::setupUserInterface()
 {
 	SGMPersistentView* persistentView =


### PR DESCRIPTION
Very straight forward registration of exporters for SGM.  Line and map scans are registered with normal ASCII files but I setup the XAS scans to use the XDI format.