### PR TITLE
Pull Request for Issue1753: Continuous Scans Missing Thumbnails

### DIFF
--- a/SGMAcquaman_internal.pro
+++ b/SGMAcquaman_internal.pro
@@ -21,7 +21,8 @@ HEADERS += \
     source/ui/SGM/SGMLineScanConfigurationView.h \
     source/acquaman/SGM/SGMMapScanConfiguration.h \
     source/acquaman/SGM/SGMMapScanController.h \
-    source/ui/SGM/SGMMapScanConfigurationView.h
+    source/ui/SGM/SGMMapScanConfigurationView.h \
+    source/application/SGM/SGM.h
 
 SOURCES += \
     source/application/SGM/SGMMain.cpp \

--- a/source/acquaman/AMContinuousScanActionController.cpp
+++ b/source/acquaman/AMContinuousScanActionController.cpp
@@ -27,8 +27,9 @@ AMContinuousScanActionController::AMContinuousScanActionController(AMContinuousS
 	: AMScanActionController(configuration, parent)
 {
 	continuousConfiguration_ = configuration;
-
 	insertionIndex_ = AMnDIndex(0);
+
+	connect(this, SIGNAL(started()), this, SLOT(onScanningActionsStarted()));
 }
 
 AMContinuousScanActionController::~AMContinuousScanActionController()
@@ -133,6 +134,11 @@ void AMContinuousScanActionController::flushCDFDataStoreToDisk()
 		AMErrorMon::report(AMErrorReport(this, AMErrorReport::Serious, 38, "Error saving the currently-running scan's raw data file to disk. Watch out... your data may not be saved! Please report this bug to your beamline's software developers."));
 }
 
+void AMContinuousScanActionController::onScanningActionsStarted()
+{
+	disconnect(scanningActions_, SIGNAL(succeeded()), this, SLOT(onScanningActionsSucceeded()));
+}
+
 bool AMContinuousScanActionController::event(QEvent *e)
 {
 	if (e->type() == (QEvent::Type)AMAgnosticDataAPIDefinitions::MessageEvent){
@@ -148,6 +154,7 @@ bool AMContinuousScanActionController::event(QEvent *e)
 		case AMAgnosticDataAPIDefinitions::AxisFinished:{
 
 			onAxisFinished();
+			flushCDFDataStoreToDisk();
 
 			break;
 		}
@@ -161,6 +168,7 @@ bool AMContinuousScanActionController::event(QEvent *e)
 
 			AMAgnosticDataAPIDataAvailableMessage *dataAvailableMessage = static_cast<AMAgnosticDataAPIDataAvailableMessage*>(&message);
 			fillDataMaps(dataAvailableMessage);
+			flushCDFDataStoreToDisk();
 
 			break;}
 

--- a/source/acquaman/AMContinuousScanActionController.h
+++ b/source/acquaman/AMContinuousScanActionController.h
@@ -38,6 +38,8 @@ public slots:
 protected slots:
 	/// Helper slot that tells AMCDFDataStore to flush it's contents to disk.  This prevents it from corrupting itself.
 	void flushCDFDataStoreToDisk();
+	/// Slot that disables the connection to onScanningActionsSucceeded() upon startup.
+	void onScanningActionsStarted();
 
 protected:
 	/// Implementation to ensure that the data acquisition event is caught and handled.

--- a/source/acquaman/SGM/SGMXASScanController.cpp
+++ b/source/acquaman/SGM/SGMXASScanController.cpp
@@ -311,6 +311,8 @@ void SGMXASScanController::onAxisFinished()
 		i.value()->deleteLater();
 		i++;
 	}
+
+	onScanningActionsSucceeded();
 }
 
 void SGMXASScanController::fillDataMaps(AMAgnosticDataAPIDataAvailableMessage *message)

--- a/source/application/SGM/SGM.h
+++ b/source/application/SGM/SGM.h
@@ -1,0 +1,71 @@
+#ifndef SGM
+#define SGM
+
+#include "dataman/database/AMDbObjectSupport.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
+
+namespace SGM
+{
+	/// Builds the standard exporter option used for all exported scans.
+	inline AMExporterOptionXDIFormat *buildXDIFormatExporterOption(const QString &name, bool includeHigherOrderSources)
+	{
+		QList<int> matchIDs = AMDatabase::database("user")->objectsMatching(AMDbObjectSupport::s()->tableNameForClass<AMExporterOptionXDIFormat>(), "name", name);
+
+		AMExporterOptionXDIFormat *option = new AMExporterOptionXDIFormat();
+
+		if (matchIDs.count() != 0)
+			option->loadFromDb(AMDatabase::database("user"), matchIDs.at(0));
+
+		option->setName(name);
+		option->setFileName("$name_$number.dat");
+		option->setHeaderText("Scan: $name #$number\nDate: $dateTime\nSample: $sample\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
+		option->setHeaderIncluded(true);
+		option->setColumnHeader("$dataSetName $dataSetInfoDescription");
+		option->setColumnHeaderIncluded(true);
+		option->setColumnHeaderDelimiter("");
+		option->setSectionHeader("");
+		option->setSectionHeaderIncluded(true);
+		option->setIncludeAllDataSources(true);
+		option->setFirstColumnOnly(true);
+		option->setIncludeHigherDimensionSources(includeHigherOrderSources);
+		option->setSeparateHigherDimensionalSources(true);
+		option->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
+		option->setHigherDimensionsInRows(true);
+		option->storeToDb(AMDatabase::database("user"));
+
+		return option;
+	}
+
+	/// Builds the standard exporter option used for all exported scans.
+	inline AMExporterOptionGeneralAscii *buildAsciiFormatExporterOption(const QString &name, bool includeHigherOrderSources)
+	{
+		QList<int> matchIDs = AMDatabase::database("user")->objectsMatching(AMDbObjectSupport::s()->tableNameForClass<AMExporterOptionGeneralAscii>(), "name", name);
+
+		AMExporterOptionGeneralAscii *option = new AMExporterOptionGeneralAscii();
+
+		if (matchIDs.count() != 0)
+			option->loadFromDb(AMDatabase::database("user"), matchIDs.at(0));
+
+		option->setName(name);
+		option->setFileName("$name_$number.dat");
+		option->setHeaderText("Scan: $name #$number\nDate: $dateTime\nSample: $sample\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
+		option->setHeaderIncluded(true);
+		option->setColumnHeader("$dataSetName $dataSetInfoDescription");
+		option->setColumnHeaderIncluded(true);
+		option->setColumnHeaderDelimiter("");
+		option->setSectionHeader("");
+		option->setSectionHeaderIncluded(true);
+		option->setIncludeAllDataSources(true);
+		option->setFirstColumnOnly(true);
+		option->setIncludeHigherDimensionSources(includeHigherOrderSources);
+		option->setSeparateHigherDimensionalSources(true);
+		option->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
+		option->setHigherDimensionsInRows(true);
+		option->storeToDb(AMDatabase::database("user"));
+
+		return option;
+	}
+}
+
+#endif // SGM
+

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -20,19 +20,24 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "SGMAppController.h"
-#include "beamline/SGM/SGMBeamline.h"
-#include "beamline/CLS/CLSStorageRing.h"
 
 #include "acquaman/AMGenericStepScanConfiguration.h"
 #include "acquaman/SGM/SGMXASScanConfiguration.h"
 #include "acquaman/SGM/SGMLineScanConfiguration.h"
 #include "acquaman/SGM/SGMMapScanConfiguration.h"
+#include "application/AMAppControllerSupport.h"
+#include "application/SGM/SGM.h"
 #include "beamline/CLS/CLSAmptekSDD123DetectorNew.h"
 #include "beamline/CLS/CLSFacilityID.h"
+#include "beamline/CLS/CLSStorageRing.h"
+#include "beamline/SGM/SGMBeamline.h"
 #include "beamline/SGM/SGMHexapod.h"
 #include "beamline/SGM/energy/SGMEnergyPosition.h"
+#include "beamline/SGM/energy/SGMEnergyControlSet.h"
 #include "dataman/AMRun.h"
 #include "dataman/database/AMDbObjectSupport.h"
+#include "dataman/export/AMExporterXDIFormat.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
 #include "ui/AMMainWindow.h"
 #include "ui/acquaman/AMGenericStepScanConfigurationView.h"
 #include "ui/CLS/CLSAMDSScalerView.h"
@@ -194,8 +199,20 @@ void SGMAppController::registerClasses()
 
 void SGMAppController::setupExporterOptions()
 {
+	AMExporterOptionXDIFormat *sgmXASExportOptions = SGM::buildXDIFormatExporterOption("SGMXASDefault", true);
+	if(sgmXASExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<SGMXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(sgmXASExportOptions->id());
+
+	AMExporterOptionGeneralAscii *sgmLineExportOptions = SGM::buildAsciiFormatExporterOption("SGMLineDefault", true);
+	if(sgmLineExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<SGMLineScanConfiguration, AMExporterGeneralAscii, AMExporterOptionGeneralAscii>(sgmLineExportOptions->id());
+
+	AMExporterOptionGeneralAscii *sgmMapExportOptions = SGM::buildAsciiFormatExporterOption("SGMMapDefault", true);
+	if(sgmMapExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<SGMMapScanConfiguration, AMExporterGeneralAscii, AMExporterOptionGeneralAscii>(sgmMapExportOptions->id());
+
 }
-#include "beamline/SGM/energy/SGMEnergyControlSet.h"
+
 void SGMAppController::setupUserInterface()
 {
 	SGMPersistentView* persistentView =


### PR DESCRIPTION
This was actually an issue of doing the scan cleanup (exporting, thumbnail generation, etc.) before the data was placed in the data store.  Fixed the behaviour by calling `onScanningActionsSucceeded()` inside the continuous scan controller rather than relying on the signals from the `scanActionsTree_`.