### PR TITLE
Pull Request for Issue1792: Adding stop button to M1, M2, mono views

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -434,7 +434,8 @@ HEADERS += \
     source/actions3/actions/AMControlCalibrateAction.h \
     source/beamline/AMEnumeratedControl.h \
 	source/beamline/AMSingleEnumeratedControl.h \
-	source/beamline/AMExclusiveStatesEnumeratedControl.h
+	source/beamline/AMExclusiveStatesEnumeratedControl.h \
+    source/ui/beamline/AMControlStopButton.h
 
 FORMS += \
 
@@ -830,7 +831,8 @@ SOURCES += \
     source/actions3/actions/AMControlCalibrateAction.cpp \
     source/beamline/AMEnumeratedControl.cpp \
     source/beamline/AMSingleEnumeratedControl.cpp \
-	source/beamline/AMExclusiveStatesEnumeratedControl.cpp
+	source/beamline/AMExclusiveStatesEnumeratedControl.cpp \
+    source/ui/beamline/AMControlStopButton.cpp
 
 RESOURCES *= source/icons/icons.qrc \
 		source/configurationFiles/configurationFiles.qrc \
@@ -847,3 +849,5 @@ contains(DEFINES, AM_BUILD_REPORTER_ENABLED){
 
 	SOURCES *= source/util/AMRunTimeBuildInfo.cpp
 }
+
+

--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -434,7 +434,8 @@ HEADERS += \
     source/actions3/actions/AMControlCalibrateAction.h \
     source/beamline/AMEnumeratedControl.h \
 	source/beamline/AMSingleEnumeratedControl.h \
-	source/beamline/AMExclusiveStatesEnumeratedControl.h
+	source/beamline/AMExclusiveStatesEnumeratedControl.h \
+	source/ui/beamline/AMControlStopButton.h
 
 FORMS += \
 

--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -84,7 +84,8 @@ HEADERS += \
     source/beamline/BioXAS/BioXASCarbonFilterFarmActuator.h \
     source/beamline/BioXAS/BioXASXIAFiltersActuatorControl.h \
     source/beamline/BioXAS/BioXASXIAFiltersActuator.h \
-    source/beamline/BioXAS/BioXASFilterFlipperFilters.h
+    source/beamline/BioXAS/BioXASFilterFlipperFilters.h \
+    source/ui/BioXAS/BioXASSSRLMonochromatorView.h
 
 SOURCES += \
 	source/acquaman/BioXAS/BioXASXRFScanConfiguration.cpp \
@@ -163,4 +164,7 @@ SOURCES += \
     source/beamline/BioXAS/BioXASCarbonFilterFarmActuator.cpp \
     source/beamline/BioXAS/BioXASXIAFiltersActuatorControl.cpp \
     source/beamline/BioXAS/BioXASXIAFiltersActuator.cpp \
-    source/beamline/BioXAS/BioXASFilterFlipperFilters.cpp
+    source/beamline/BioXAS/BioXASFilterFlipperFilters.cpp \
+    source/ui/BioXAS/BioXASSSRLMonochromatorView.cpp
+
+

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -99,11 +99,12 @@ AMAction3* BioXASXASScanActionController::createInitializationActions()
 	// Initialize the mono.
 
 	AMSequentialListAction3 *monoInitialization = 0;
-	BioXASMonochromator *mono = BioXASBeamline::bioXAS()->mono();
+	BioXASSSRLMonochromator *mono = qobject_cast<BioXASSSRLMonochromator*>(BioXASBeamline::bioXAS()->mono());
 
 	if (mono) {
 
-		// Set the bragg motor power to PowerOn, must be on to move/scan.
+		// If the mono is an SSRL mono, must set the bragg motor power to PowerOn to move/scan.
+
 		CLSMAXvMotor *braggMotor = qobject_cast<CLSMAXvMotor*>(mono->bragg());
 
 		if (braggMotor) {
@@ -165,7 +166,7 @@ AMAction3* BioXASXASScanActionController::createCleanupActions()
 	// Create mono cleanup actions.
 
 	AMSequentialListAction3 *monoCleanup = 0;
-	BioXASMonochromator *mono = BioXASBeamline::bioXAS()->mono();
+	BioXASSSRLMonochromator *mono = qobject_cast<BioXASSSRLMonochromator*>(BioXASBeamline::bioXAS()->mono());
 
 	if (mono) {
 

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -53,7 +53,7 @@ QString BioXASXASScanActionController::scanNotes()
 
 	BioXASSSRLMonochromator *mono = BioXASBeamline::bioXAS()->mono();
 	if (mono) {
-		double settlingTime = mono->braggMotor()->settlingTime();
+		double settlingTime = mono->bragg()->settlingTime();
 		if (settlingTime > 0)
 			notes.append(QString("Settling time:\t%1 s\n").arg(settlingTime));
 	}
@@ -104,7 +104,7 @@ AMAction3* BioXASXASScanActionController::createInitializationActions()
 	if (mono) {
 
 		// Set the bragg motor power to PowerOn, must be on to move/scan.
-		CLSMAXvMotor *braggMotor = qobject_cast<CLSMAXvMotor*>(mono->braggMotor());
+		CLSMAXvMotor *braggMotor = qobject_cast<CLSMAXvMotor*>(mono->bragg());
 
 		if (braggMotor) {
 			monoInitialization = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Monochromator Initialization", "BioXAS Monochromator Initialization"));
@@ -170,7 +170,7 @@ AMAction3* BioXASXASScanActionController::createCleanupActions()
 	if (mono) {
 
 		// Set the bragg motor power to PowerAutoSoftware. The motor can get too warm when left on for too long, that's why we turn it off when not in use.
-		CLSMAXvMotor *braggMotor = qobject_cast<CLSMAXvMotor*>(mono->braggMotor());
+		CLSMAXvMotor *braggMotor = qobject_cast<CLSMAXvMotor*>(mono->bragg());
 
 		if (braggMotor) {
 			monoCleanup = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Monochromator Cleanup", "BioXAS Monochromator Cleanup"));

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -380,7 +380,7 @@ QWidget* BioXASAppController::createComponentView(QObject *component)
 
 		BioXASSSRLMonochromator *mono = qobject_cast<BioXASSSRLMonochromator*>(component);
 		if (!componentFound && mono) {
-			componentView = new BioXASSSRLMonochromatorConfigurationView(mono);
+			componentView = new BioXASSSRLMonochromatorView(mono);
 			componentFound = true;
 		}
 

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -590,7 +590,7 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 
 		BioXASMonochromator *mono = BioXASBeamline::bioXAS()->mono();
 		if (mono) {
-			AMControl *energyControl = mono->energyControl();
+			AMControl *energyControl = mono->energy();
 			if (energyControl){
 
 				configuration->setControl(0, energyControl->toInfo());

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -589,10 +589,12 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 		// Set the energy as the scanned control.
 
 		BioXASMonochromator *mono = BioXASBeamline::bioXAS()->mono();
-		if (mono) {
-			AMControl *energyControl = mono->energy();
-			if (energyControl){
 
+		if (mono) {
+
+			AMControl *energyControl = mono->energy();
+
+			if (energyControl) {
 				configuration->setControl(0, energyControl->toInfo());
 				configuration->setupDefaultXANESRegions();
 			}
@@ -604,6 +606,7 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 		QList<AMAbsorptionEdge> edges = defaultElement->absorptionEdges();
 
 		if (!edges.isEmpty()) {
+
 			AMAbsorptionEdge defaultEdge = edges.first();
 			double defaultEnergy = defaultEdge.energy();
 

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -46,7 +46,7 @@
 #include "ui/acquaman/AMScanConfigurationViewHolder3.h"
 #include "ui/dataman/AMGenericScanEditor.h"
 #include "ui/BioXAS/BioXAS32ElementGeDetectorView.h"
-#include "ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h"
+#include "ui/BioXAS/BioXASSSRLMonochromatorView.h"
 #include "ui/BioXAS/BioXASXIAFiltersView.h"
 #include "ui/BioXAS/BioXASM1MirrorView.h"
 #include "ui/BioXAS/BioXASM2MirrorView.h"

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
@@ -49,26 +49,22 @@ bool BioXASBeamlineComponent::canStop() const
 
 bool BioXASBeamlineComponent::stop()
 {
-	// Want to return true if all the controls are valid and those
-	// that can be stopped are stopped, false otherwise. Returns
-	// true if there are no child controls, the expectation is that
-	// this control can't be moving otherwise.
+	bool result = false;
 
-	bool childrenValid = true;
-	bool childrenStopped = true;
+	if (canStop()) {
 
-	foreach (AMControl *control, children_) { // We want to iterate through all children and try to stop them.
+		bool childrenStopped = true;
 
-		if (control) {
-			if (control->canStop())
+		// Iterate through all child controls, attempting
+		// to stop them.
+
+		foreach (AMControl *control, children_) {
+			if (control)
 				childrenStopped &= control->stop();
-
-		} else {
-			childrenValid &= false;
 		}
-	}
 
-	bool result = childrenValid && childrenStopped;
+		result = childrenStopped;
+	}
 
 	return result;
 }

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
@@ -11,6 +11,20 @@ BioXASBeamlineComponent::~BioXASBeamlineComponent()
 
 }
 
+bool BioXASBeamlineComponent::stop() const
+{
+	bool result = true;
+
+	foreach (AMControl *control, children_) {
+		if (control && control->stop())
+			result = true;
+		else
+			result = false;
+	}
+
+	return result;
+}
+
 void BioXASBeamlineComponent::addChildControl(AMControl *control)
 {
 	if (control) {

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.h
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.h
@@ -38,7 +38,6 @@ protected slots:
 protected:
 	/// The current connected state.
 	bool connected_;
-
 };
 
 #endif // BIOXASBEAMLINECOMPONENT_H

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.h
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.h
@@ -13,9 +13,15 @@ public:
 	/// Destructor.
 	virtual ~BioXASBeamlineComponent();
 
+	/// Returns true if this control should be able to be stopped (if connected), false otherwise.
+	virtual bool shouldStop() const { return true; }
+
+	/// Returns true if this control can be stopped right now, false otherwise.
+	virtual bool canStop() const { return true; }
+
 public slots:
-	/// Stops all controls that can be stopped.
-	virtual bool stop() const;
+	/// Stops all child controls that can be stopped.
+	virtual bool stop();
 
 protected slots:
 	/// Adds a given control to the list of child controls.

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.h
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.h
@@ -15,9 +15,8 @@ public:
 
 	/// Returns true if this control should be able to be stopped (if connected), false otherwise.
 	virtual bool shouldStop() const { return true; }
-
-	/// Returns true if this control can be stopped right now, false otherwise.
-	virtual bool canStop() const { return true; }
+	/// Returns true if this control can be stopped right now, false otherwise. Finds this out be examining all child controls. Subclasses can reimplement to achieve their particular behavior.
+	virtual bool canStop() const;
 
 public slots:
 	/// Stops all child controls that can be stopped.

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.h
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.h
@@ -13,6 +13,10 @@ public:
 	/// Destructor.
 	virtual ~BioXASBeamlineComponent();
 
+public slots:
+	/// Stops all controls that can be stopped.
+	virtual bool stop() const;
+
 protected slots:
 	/// Adds a given control to the list of child controls.
 	virtual void addChildControl(AMControl *control);

--- a/source/beamline/BioXAS/BioXASM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASM1Mirror.cpp
@@ -22,3 +22,19 @@ bool BioXASM1Mirror::isConnected() const
 
 	return isConnected;
 }
+
+void BioXASM1Mirror::setUpperSlitBladeMotor(CLSMAXvMotor *newControl)
+{
+	if (upperSlitBladeMotor_ != newControl) {
+
+		if (upperSlitBladeMotor_)
+			removeChildControl(upperSlitBladeMotor_);
+
+		upperSlitBladeMotor_ = newControl;
+
+		if (upperSlitBladeMotor_)
+			addChildControl(upperSlitBladeMotor_);
+
+		emit upperSlitBladeMotorChanged(upperSlitBladeMotor_);
+	}
+}

--- a/source/beamline/BioXAS/BioXASM1Mirror.h
+++ b/source/beamline/BioXAS/BioXASM1Mirror.h
@@ -15,13 +15,21 @@ public:
 	/// Destructor.
 	virtual ~BioXASM1Mirror();
 
-	/// Returns the current connected state. True if this control is connected, false otherwise.
+	/// Returns the current connected state.
 	virtual bool isConnected() const;
 
-	/// Returns the upper slit blade control.
-	AMControl* upperSlitBladeMotorControl() const { return upperSlitBladeMotor_; }
+	/// Returns the upper slit blade motor control.
+	CLSMAXvMotor* upperSlitBladeMotor() const { return upperSlitBladeMotor_; }
 
-protected:
+signals:
+	/// Notifier that the upper slit blade motor control has changed.
+	void upperSlitBladeMotorChanged(CLSMAXvMotor *newControl);
+
+protected slots:
+	/// Sets the upper slit blade motor control.
+	void setUpperSlitBladeMotor(CLSMAXvMotor *newControl);
+
+private:
 	/// The upper slit blade motor control.
 	CLSMAXvMotor *upperSlitBladeMotor_;
 };

--- a/source/beamline/BioXAS/BioXASM2Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASM2Mirror.cpp
@@ -5,7 +5,7 @@ BioXASM2Mirror::BioXASM2Mirror(const QString &name, QObject *parent) :
 {
 	// Initialize member variables.
 
-	screenMotor_ = 0;
+	screen_ = 0;
 }
 
 BioXASM2Mirror::~BioXASM2Mirror()
@@ -17,10 +17,26 @@ bool BioXASM2Mirror::isConnected() const
 {
 	bool isConnected = (
 				BioXASMirror::isConnected() &&
-				screenMotor_ && screenMotor_->isConnected()
+				screen_ && screen_->isConnected()
 				);
 
 	return isConnected;
+}
+
+void BioXASM2Mirror::setScreen(AMControl *newControl)
+{
+	if (screen_ != newControl) {
+
+		if (screen_)
+			removeChildControl(screen_);
+
+		screen_ = newControl;
+
+		if (screen_)
+			addChildControl(screen_);
+
+		emit screenChanged(screen_);
+	}
 }
 
 

--- a/source/beamline/BioXAS/BioXASM2Mirror.h
+++ b/source/beamline/BioXAS/BioXASM2Mirror.h
@@ -1,8 +1,6 @@
 #ifndef BIOXASM2MIRROR_H
 #define BIOXASM2MIRROR_H
 
-#include <QObject>
-
 #include "beamline/BioXAS/BioXASMirror.h"
 
 class BioXASM2Mirror : public BioXASMirror
@@ -22,12 +20,19 @@ public:
 	virtual bool isConnected() const;
 
 	/// Returns the fluorescence screen control.
-	AMControl* screenMotorControl() const { return screenMotor_; }
+	AMControl* screen() const { return screen_; }
+
+signals:
+	/// Notifier that the fluorescence screen control has changed.
+	void screenChanged(AMControl *newControl);
+
+public slots:
+	/// Sets the fluorescence screen control.
+	void setScreen(AMControl *newControl);
 
 protected:
-	/// The mirror fluorescence screen control.
-	AMSinglePVControl *screenMotor_;
-
+	/// The fluorescence screen control.
+	AMControl *screen_;
 };
 
 #endif // BIOXASM2MIRROR_H

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -70,62 +70,62 @@ QList<AMControl *> BioXASMainBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		break;
 
 	case BioXASBeamlineDef::M1Motor:	// BioXAS M1 motors
-		matchedMotors.append(m1Mirror_->upstreamInboardMotorControl());
-		matchedMotors.append(m1Mirror_->upstreamOutboardMotorControl());
-		matchedMotors.append(m1Mirror_->downstreamMotorControl());
-		matchedMotors.append(m1Mirror_->stripeSelectMotorControl());
-		matchedMotors.append(m1Mirror_->yawMotorControl());
-		matchedMotors.append(m1Mirror_->benderUpstreamMotorControl());
-		matchedMotors.append(m1Mirror_->benderDownstreamMotorControl());
-		matchedMotors.append(m1Mirror_->upperSlitBladeMotorControl());
+		matchedMotors.append(m1Mirror_->upstreamInboardMotor());
+		matchedMotors.append(m1Mirror_->upstreamOutboardMotor());
+		matchedMotors.append(m1Mirror_->downstreamMotor());
+		matchedMotors.append(m1Mirror_->stripeSelectMotor());
+		matchedMotors.append(m1Mirror_->yawMotor());
+		matchedMotors.append(m1Mirror_->upstreamBenderMotor());
+		matchedMotors.append(m1Mirror_->downstreamBenderMotor());
+		matchedMotors.append(m1Mirror_->upperSlitBladeMotor());
 		break;
 
 	case BioXASBeamlineDef::MaskMotor:	// BioXAS Variable Mask motors
-		matchedMotors.append(mono_->upperSlitBladeMotor());
-		matchedMotors.append(mono_->lowerSlitBladeMotor());
+		matchedMotors.append(mono_->upperSlit());
+		matchedMotors.append(mono_->lowerSlit());
 		break;
 
 	case BioXASBeamlineDef::MonoMotor:	// BioXAS Mono motors
-		matchedMotors.append(mono_->paddleMotor());
-		matchedMotors.append(mono_->braggMotor());
-		matchedMotors.append(mono_->verticalMotor());
-		matchedMotors.append(mono_->lateralMotor());
-		matchedMotors.append(mono_->crystalChangeMotor());
-		matchedMotors.append(mono_->crystal1PitchMotor());
-		matchedMotors.append(mono_->crystal1RollMotor());
-		matchedMotors.append(mono_->crystal2PitchMotor());
-		matchedMotors.append(mono_->crystal2RollMotor());
+		matchedMotors.append(mono_->paddle());
+		matchedMotors.append(mono_->bragg());
+		matchedMotors.append(mono_->vertical());
+		matchedMotors.append(mono_->lateral());
+		matchedMotors.append(mono_->crystalChange());
+		matchedMotors.append(mono_->crystal1Pitch());
+		matchedMotors.append(mono_->crystal1Roll());
+		matchedMotors.append(mono_->crystal2Pitch());
+		matchedMotors.append(mono_->crystal2Roll());
 		break;
 
 	case BioXASBeamlineDef::M2Motor:	// BioXAS M2 motors
-		matchedMotors.append(m2Mirror_->upstreamInboardMotorControl());
-		matchedMotors.append(m2Mirror_->upstreamOutboardMotorControl());
-		matchedMotors.append(m2Mirror_->downstreamMotorControl());
-		matchedMotors.append(m2Mirror_->stripeSelectMotorControl());
-		matchedMotors.append(m2Mirror_->yawMotorControl());
-		matchedMotors.append(m2Mirror_->benderUpstreamMotorControl());
-		matchedMotors.append(m2Mirror_->benderDownstreamMotorControl());
+		matchedMotors.append(m2Mirror_->upstreamInboardMotor());
+		matchedMotors.append(m2Mirror_->upstreamOutboardMotor());
+		matchedMotors.append(m2Mirror_->downstreamMotor());
+		matchedMotors.append(m2Mirror_->stripeSelectMotor());
+		matchedMotors.append(m2Mirror_->yawMotor());
+		matchedMotors.append(m2Mirror_->upstreamBenderMotor());
+		matchedMotors.append(m2Mirror_->downstreamBenderMotor());
 		break;
 
 	case BioXASBeamlineDef::PseudoM1Motor: // BioXAS Pseudo M1 motor
-		matchedMotors.append(m1Mirror_->rollControl());
-		matchedMotors.append(m1Mirror_->pitchControl());
-		matchedMotors.append(m1Mirror_->heightControl());
-		matchedMotors.append(m1Mirror_->yawControl());
-		matchedMotors.append(m1Mirror_->lateralControl());
+		matchedMotors.append(m1Mirror_->roll());
+		matchedMotors.append(m1Mirror_->pitch());
+		matchedMotors.append(m1Mirror_->height());
+		matchedMotors.append(m1Mirror_->yaw());
+		matchedMotors.append(m1Mirror_->lateral());
 		break;
 
 	case BioXASBeamlineDef::PseudoM2Motor: // BioXAS Pseudo M2 motor
-		matchedMotors.append(m2Mirror_->rollControl());
-		matchedMotors.append(m2Mirror_->pitchControl());
-		matchedMotors.append(m2Mirror_->yawControl());
-		matchedMotors.append(m2Mirror_->heightControl());
-		matchedMotors.append(m2Mirror_->lateralControl());
+		matchedMotors.append(m2Mirror_->roll());
+		matchedMotors.append(m2Mirror_->pitch());
+		matchedMotors.append(m2Mirror_->yaw());
+		matchedMotors.append(m2Mirror_->height());
+		matchedMotors.append(m2Mirror_->lateral());
 		break;
 
 	case BioXASBeamlineDef::PseudoMonoMotor: // BioXAS Pseudo Mono motor
-		matchedMotors.append(mono_->energyControl());
-		matchedMotors.append(mono_->regionControl());
+		matchedMotors.append(mono_->energy());
+		matchedMotors.append(mono_->region());
 		break;
 
 	default:
@@ -148,22 +148,22 @@ AMBasicControlDetectorEmulator* BioXASMainBeamline::energySetpointDetector() con
 
 AMBasicControlDetectorEmulator* BioXASMainBeamline::encoderEnergyFeedbackDetector() const
 {
-	return detectorForControl(mono_->encoderEnergyControl());
+	return detectorForControl(mono_->encoderEnergy());
 }
 
 AMBasicControlDetectorEmulator* BioXASMainBeamline::stepEnergyFeedbackDetector() const
 {
-	return detectorForControl(mono_->stepEnergyControl());
+	return detectorForControl(mono_->stepEnergy());
 }
 
 AMBasicControlDetectorEmulator* BioXASMainBeamline::braggDetector() const
 {
-	return detectorForControl(mono_->braggMotor());
+	return detectorForControl(mono_->bragg());
 }
 
 AMBasicControlDetectorEmulator* BioXASMainBeamline::braggStepSetpointDetector() const
 {
-	return detectorForControl(mono_->braggMotor()->stepSetpointControl());
+	return detectorForControl(mono_->bragg()->stepSetpointControl());
 }
 
 AMBasicControlDetectorEmulator* BioXASMainBeamline::braggEncoderStepDegFeedbackDetector() const
@@ -183,7 +183,7 @@ void BioXASMainBeamline::setupComponents()
 
 	// Mono.
 	mono_ = new BioXASMainMonochromator(this);
-	mono_->setM1MirrorPitchControl(m1Mirror_->pitchControl());
+	mono_->setM1MirrorPitchControl(m1Mirror_->pitch());
 	connect( mono_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// M2 Mirror.
@@ -249,13 +249,13 @@ void BioXASMainBeamline::setupComponents()
 void BioXASMainBeamline::setupControlsAsDetectors()
 {
 	addControlAsDetector("ScalerDwellTimeFeedback", "ScalerDwellTimeFeedback", scaler_->dwellTimeControl());
-	addControlAsDetector("MonoEncoderEnergyFeedback", "MonoEncoderEnergyFeedback", mono_->encoderEnergyControl());
-	addControlAsDetector("MonoStepEnergyFeedback", "MonoStepEnergyFeedback", mono_->stepEnergyControl());
-	addControlAsDetector("MonoStepAngleFeedback", "MonoStepAngleFeedback", mono_->stepBraggControl());
-	addControlAsDetector("MonoStepSetpoint", "MonoStepSetpoint", mono_->braggMotor()->stepSetpointControl());
+	addControlAsDetector("MonoEncoderEnergyFeedback", "MonoEncoderEnergyFeedback", mono_->encoderEnergy());
+	addControlAsDetector("MonoStepEnergyFeedback", "MonoStepEnergyFeedback", mono_->stepEnergy());
+	addControlAsDetector("MonoStepAngleFeedback", "MonoStepAngleFeedback", mono_->stepBragg());
+	addControlAsDetector("MonoStepSetpoint", "MonoStepSetpoint", mono_->bragg()->stepSetpointControl());
 	addControlAsDetector("MonoEncoderStepsDegFeedback", "MonoEncoderStepsDegFeedback", mono_->encoderStepsDiffControl());
 
-	energySetpointDetector_ = new AMBasicControlDetectorEmulator("EnergySetpoint", "EnergySetpoint", mono_->energyControl(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+	energySetpointDetector_ = new AMBasicControlDetectorEmulator("EnergySetpoint", "EnergySetpoint", mono_->energy(), 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 	energySetpointDetector_->setControlProperty(AMBasicControlDetectorEmulator::Control::Setpoint);
 }
 
@@ -263,63 +263,63 @@ void BioXASMainBeamline::setupExposedControls()
 {
 	// M1 mirror controls
 
-	addExposedControl(m1Mirror_->upstreamInboardMotorControl());
-	addExposedControl(m1Mirror_->upstreamOutboardMotorControl());
-	addExposedControl(m1Mirror_->downstreamMotorControl());
-	addExposedControl(m1Mirror_->stripeSelectMotorControl());
-	addExposedControl(m1Mirror_->yawMotorControl());
-	addExposedControl(m1Mirror_->benderUpstreamMotorControl());
-	addExposedControl(m1Mirror_->benderDownstreamMotorControl());
-	addExposedControl(m1Mirror_->upperSlitBladeMotorControl());
+	addExposedControl(m1Mirror_->upstreamInboardMotor());
+	addExposedControl(m1Mirror_->upstreamOutboardMotor());
+	addExposedControl(m1Mirror_->downstreamMotor());
+	addExposedControl(m1Mirror_->stripeSelectMotor());
+	addExposedControl(m1Mirror_->yawMotor());
+	addExposedControl(m1Mirror_->upstreamBenderMotor());
+	addExposedControl(m1Mirror_->downstreamBenderMotor());
+	addExposedControl(m1Mirror_->upperSlitBladeMotor());
 
-	addExposedControl(m1Mirror_->rollControl());
-	addExposedControl(m1Mirror_->pitchControl());
-	addExposedControl(m1Mirror_->heightControl());
-	addExposedControl(m1Mirror_->yawControl());
-	addExposedControl(m1Mirror_->lateralControl());
-	addExposedControl(m1Mirror_->bendControl());
+	addExposedControl(m1Mirror_->roll());
+	addExposedControl(m1Mirror_->pitch());
+	addExposedControl(m1Mirror_->height());
+	addExposedControl(m1Mirror_->yaw());
+	addExposedControl(m1Mirror_->lateral());
+	addExposedControl(m1Mirror_->bend());
 
 	// Mono controls.
 
-	addExposedControl(mono_->encoderEnergyControl());
-	addExposedControl(mono_->stepEnergyControl());
-	addExposedControl(mono_->regionControl());
-	addExposedControl(mono_->braggMotor());
-	addExposedControl(mono_->braggMotor()->EGUVelocityControl());
-	addExposedControl(mono_->braggMotor()->EGUBaseVelocityControl());
-	addExposedControl(mono_->braggMotor()->EGUAccelerationControl());
-	addExposedControl(mono_->braggMotor()->preDeadBandControl());
-	addExposedControl(mono_->braggMotor()->postDeadBandControl());
-	addExposedControl(mono_->braggMotor()->encoderMovementTypeControl());
-	addExposedControl(mono_->braggMotor()->encoderStepSoftRatioControl());
-	addExposedControl(mono_->braggMotor()->encoderCalibrationSlopeControl());
-	addExposedControl(mono_->braggMotor()->stepCalibrationSlopeControl());
-	addExposedControl(mono_->braggMotor()->retries());
-	addExposedControl(mono_->verticalMotor());
-	addExposedControl(mono_->lateralMotor());
-	addExposedControl(mono_->crystal1PitchMotor());
-	addExposedControl(mono_->crystal1RollMotor());
-	addExposedControl(mono_->crystal2PitchMotor());
-	addExposedControl(mono_->crystal2RollMotor());
+	addExposedControl(mono_->encoderEnergy());
+	addExposedControl(mono_->stepEnergy());
+	addExposedControl(mono_->region());
+	addExposedControl(mono_->bragg());
+	addExposedControl(mono_->bragg()->EGUVelocityControl());
+	addExposedControl(mono_->bragg()->EGUBaseVelocityControl());
+	addExposedControl(mono_->bragg()->EGUAccelerationControl());
+	addExposedControl(mono_->bragg()->preDeadBandControl());
+	addExposedControl(mono_->bragg()->postDeadBandControl());
+	addExposedControl(mono_->bragg()->encoderMovementTypeControl());
+	addExposedControl(mono_->bragg()->encoderStepSoftRatioControl());
+	addExposedControl(mono_->bragg()->encoderCalibrationSlopeControl());
+	addExposedControl(mono_->bragg()->stepCalibrationSlopeControl());
+	addExposedControl(mono_->bragg()->retries());
+	addExposedControl(mono_->vertical());
+	addExposedControl(mono_->lateral());
+	addExposedControl(mono_->crystal1Pitch());
+	addExposedControl(mono_->crystal1Roll());
+	addExposedControl(mono_->crystal2Pitch());
+	addExposedControl(mono_->crystal2Roll());
 	addExposedControl(mono_->encoderStepsDiffControl());
 
 	// M2 mirror controls.
 
-	addExposedControl(m2Mirror_->upstreamInboardMotorControl());
-	addExposedControl(m2Mirror_->upstreamOutboardMotorControl());
-	addExposedControl(m2Mirror_->downstreamMotorControl());
-	addExposedControl(m2Mirror_->stripeSelectMotorControl());
-	addExposedControl(m2Mirror_->yawMotorControl());
-	addExposedControl(m2Mirror_->benderUpstreamMotorControl());
-	addExposedControl(m2Mirror_->benderDownstreamMotorControl());
-	addExposedControl(m2Mirror_->screenMotorControl());
+	addExposedControl(m2Mirror_->upstreamInboardMotor());
+	addExposedControl(m2Mirror_->upstreamOutboardMotor());
+	addExposedControl(m2Mirror_->downstreamMotor());
+	addExposedControl(m2Mirror_->stripeSelectMotor());
+	addExposedControl(m2Mirror_->yawMotor());
+	addExposedControl(m2Mirror_->upstreamBenderMotor());
+	addExposedControl(m2Mirror_->downstreamBenderMotor());
+	addExposedControl(m2Mirror_->screen());
 
-	addExposedControl(m2Mirror_->rollControl());
-	addExposedControl(m2Mirror_->pitchControl());
-	addExposedControl(m2Mirror_->heightControl());
-	addExposedControl(m2Mirror_->yawControl());
-	addExposedControl(m2Mirror_->lateralControl());
-	addExposedControl(m2Mirror_->bendControl());
+	addExposedControl(m2Mirror_->roll());
+	addExposedControl(m2Mirror_->pitch());
+	addExposedControl(m2Mirror_->height());
+	addExposedControl(m2Mirror_->yaw());
+	addExposedControl(m2Mirror_->lateral());
+	addExposedControl(m2Mirror_->bend());
 
 	// Carbon filter farm controls.
 

--- a/source/beamline/BioXAS/BioXASMainM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASMainM1Mirror.cpp
@@ -4,68 +4,25 @@
 BioXASMainM1Mirror::BioXASMainM1Mirror(QObject *parent) :
 	BioXASM1Mirror("MainM1Mirror", parent)
 {
-	// Initialize inherited variables.
+	setUpstreamLength(-543.725);
+	setDownstreamLength(543.725);
 
-	upstreamLength_ = -543.725;
-	downstreamLength_ = 543.725;
+	setUpstreamInboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I21-01"), QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), true, -619.125, 190.438, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamOutboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I21-02"), QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), true, -619.125, -12.763, 0.05, 2.0, this, QString(":mm")));
+	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I21-03"), QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
+	setStripeSelectMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-04 STRIPE SELECT"), QString("SMTR1607-5-I21-04"), QString("SMTR1607-5-I21-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
+	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-05 YAW"), QString("SMTR1607-5-I21-05"), QString("SMTR1607-5-I21-05 YAW"), true, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I21-06"), QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), true, 0.05, 2.0, this, QString(":lbs")));
+	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I21-07"), QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), true, 0.1, 2.0, this, QString(":lbs")));
 
-	upstreamInboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I21-01"), QString("SMTR1607-5-I21-01 VERT INB (UPSTREAM)"), true, -619.125, 190.438, 0.05, 2.0, this, QString(":mm"));
-	upstreamOutboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I21-02"), QString("SMTR1607-5-I21-02 VERT OUTB (UPSTREAM)"), true, -619.125, -12.763, 0.05, 2.0, this, QString(":mm"));
-	downstreamMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I21-03"), QString("SMTR1607-5-I21-03 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm"));
-	stripeSelectMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-04 STRIPE SELECT"), QString("SMTR1607-5-I21-04"), QString("SMTR1607-5-I21-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm"));
-	yawMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-05 YAW"), QString("SMTR1607-5-I21-05"), QString("SMTR1607-5-I21-05 YAW"), true, 0.05, 2.0, this, QString(":mm"));
-	benderUpstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I21-06"), QString("SMTR1607-5-I21-06 BENDER (UPSTREAM)"), true, 0.05, 2.0, this, QString(":lbs"));
-	benderDownstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I21-07"), QString("SMTR1607-5-I21-07 BENDER (DOWNSTREAM)"), true, 0.1, 2.0, this, QString(":lbs"));
-	upperSlitBladeMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-08 UPPER SLIT"), QString("SMTR1607-5-I21-08"), QString("SMTR1607-5-I21-08 UPPER SLIT"), true, 0.1, 2.0, this, QString(":mm"));
+	setPitch(new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this));
+	setRoll(new BioXASMirrorRollControl(name()+"RollControl", "deg", this));
+	setHeight(new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this));
+	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
+	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
+	setBend(new BioXASMainM1MirrorBendControl(name()+"BendControl", "m", this));
 
-	pitch_ = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
-	pitch_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	pitch_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	pitch_->setDownstreamMotor(downstreamMotor_);
-
-	roll_ = new BioXASMirrorRollControl(name()+"RollControl", "deg", this);
-	roll_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	roll_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	roll_->setDownstreamMotor(downstreamMotor_);
-
-	height_ = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
-	height_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	height_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	height_->setDownstreamMotor(downstreamMotor_);
-
-	lateral_ = new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this);
-	lateral_->setStripeSelectionMotor(stripeSelectMotor_);
-	lateral_->setYawMotor(yawMotor_);
-	lateral_->setUpstreamLength(upstreamLength_);
-	lateral_->setDownstreamLength(downstreamLength_);
-
-	yaw_ = new BioXASMirrorYawControl(name()+"YawControl", "deg", this);
-	yaw_->setYawMotor(yawMotor_);
-	yaw_->setStripeSelectionMotor(stripeSelectMotor_);
-	yaw_->setUpstreamLength(upstreamLength_);
-	yaw_->setDownstreamLength(downstreamLength_);
-
-	bend_ = new BioXASMainM1MirrorBendControl(name()+"BendControl", "m", this);
-	bend_->setUpstreamBenderMotor(benderUpstreamMotor_);
-	bend_->setDownstreamBenderMotor(benderDownstreamMotor_);
-
-	// Make connections.
-
-	connect( upstreamInboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( upstreamOutboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( downstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stripeSelectMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yawMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderUpstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderDownstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( upperSlitBladeMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( pitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( roll_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( height_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lateral_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yaw_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( bend_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	setUpperSlitBladeMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-08 UPPER SLIT"), QString("SMTR1607-5-I21-08"), QString("SMTR1607-5-I21-08 UPPER SLIT"), true, 0.1, 2.0, this, QString(":mm")));
 }
 
 BioXASMainM1Mirror::~BioXASMainM1Mirror()

--- a/source/beamline/BioXAS/BioXASMainM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASMainM1Mirror.cpp
@@ -1,5 +1,6 @@
 #include "BioXASMainM1Mirror.h"
 #include "beamline/BioXAS/BioXASMainM1MirrorBendControl.h"
+#include "beamline/BioXAS/BioXASMirrorMotor.h"
 
 BioXASMainM1Mirror::BioXASMainM1Mirror(QObject *parent) :
 	BioXASM1Mirror("MainM1Mirror", parent)

--- a/source/beamline/BioXAS/BioXASMainM2Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASMainM2Mirror.cpp
@@ -1,71 +1,29 @@
 #include "BioXASMainM2Mirror.h"
 #include "beamline/BioXAS/BioXASMainM2MirrorBendControl.h"
+#include "beamline/BioXAS/BioXASMirrorMotor.h"
 
 BioXASMainM2Mirror::BioXASMainM2Mirror(QObject *parent) :
 	BioXASM2Mirror("MainM2Mirror", parent)
 {
-	// Initialize member variables.
+	setUpstreamLength(-543.77);
+	setDownstreamLength(543.68);
 
-	upstreamLength_ = -543.77;
-	downstreamLength_ = 543.68;
+	setUpstreamInboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I21-15 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I21-15"), QString("SMTR1607-5-I21-15 VERT INB (UPSTREAM)"), true, -619.125, 61.933, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamOutboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I21-16 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I21-16"), QString("SMTR1607-5-I21-16 VERT OUTB (UPSTREAM)"), true, -619.125, -141.268, 0.05, 2.0, this, QString(":mm")));
+	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I21-17 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I21-17"), QString("SMTR1607-5-I21-17 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
+	setStripeSelectMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-18 STRIPE SELECT"), QString("SMTR1607-5-I21-18"), QString("SMTR1607-5-I21-18 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
+	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-19 YAW"), QString("SMTR1607-5-I21-19"), QString("SMTR1607-5-I21-19 YAW"), true, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I21-20"), QString("SMTR1607-5-I21-20 BENDER (UPSTREAM)"), true, 0.1, 2.0, this, QString(":lbs")));
+	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I21-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I21-21"), QString("SMTR1607-5-I21-21 BENDER (DOWNSTREAM)"), true, 0.1, 2.0, this, QString(":lbs")));
 
-	upstreamInboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I21-15 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I21-15"), QString("SMTR1607-5-I21-15 VERT INB (UPSTREAM)"), true, -619.125, 61.933, 0.05, 2.0, this, QString(":mm"));
-	upstreamOutboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I21-16 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I21-16"), QString("SMTR1607-5-I21-16 VERT OUTB (UPSTREAM)"), true, -619.125, -141.268, 0.05, 2.0, this, QString(":mm"));
-	downstreamMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I21-17 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I21-17"), QString("SMTR1607-5-I21-17 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm"));
-	stripeSelectMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-18 STRIPE SELECT"), QString("SMTR1607-5-I21-18"), QString("SMTR1607-5-I21-18 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm"));
-	yawMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-19 YAW"), QString("SMTR1607-5-I21-19"), QString("SMTR1607-5-I21-19 YAW"), true, 0.05, 2.0, this, QString(":mm"));
-	benderUpstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I21-20"), QString("SMTR1607-5-I21-20 BENDER (UPSTREAM)"), true, 0.1, 2.0, this, QString(":lbs"));
-	benderDownstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I21-21"), QString("SMTR1607-5-I21-21 BENDER (DOWNSTREAM)"), true, 0.1, 2.0, this, QString(":lbs"));
-	screenMotor_ = new AMSinglePVControl("M2FluorescentScreen", "VSC1607-5-I21-02:InBeam", this);
+	setPitch(new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this));
+	setRoll(new BioXASMirrorRollControl(name()+"RollControl", "deg", this));
+	setHeight(new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this));
+	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
+	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
+	setBend(new BioXASMainM2MirrorBendControl(name()+"BendControl", "m", this));
 
-	pitch_ = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
-	pitch_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	pitch_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	pitch_->setDownstreamMotor(downstreamMotor_);
-
-	roll_ = new BioXASMirrorRollControl(name()+"RollControl", "deg", this);
-	roll_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	roll_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	roll_->setDownstreamMotor(downstreamMotor_);
-
-	height_ = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
-	height_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	height_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	height_->setDownstreamMotor(downstreamMotor_);
-
-	lateral_ = new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this);
-	lateral_->setUpstreamLength(upstreamLength_);
-	lateral_->setDownstreamLength(downstreamLength_);
-	lateral_->setStripeSelectionMotor(stripeSelectMotor_);
-	lateral_->setYawMotor(yawMotor_);
-
-	yaw_ = new BioXASMirrorYawControl(name()+"YawControl", "deg", this);
-	yaw_->setUpstreamLength(upstreamLength_);
-	yaw_->setDownstreamLength(downstreamLength_);
-	yaw_->setYawMotor(yawMotor_);
-	yaw_->setStripeSelectionMotor(stripeSelectMotor_);
-
-	bend_ = new BioXASMainM2MirrorBendControl(name()+"BendControl", "m", this);
-	bend_->setUpstreamBenderMotor(benderUpstreamMotor_);
-	bend_->setDownstreamBenderMotor(benderDownstreamMotor_);
-
-	// Make connections.
-
-	connect( upstreamInboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( upstreamOutboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( downstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stripeSelectMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yawMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderUpstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderDownstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( screenMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( pitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( roll_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( height_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lateral_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yaw_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( bend_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	setScreen(new AMSinglePVControl("M2FluorescentScreen", "VSC1607-5-I21-02:InBeam", this));
 }
 
 BioXASMainM2Mirror::~BioXASMainM2Mirror()

--- a/source/beamline/BioXAS/BioXASMainMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASMainMonochromator.cpp
@@ -4,7 +4,7 @@ BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	BioXASSSRLMonochromator("MainMono", parent)
 {
 	setUpperSlit(new CLSMAXvMotor(QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), QString("SMTR1607-5-I21-09"), QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), true, 0.1, 2.0, this));
-	setLowerSLit(new CLSMAXvMotor(QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), QString("SMTR1607-5-I21-10"), QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), true, 0.1, 2.0, this));
+	setLowerSlit(new CLSMAXvMotor(QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), QString("SMTR1607-5-I21-10"), QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), true, 0.1, 2.0, this));
 	setSlitsStatus(new AMReadOnlyPVControl(QString("SlitsStatus"), QString("BL1607-5-I21:Mono:SlitsClosed"), this));
 	setPaddle(new CLSMAXvMotor(QString("SMTR1607-5-I21-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I21-11"), QString("SMTR1607-5-I21-11 PHOSPHOR PADDLE"), false, 0.1, 2.0, this));
 	setPaddleStatus(new AMReadOnlyPVControl(QString("PaddleStatus"), QString("BL1607-5-I21:Mono:PaddleExtracted"), this));

--- a/source/beamline/BioXAS/BioXASMainMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASMainMonochromator.cpp
@@ -3,104 +3,33 @@
 BioXASMainMonochromator::BioXASMainMonochromator(QObject *parent) :
 	BioXASSSRLMonochromator("MainMono", parent)
 {
-	// Create components.
+	setUpperSlit(new CLSMAXvMotor(QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), QString("SMTR1607-5-I21-09"), QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), true, 0.1, 2.0, this));
+	setLowerSLit(new CLSMAXvMotor(QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), QString("SMTR1607-5-I21-10"), QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), true, 0.1, 2.0, this));
+	setSlitsStatus(new AMReadOnlyPVControl(QString("SlitsStatus"), QString("BL1607-5-I21:Mono:SlitsClosed"), this));
+	setPaddle(new CLSMAXvMotor(QString("SMTR1607-5-I21-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I21-11"), QString("SMTR1607-5-I21-11 PHOSPHOR PADDLE"), false, 0.1, 2.0, this));
+	setPaddleStatus(new AMReadOnlyPVControl(QString("PaddleStatus"), QString("BL1607-5-I21:Mono:PaddleExtracted"), this));
+	setKeyStatus(new AMReadOnlyPVControl(QString("KeyStatus"), QString("BL1607-5-I21:Mono:KeyStatus"), this));
+	setBrakeStatus(new AMReadOnlyPVControl(QString("BrakeStatus"), QString("BL1607-5-I21:Mono:BrakeOff"), this));
+	setBraggAtCrystalChangePositionStatus(new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I21:Mono:XtalChangePos", this));
+	setCrystalChange(new CLSMAXvMotor(QString("SMTR1607-5-I21-22 XTAL XCHAGE"), QString("SMTR1607-5-I21-22"), QString("SMTR1607-5-I21-22 XTAL XCHAGE"), true, 0.05, 2.0, this));
+	setRegionAStatus(new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I21:Mono:Region:A", this));
+	setRegionBStatus(new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I21:Mono:Region:B", this));
+	setVertical(new CLSMAXvMotor(QString("SMTR1607-5-I21-13 VERTICAL"), QString("SMTR1607-5-I21-13"), QString("SMTR1607-5-I21-13 VERTICAL"), true, 0.05, 2.0, this));
+	setLateral(new CLSMAXvMotor(QString("SMTR1607-5-I21-14 LATERAL"), QString("SMTR1607-5-I21-14"), QString("SMTR1607-5-I21-14 LATERAL"), true, 0.05, 2.0, this));
+	setCrystal1Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I21-23 XTAL 1 PITCH"), QString("SMTR1607-5-I21-23"), QString("SMTR1607-5-I21-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V")));
+	setCrystal1Roll(new CLSMAXvMotor(QString("SMTR1607-5-I21-24 XTAL 1 ROLL"), QString("SMTR1607-5-I21-24"), QString("SMTR1607-5-I21-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V")));
+	setCrystal2Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I21-25 XTAL 2 PITCH"), QString("SMTR1607-5-I21-25"), QString("SMTR1607-5-I21-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V")));
+	setCrystal2Roll(new CLSMAXvMotor(QString("SMTR1607-5-I21-26 XTAL 2 ROLL"), QString("SMTR1607-5-I21-26"), QString("SMTR1607-5-I21-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V")));
 
-	upperSlit_ = new AMPVwStatusControl("UpperSlitBlade", "SMTR1607-5-I21-09:mm:fbk", "SMTR1607-5-I21-09:mm", "SMTR1607-5-I21-09:status", "SMTR1607-5-I21-09:stop", this);
-	lowerSlit_ = new AMPVwStatusControl("LowerSlitBlade", "SMTR1607-5-I21-10:mm:fbk", "SMTR1607-5-I21-10:mm", "SMTR1607-5-I21-10:status", "SMTR1607-5-I21-10:stop", this);
-	slitsStatus_ = new AMReadOnlyPVControl(QString("SlitsStatus"), QString("BL1607-5-I21:Mono:SlitsClosed"), this);
-	paddle_ = new AMPVwStatusControl("Paddle", "SMTR1607-5-I21-11:mm:fbk", "SMTR1607-5-I21-11:mm", "SMTR1607-5-I21-11:status", "SMTR1607-5-I21-11:stop", this);
-	paddleStatus_ = new AMReadOnlyPVControl(QString("PaddleStatus"), QString("BL1607-5-I21:Mono:PaddleExtracted"), this);
-	keyStatus_ = new AMReadOnlyPVControl(QString("KeyStatus"), QString("BL1607-5-I21:Mono:KeyStatus"), this);
-	brakeStatus_ = new AMReadOnlyPVControl(QString("BrakeStatus"), QString("BL1607-5-I21:Mono:BrakeOff"), this);
-	braggAtCrystalChangePositionStatus_ = new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I21:Mono:XtalChangePos", this);
-	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I21-22:mm:fbk", "SMTR1607-5-I21-22:mm", "SMTR1607-5-I21-22:status", "SMTR1607-5-I21-22:stop", this);
-	crystalChangeCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCWStatus", "SMTR1607-5-I21-22:cw", this);
-	crystalChangeCCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCCWStatus", "SMTR1607-5-I21-22:ccw", this);
-	regionAStatus_ = new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I21:Mono:Region:A", this);
-	regionBStatus_ = new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I21:Mono:Region:B", this);
+	setStepBragg(new CLSMAXvMotor(QString("SMTR1607-5-I21-12 BRAGG"), QString("SMTR1607-5-I21-12"), QString("SMTR1607-5-I21-12 BRAGG"), false, 0.05, 2.0, this, QString(":deg")));
+	setEncoderBragg(new CLSMAXvMotor(QString("SMTR1607-5-I21-12 BRAGG"), QString("SMTR1607-5-I21-12"), QString("SMTR1607-5-I21-12 BRAGG"), true, 0.05, 2.0, this, QString(":deg")));
 
-	upperSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), QString("SMTR1607-5-I21-09"), QString("SMTR1607-5-I21-09 VERT UPPER BLADE"), true, 0.1, 2.0, this);
-	lowerSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), QString("SMTR1607-5-I21-10"), QString("SMTR1607-5-I21-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
-	paddleMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I21-11"), QString("SMTR1607-5-I21-11 PHOSPHOR PADDLE"), false, 0.1, 2.0, this);
-	encoderBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-12 BRAGG"), QString("SMTR1607-5-I21-12"), QString("SMTR1607-5-I21-12 BRAGG"), true, 0.05, 2.0, this, QString(":deg"));
-	stepsBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-12 BRAGG"), QString("SMTR1607-5-I21-12"), QString("SMTR1607-5-I21-12 BRAGG"), false, 0.05, 2.0, this, QString(":deg"));
-	verticalMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-13 VERTICAL"), QString("SMTR1607-5-I21-13"), QString("SMTR1607-5-I21-13 VERTICAL"), true, 0.05, 2.0, this);
-	lateralMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-14 LATERAL"), QString("SMTR1607-5-I21-14"), QString("SMTR1607-5-I21-14 LATERAL"), true, 0.05, 2.0, this);
-	crystalChangeMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-22 XTAL XCHAGE"), QString("SMTR1607-5-I21-22"), QString("SMTR1607-5-I21-22 XTAL XCHAGE"), true, 0.05, 2.0, this);
-	crystal1PitchMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-23 XTAL 1 PITCH"), QString("SMTR1607-5-I21-23"), QString("SMTR1607-5-I21-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V"));
-	crystal1RollMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-24 XTAL 1 ROLL"), QString("SMTR1607-5-I21-24"), QString("SMTR1607-5-I21-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V"));
-	crystal2PitchMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-25 XTAL 2 PITCH"), QString("SMTR1607-5-I21-25"), QString("SMTR1607-5-I21-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V"));
-	crystal2RollMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I21-26 XTAL 2 ROLL"), QString("SMTR1607-5-I21-26"), QString("SMTR1607-5-I21-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V"));
+	setStepEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"StepEnergyControl", this));
+	setEncoderEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"EncoderEnergyControl", this));
+
+	setRegion(new BioXASSSRLMonochromatorRegionControl(name()+"RegionControl", this));
 
 	encoderStepsDiff_ = new AMReadOnlyPVControl(name()+"EncoderStepsDiffControlDeg", "BL1607-7-I21:Mono:fbk:diff", this);
-
-	// Create region control.
-
-	region_ = new BioXASSSRLMonochromatorRegionControl(name()+"RegionControl", this);
-	region_->setUpperSlitControl(upperSlit_);
-	region_->setLowerSlitControl(lowerSlit_);
-	region_->setSlitsStatusControl(slitsStatus_);
-	region_->setPaddleControl(paddle_);
-	region_->setPaddleStatusControl(paddleStatus_);
-	region_->setKeyStatusControl(keyStatus_);
-	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(braggMotor());
-	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
-	region_->setCrystalChangeControl(crystalChange_);
-	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);
-	region_->setCrystalChangeCCWLimitStatusControl(crystalChangeCCWLimitStatus_);
-	region_->setRegionAStatusControl(regionAStatus_);
-	region_->setRegionBStatusControl(regionBStatus_);
-
-	// Create energy control.
-
-	encoderEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name()+"EncoderEnergyControl", this);
-	encoderEnergy_->setBraggControl(encoderBraggMotor_);
-	encoderEnergy_->setRegionControl(region_);
-	encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
-
-	stepEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name()+"StepEnergyControl", this);
-	stepEnergy_->setBraggControl(stepsBraggMotor_);
-	stepEnergy_->setRegionControl(region_);
-	stepEnergy_->setM1MirrorPitchControl(m1Pitch_);
-
-	// Listen to connection states.
-
-	connect( upperSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lowerSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( slitsStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( paddle_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( paddleStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( keyStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( brakeStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( braggAtCrystalChangePositionStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChangeCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChangeCCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( regionAStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( regionBStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( upperSlitMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lowerSlitMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( paddleMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( encoderBraggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stepsBraggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( verticalMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lateralMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChangeMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal1PitchMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal1RollMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal2PitchMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal2RollMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( region_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( encoderEnergy_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stepEnergy_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	// Current settings.
-
-	updateConnected();
-	updateMotorSettlingTime();
 }
 
 BioXASMainMonochromator::~BioXASMainMonochromator()

--- a/source/beamline/BioXAS/BioXASMainMonochromator.h
+++ b/source/beamline/BioXAS/BioXASMainMonochromator.h
@@ -1,8 +1,6 @@
 #ifndef BIOXASMAINMONOCHROMATOR_H
 #define BIOXASMAINMONOCHROMATOR_H
 
-#include <QObject>
-
 #include "beamline/BioXAS/BioXASSSRLMonochromator.h"
 
 class BioXASMainMonochromator : public BioXASSSRLMonochromator

--- a/source/beamline/BioXAS/BioXASMirror.cpp
+++ b/source/beamline/BioXAS/BioXASMirror.cpp
@@ -10,8 +10,8 @@ BioXASMirror::BioXASMirror(const QString &name, QObject *parent) :
 	downstreamMotor_ = 0;
 	stripeSelectMotor_ = 0;
 	yawMotor_ = 0;
-	benderUpstreamMotor_ = 0;
-	benderDownstreamMotor_ = 0;
+	upstreamBenderMotor_ = 0;
+	downstreamBenderMotor_ = 0;
 
 	pitch_ = 0;
 	roll_ = 0;
@@ -37,8 +37,8 @@ bool BioXASMirror::isConnected() const
 				downstreamMotor_ && downstreamMotor_->isConnected() &&
 				stripeSelectMotor_ && stripeSelectMotor_->isConnected() &&
 				yawMotor_ && yawMotor_->isConnected() &&
-				benderUpstreamMotor_ && benderUpstreamMotor_->isConnected() &&
-				benderDownstreamMotor_ && benderDownstreamMotor_->isConnected() &&
+				upstreamBenderMotor_ && upstreamBenderMotor_->isConnected() &&
+				downstreamBenderMotor_ && downstreamBenderMotor_->isConnected() &&
 
 				pitch_ && pitch_->isConnected() &&
 				roll_ && roll_->isConnected() &&
@@ -55,7 +55,7 @@ void BioXASMirror::setUpstreamLength(double newLength)
 {
 	if (upstreamLength_ != newLength) {
 		upstreamLength_ = newLength;
-		emit upstreamMirrorChanged(upstreamLength_);
+		emit upstreamLengthChanged(upstreamLength_);
 	}
 }
 
@@ -67,7 +67,7 @@ void BioXASMirror::setDownstreamLength(double newLength)
 	}
 }
 
-void BioXASMirror::setUpstreamInboardMotor(CLSMAXvMotor *newControl)
+void BioXASMirror::setUpstreamInboardMotor(BioXASMirrorMotor *newControl)
 {
 	if (upstreamInboardMotor_ != newControl) {
 
@@ -87,7 +87,7 @@ void BioXASMirror::setUpstreamInboardMotor(CLSMAXvMotor *newControl)
 	}
 }
 
-void BioXASMirror::setUpstreamOutboardMotor(CLSMAXvMotor *newControl)
+void BioXASMirror::setUpstreamOutboardMotor(BioXASMirrorMotor *newControl)
 {
 	if (upstreamOutboardMotor_ != newControl) {
 
@@ -107,7 +107,7 @@ void BioXASMirror::setUpstreamOutboardMotor(CLSMAXvMotor *newControl)
 	}
 }
 
-void BioXASMirror::setDownstreamMotor(CLSMAXvMotor *newControl)
+void BioXASMirror::setDownstreamMotor(BioXASMirrorMotor *newControl)
 {
 	if (downstreamMotor_ != newControl) {
 
@@ -142,7 +142,7 @@ void BioXASMirror::setStripeSelectMotor(CLSMAXvMotor *newControl)
 		updateLateral();
 		updateYaw();
 
-		emit stripSelectMotorChanged(stripeSelectMotor_);
+		emit stripeSelectMotorChanged(stripeSelectMotor_);
 	}
 }
 
@@ -251,7 +251,7 @@ void BioXASMirror::setHeight(BioXASMirrorHeightControl *newControl)
 
 		updateHeight();
 
-		emit pitchChanged(height_);
+		emit heightChanged(height_);
 	}
 }
 
@@ -359,7 +359,7 @@ void BioXASMirror::updateYaw()
 void BioXASMirror::updateBend()
 {
 	if (bend_) {
-		bend_->setUpstreamBenderMotor(benderUpstreamMotor_);
-		bend_->setDownstreamBenderMotor(benderDownstreamMotor_);
+		bend_->setUpstreamBenderMotor(upstreamBenderMotor_);
+		bend_->setDownstreamBenderMotor(downstreamBenderMotor_);
 	}
 }

--- a/source/beamline/BioXAS/BioXASMirror.cpp
+++ b/source/beamline/BioXAS/BioXASMirror.cpp
@@ -50,3 +50,316 @@ bool BioXASMirror::isConnected() const
 
 	return isConnected;
 }
+
+void BioXASMirror::setUpstreamLength(double newLength)
+{
+	if (upstreamLength_ != newLength) {
+		upstreamLength_ = newLength;
+		emit upstreamMirrorChanged(upstreamLength_);
+	}
+}
+
+void BioXASMirror::setDownstreamLength(double newLength)
+{
+	if (downstreamLength_ != newLength) {
+		downstreamLength_ = newLength;
+		emit downstreamLengthChanged(downstreamLength_);
+	}
+}
+
+void BioXASMirror::setUpstreamInboardMotor(CLSMAXvMotor *newControl)
+{
+	if (upstreamInboardMotor_ != newControl) {
+
+		if (upstreamInboardMotor_)
+			removeChildControl(upstreamInboardMotor_);
+
+		upstreamInboardMotor_ = newControl;
+
+		if (upstreamInboardMotor_)
+			addChildControl(upstreamInboardMotor_);
+
+		updatePitch();
+		updateRoll();
+		updateHeight();
+
+		emit upstreamInboardMotorChanged(upstreamInboardMotor_);
+	}
+}
+
+void BioXASMirror::setUpstreamOutboardMotor(CLSMAXvMotor *newControl)
+{
+	if (upstreamOutboardMotor_ != newControl) {
+
+		if (upstreamOutboardMotor_)
+			removeChildControl(upstreamOutboardMotor_);
+
+		upstreamOutboardMotor_ = newControl;
+
+		if (upstreamOutboardMotor_)
+			addChildControl(upstreamOutboardMotor_);
+
+		updatePitch();
+		updateRoll();
+		updateHeight();
+
+		emit upstreamOutboardMotorChanged(upstreamOutboardMotor_);
+	}
+}
+
+void BioXASMirror::setDownstreamMotor(CLSMAXvMotor *newControl)
+{
+	if (downstreamMotor_ != newControl) {
+
+		if (downstreamMotor_)
+			removeChildControl(downstreamMotor_);
+
+		downstreamMotor_ = newControl;
+
+		if (downstreamMotor_)
+			addChildControl(downstreamMotor_);
+
+		updatePitch();
+		updateRoll();
+		updateHeight();
+
+		emit downstreamMotorChanged(downstreamMotor_);
+	}
+}
+
+void BioXASMirror::setStripeSelectMotor(CLSMAXvMotor *newControl)
+{
+	if (stripeSelectMotor_ != newControl) {
+
+		if (stripeSelectMotor_)
+			removeChildControl(stripeSelectMotor_);
+
+		stripeSelectMotor_ = newControl;
+
+		if (stripeSelectMotor_)
+			addChildControl(stripeSelectMotor_);
+
+		updateLateral();
+		updateYaw();
+
+		emit stripSelectMotorChanged(stripeSelectMotor_);
+	}
+}
+
+void BioXASMirror::setYawMotor(CLSMAXvMotor *newControl)
+{
+	if (yawMotor_ != newControl) {
+
+		if (yawMotor_)
+			removeChildControl(yawMotor_);
+
+		yawMotor_ = newControl;
+
+		if (yawMotor_)
+			addChildControl(yawMotor_);
+
+		updateLateral();
+		updateYaw();
+
+		emit yawMotorChanged(yawMotor_);
+	}
+}
+
+void BioXASMirror::setUpstreamBenderMotor(CLSMAXvMotor *newControl)
+{
+	if (upstreamBenderMotor_ != newControl) {
+
+		if (upstreamBenderMotor_)
+			removeChildControl(upstreamBenderMotor_);
+
+		upstreamBenderMotor_ = newControl;
+
+		if (upstreamBenderMotor_)
+			addChildControl(upstreamBenderMotor_);
+
+		updateBend();
+
+		emit upstreamBenderMotorChanged(upstreamBenderMotor_);
+	}
+}
+
+void BioXASMirror::setDownstreamBenderMotor(CLSMAXvMotor *newControl)
+{
+	if (downstreamBenderMotor_ != newControl) {
+
+		if (downstreamBenderMotor_)
+			removeChildControl(downstreamBenderMotor_);
+
+		downstreamBenderMotor_ = newControl;
+
+		if (downstreamBenderMotor_)
+			addChildControl(downstreamBenderMotor_);
+
+		updateBend();
+
+		emit downstreamBenderMotorChanged(downstreamBenderMotor_);
+	}
+}
+
+void BioXASMirror::setPitch(BioXASMirrorPitchControl *newControl)
+{
+	if (pitch_ != newControl) {
+
+		if (pitch_)
+			removeChildControl(pitch_);
+
+		pitch_ = newControl;
+
+		if (pitch_)
+			addChildControl(pitch_);
+
+		updatePitch();
+
+		emit pitchChanged(pitch_);
+	}
+}
+
+void BioXASMirror::setRoll(BioXASMirrorRollControl *newControl)
+{
+	if (roll_ != newControl) {
+
+		if (roll_)
+			removeChildControl(roll_);
+
+		roll_ = newControl;
+
+		if (roll_)
+			addChildControl(roll_);
+
+		updateRoll();
+
+		emit rollChanged(roll_);
+	}
+}
+
+void BioXASMirror::setHeight(BioXASMirrorHeightControl *newControl)
+{
+	if (height_ != newControl) {
+
+		if (height_)
+			removeChildControl(height_);
+
+		height_ = newControl;
+
+		if (height_)
+			addChildControl(height_);
+
+		updateHeight();
+
+		emit pitchChanged(height_);
+	}
+}
+
+void BioXASMirror::setLateral(BioXASMirrorLateralControl *newControl)
+{
+	if (lateral_ != newControl) {
+
+		if (lateral_)
+			removeChildControl(lateral_);
+
+		lateral_ = newControl;
+
+		if (lateral_)
+			addChildControl(lateral_);
+
+		updateLateral();
+
+		emit lateralChanged(lateral_);
+	}
+}
+
+void BioXASMirror::setYaw(BioXASMirrorYawControl *newControl)
+{
+	if (yaw_ != newControl) {
+
+		if (yaw_)
+			removeChildControl(yaw_);
+
+		yaw_ = newControl;
+
+		if (yaw_)
+			addChildControl(yaw_);
+
+		updateYaw();
+
+		emit yawChanged(yaw_);
+	}
+}
+
+void BioXASMirror::setBend(BioXASMirrorBendControl *newControl)
+{
+	if (bend_ != newControl) {
+
+		if (bend_)
+			removeChildControl(bend_);
+
+		bend_ = newControl;
+
+		if (bend_)
+			addChildControl(bend_);
+
+		updateBend();
+
+		emit bendChanged(bend_);
+	}
+}
+
+void BioXASMirror::updatePitch()
+{
+	if (pitch_) {
+		pitch_->setUpstreamInboardMotor(upstreamInboardMotor_);
+		pitch_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
+		pitch_->setDownstreamMotor(downstreamMotor_);
+	}
+}
+
+void BioXASMirror::updateRoll()
+{
+	if (roll_) {
+		roll_->setUpstreamInboardMotor(upstreamInboardMotor_);
+		roll_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
+		roll_->setDownstreamMotor(downstreamMotor_);
+	}
+}
+
+void BioXASMirror::updateHeight()
+{
+	if (height_) {
+		height_->setUpstreamInboardMotor(upstreamInboardMotor_);
+		height_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
+		height_->setDownstreamMotor(downstreamMotor_);
+	}
+}
+
+void BioXASMirror::updateLateral()
+{
+	if (lateral_) {
+		lateral_->setStripeSelectionMotor(stripeSelectMotor_);
+		lateral_->setYawMotor(yawMotor_);
+		lateral_->setUpstreamLength(upstreamLength_);
+		lateral_->setDownstreamLength(downstreamLength_);
+	}
+}
+
+void BioXASMirror::updateYaw()
+{
+	if (yaw_) {
+		yaw_->setYawMotor(yawMotor_);
+		yaw_->setStripeSelectionMotor(stripeSelectMotor_);
+		yaw_->setUpstreamLength(upstreamLength_);
+		yaw_->setDownstreamLength(downstreamLength_);
+	}
+}
+
+void BioXASMirror::updateBend()
+{
+	if (bend_) {
+		bend_->setUpstreamBenderMotor(benderUpstreamMotor_);
+		bend_->setDownstreamBenderMotor(benderDownstreamMotor_);
+	}
+}

--- a/source/beamline/BioXAS/BioXASMirror.h
+++ b/source/beamline/BioXAS/BioXASMirror.h
@@ -25,19 +25,19 @@ public:
 	virtual bool isConnected() const;
 
 	/// Returns the upstream inboard motor control.
-	CLSMAXvMotor* upstreamInboardMotor() const { return upstreamInboardMotor_; }
+	BioXASMirrorMotor* upstreamInboardMotor() const { return upstreamInboardMotor_; }
 	/// Returns the upstream outboard motor control.
-	CLSMAXvMotor* upstreamOutboardMotor() const { return upstreamOutboardMotor_; }
+	BioXASMirrorMotor* upstreamOutboardMotor() const { return upstreamOutboardMotor_; }
 	/// Returns the downstream motor control.
-	CLSMAXvMotor* downstreamMotor() const { return downstreamMotor_; }
+	BioXASMirrorMotor* downstreamMotor() const { return downstreamMotor_; }
 	/// Returns the stripe selection motor control.
 	CLSMAXvMotor* stripeSelectMotor() const { return stripeSelectMotor_; }
 	/// Returns the yaw motor control.
 	CLSMAXvMotor* yawMotor() const { return yawMotor_; }
 	/// Returns the bender upstream motor control.
-	CLSMAXvMotor* benderUpstreamMotor() const { return benderUpstreamMotor_; }
+	CLSMAXvMotor* upstreamBenderMotor() const { return upstreamBenderMotor_; }
 	/// Returns the bender downstream motor control.
-	CLSMAXvMotor* benderDownstreamMotor() const { return benderDownstreamMotor_; }
+	CLSMAXvMotor* downstreamBenderMotor() const { return downstreamBenderMotor_; }
 
 	/// Returns the pitch control.
 	BioXASMirrorPitchControl* pitch() const { return pitch_; }
@@ -59,17 +59,17 @@ public:
 
 signals:
 	/// Notifier that the upstream mirror length has changed.
-	void upstreamMirrorLengthChanged(double newLength);
+	void upstreamLengthChanged(double newLength);
 	/// Notifier that the downstream mirror length has changed.
-	void downstreamMirrorLengthChanged(double newLength);
+	void downstreamLengthChanged(double newLength);
 	/// Notifier that the upstream inboard motor control has changed.
-	void upstreamInboardMotorChanged(CLSMAXvMotor *newControl);
+	void upstreamInboardMotorChanged(BioXASMirrorMotor *newControl);
 	/// Notifier that the upstream outboard motor control has changed.
-	void upstreamOutboardMotorChanged(CLSMAXvMotor *newControl);
+	void upstreamOutboardMotorChanged(BioXASMirrorMotor *newControl);
 	/// Notifier that the downstream motor control has changed.
-	void downstreamMotorChanged(CLSMAXvMotor *newControl);
+	void downstreamMotorChanged(BioXASMirrorMotor *newControl);
 	/// Notifier that the stripe selection motor control has changed.
-	void stripeSelectionMotorChanged(CLSMAXvMotor *newControl);
+	void stripeSelectMotorChanged(CLSMAXvMotor *newControl);
 	/// Notifier that the yaw motor control has changed.
 	void yawMotorChanged(CLSMAXvMotor *newControl);
 	/// Notifier that the upstream bender motor control has changed.
@@ -96,11 +96,11 @@ protected slots:
 	void setDownstreamLength(double newLength);
 
 	/// Sets the upstream inboard motor control.
-	void setUpstreamInboardMotor(CLSMAXvMotor *newControl);
+	void setUpstreamInboardMotor(BioXASMirrorMotor *newControl);
 	/// Sets the upstream outboard motor control.
-	void setUpstreamOutboardMotor(CLSMAXvMotor *newControl);
+	void setUpstreamOutboardMotor(BioXASMirrorMotor *newControl);
 	/// Sets the downstream motor control.
-	void setDownstreamMotor(CLSMAXvMotor *newControl);
+	void setDownstreamMotor(BioXASMirrorMotor *newControl);
 	/// Sets the stripe select motor control.
 	void setStripeSelectMotor(CLSMAXvMotor *newControl);
 	/// Sets the yaw motor control.

--- a/source/beamline/BioXAS/BioXASMirror.h
+++ b/source/beamline/BioXAS/BioXASMirror.h
@@ -25,39 +25,118 @@ public:
 	virtual bool isConnected() const;
 
 	/// Returns the upstream inboard motor control.
-	AMControl* upstreamInboardMotorControl() const { return upstreamInboardMotor_; }
+	CLSMAXvMotor* upstreamInboardMotor() const { return upstreamInboardMotor_; }
 	/// Returns the upstream outboard motor control.
-	AMControl* upstreamOutboardMotorControl() const { return upstreamOutboardMotor_; }
+	CLSMAXvMotor* upstreamOutboardMotor() const { return upstreamOutboardMotor_; }
 	/// Returns the downstream motor control.
-	AMControl* downstreamMotorControl() const { return downstreamMotor_; }
+	CLSMAXvMotor* downstreamMotor() const { return downstreamMotor_; }
 	/// Returns the stripe selection motor control.
-	AMControl* stripeSelectMotorControl() const { return stripeSelectMotor_; }
+	CLSMAXvMotor* stripeSelectMotor() const { return stripeSelectMotor_; }
 	/// Returns the yaw motor control.
-	AMControl* yawMotorControl() const { return yawMotor_; }
+	CLSMAXvMotor* yawMotor() const { return yawMotor_; }
 	/// Returns the bender upstream motor control.
-	AMControl* benderUpstreamMotorControl() const { return benderUpstreamMotor_; }
+	CLSMAXvMotor* benderUpstreamMotor() const { return benderUpstreamMotor_; }
 	/// Returns the bender downstream motor control.
-	AMControl* benderDownstreamMotorControl() const { return benderDownstreamMotor_; }
+	CLSMAXvMotor* benderDownstreamMotor() const { return benderDownstreamMotor_; }
 
 	/// Returns the pitch control.
-	AMControl* pitchControl() const { return pitch_; }
+	BioXASMirrorPitchControl* pitch() const { return pitch_; }
 	/// Returns the roll control.
-	AMControl* rollControl() const { return roll_; }
+	BioXASMirrorRollControl* roll() const { return roll_; }
 	/// Returns the height control.
-	AMControl* heightControl() const { return height_; }
+	BioXASMirrorHeightControl* height() const { return height_; }
 	/// Returns the lateral control.
-	AMControl* lateralControl() const { return lateral_; }
+	BioXASMirrorLateralControl* lateral() const { return lateral_; }
 	/// Returns the yaw control.
-	AMControl* yawControl() const { return yaw_; }
-	/// Returns the bend radius control.
-	AMControl* bendControl() const { return bend_; }
+	BioXASMirrorYawControl* yaw() const { return yaw_; }
+	/// Returns the bend control.
+	BioXASMirrorBendControl* bend() const { return bend_; }
 
 	/// Returns the upstream mirror length.
 	double upstreamLength() const { return upstreamLength_; }
 	/// Returns the downstream mirror length.
 	double downstreamLength() const { return downstreamLength_; }
 
-protected:
+signals:
+	/// Notifier that the upstream mirror length has changed.
+	void upstreamMirrorLengthChanged(double newLength);
+	/// Notifier that the downstream mirror length has changed.
+	void downstreamMirrorLengthChanged(double newLength);
+	/// Notifier that the upstream inboard motor control has changed.
+	void upstreamInboardMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the upstream outboard motor control has changed.
+	void upstreamOutboardMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the downstream motor control has changed.
+	void downstreamMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the stripe selection motor control has changed.
+	void stripeSelectionMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the yaw motor control has changed.
+	void yawMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the upstream bender motor control has changed.
+	void upstreamBenderMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the downstream bender motor control has changed.
+	void downstreamBenderMotorChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the pitch control has changed.
+	void pitchChanged(BioXASMirrorPitchControl *newControl);
+	/// Notifier that the roll control has changed.
+	void rollChanged(BioXASMirrorRollControl *newControl);
+	/// Notifier that the height control has changed.
+	void heightChanged(BioXASMirrorHeightControl *newControl);
+	/// Notifier that the lateral control has changed.
+	void lateralChanged(BioXASMirrorLateralControl *newControl);
+	/// Notifier that the yaw control has changed.
+	void yawChanged(BioXASMirrorYawControl *newControl);
+	/// Notifier that the bend control has changed.
+	void bendChanged(BioXASMirrorBendControl *newControl);
+
+protected slots:
+	/// Sets the upstream mirror length.
+	void setUpstreamLength(double newLength);
+	/// Sets the downstream mirror length.
+	void setDownstreamLength(double newLength);
+
+	/// Sets the upstream inboard motor control.
+	void setUpstreamInboardMotor(CLSMAXvMotor *newControl);
+	/// Sets the upstream outboard motor control.
+	void setUpstreamOutboardMotor(CLSMAXvMotor *newControl);
+	/// Sets the downstream motor control.
+	void setDownstreamMotor(CLSMAXvMotor *newControl);
+	/// Sets the stripe select motor control.
+	void setStripeSelectMotor(CLSMAXvMotor *newControl);
+	/// Sets the yaw motor control.
+	void setYawMotor(CLSMAXvMotor *newControl);
+	/// Sets the upstream bender motor control.
+	void setUpstreamBenderMotor(CLSMAXvMotor *newControl);
+	/// Sets the downstream bender motor control.
+	void setDownstreamBenderMotor(CLSMAXvMotor *newControl);
+
+	/// Sets the pitch control.
+	void setPitch(BioXASMirrorPitchControl *newControl);
+	/// Sets the roll control.
+	void setRoll(BioXASMirrorRollControl *newControl);
+	/// Sets the height control.
+	void setHeight(BioXASMirrorHeightControl *newControl);
+	/// Sets the lateral control.
+	void setLateral(BioXASMirrorLateralControl *newControl);
+	/// Sets the yaw control.
+	void setYaw(BioXASMirrorYawControl *newControl);
+	/// Sets the bend control.
+	void setBend(BioXASMirrorBendControl *newControl);
+
+	/// Updates the pitch control.
+	void updatePitch();
+	/// Updates the roll control.
+	void updateRoll();
+	/// Updates the height control.
+	void updateHeight();
+	/// Updates the lateral control.
+	void updateLateral();
+	/// Updates the yaw control.
+	void updateYaw();
+	/// Updates the bend control.
+	void updateBend();
+
+private:
 	/// The upstream inboard motor control.
 	BioXASMirrorMotor *upstreamInboardMotor_;
 	/// The upstream outboard motor control.
@@ -69,9 +148,9 @@ protected:
 	/// The yaw motor control.
 	CLSMAXvMotor *yawMotor_;
 	/// The bender upstream motor control.
-	CLSMAXvMotor *benderUpstreamMotor_;
+	CLSMAXvMotor *upstreamBenderMotor_;
 	/// The bender downstream motor control.
-	CLSMAXvMotor *benderDownstreamMotor_;
+	CLSMAXvMotor *downstreamBenderMotor_;
 
 	/// The pitch pseudomotor control.
 	BioXASMirrorPitchControl *pitch_;

--- a/source/beamline/BioXAS/BioXASMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASMonochromator.cpp
@@ -1,12 +1,39 @@
 #include "BioXASMonochromator.h"
+#include "beamline/BioXAS/BioXASMonochromatorEnergyControl.h"
+#include "beamline/CLS/CLSMAXvMotor.h"
 
 BioXASMonochromator::BioXASMonochromator(const QString &name, QObject *parent) :
 	BioXASBeamlineComponent(name, parent)
 {
+	// Initialize class variables.
 
+	energy_ = 0;
 }
 
 BioXASMonochromator::~BioXASMonochromator()
 {
 
+}
+
+bool BioXASMonochromator::isConnected() const
+{
+	bool connected = ( energy_ && energy_->isConnected() );
+
+	return connected;
+}
+
+void BioXASMonochromator::setEnergy(BioXASMonochromatorEnergyControl *newControl)
+{
+	if (energy_ != newControl) {
+
+		if (energy_)
+			removeChildControl(energy_);
+
+		energy_ = newControl;
+
+		if (energy_)
+			addChildControl(energy_);
+
+		emit energyChanged(energy_);
+	}
 }

--- a/source/beamline/BioXAS/BioXASMonochromator.h
+++ b/source/beamline/BioXAS/BioXASMonochromator.h
@@ -14,11 +14,10 @@ public:
 	/// Destructor.
 	virtual ~BioXASMonochromator();
 
-	/// Returns the energy control.
-	virtual BioXASMonochromatorEnergyControl* energyControl() const = 0;
-
 	/// Returns the bragg motor.
-	virtual AMControl* braggMotor() const = 0;
+	virtual AMControl* bragg() const = 0;
+	/// Returns the energy control.
+	virtual BioXASMonochromatorEnergyControl* energy() const = 0;
 };
 
 #endif // BIOXASMONOCHROMATOR_H

--- a/source/beamline/BioXAS/BioXASMonochromator.h
+++ b/source/beamline/BioXAS/BioXASMonochromator.h
@@ -2,7 +2,9 @@
 #define BIOXASMONOCHROMATOR_H
 
 #include "beamline/BioXAS/BioXASBeamlineComponent.h"
-#include "beamline/BioXAS/BioXASMonochromatorEnergyControl.h"
+
+class BioXASMonochromatorEnergyControl;
+class CLSMAXvMotor;
 
 class BioXASMonochromator : public BioXASBeamlineComponent
 {
@@ -14,10 +16,24 @@ public:
 	/// Destructor.
 	virtual ~BioXASMonochromator();
 
-	/// Returns the bragg motor.
-	virtual AMControl* bragg() const = 0;
+	/// Returns true if connected, false otherwise.
+	virtual bool isConnected() const;
+
 	/// Returns the energy control.
-	virtual BioXASMonochromatorEnergyControl* energy() const = 0;
+	BioXASMonochromatorEnergyControl* energy() const { return energy_; }
+
+signals:
+	/// Notifier that the energy control has changed.
+	void energyChanged(BioXASMonochromatorEnergyControl *newControl);
+
+
+protected slots:
+	/// Sets the energy control.
+	virtual void setEnergy(BioXASMonochromatorEnergyControl *newControl);
+
+protected:
+	/// The energy control.
+	BioXASMonochromatorEnergyControl *energy_;
 };
 
 #endif // BIOXASMONOCHROMATOR_H

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -6,12 +6,6 @@ BioXASSSRLMonochromator::BioXASSSRLMonochromator(const QString &name, QObject *p
 {
 	// Initialize local variables.
 
-	settlingTime_ = 0.01;
-
-	encoderEnergy_ = 0;
-	stepEnergy_ = 0;
-	region_ = 0;
-
 	upperSlit_ = 0;
 	lowerSlit_ = 0;
 	slitsStatus_ = 0;
@@ -21,25 +15,27 @@ BioXASSSRLMonochromator::BioXASSSRLMonochromator(const QString &name, QObject *p
 	brakeStatus_ = 0;
 	braggAtCrystalChangePositionStatus_ = 0;
 	crystalChange_ = 0;
-	crystalChangeCWLimitStatus_ = 0;
-	crystalChangeCCWLimitStatus_ = 0;
 	regionAStatus_ = 0;
 	regionBStatus_ = 0;
+	vertical_ = 0;
+	lateral_ = 0;
+	crystalChange_ = 0;
+	crystal1Pitch_ = 0;
+	crystal1Roll_ = 0;
+	crystal2Pitch_ = 0;
+	crystal2Roll_ = 0;
 
 	m1Pitch_ = 0;
 
-	upperSlitMotor_ = 0;
-	lowerSlitMotor_ = 0;
-	paddleMotor_ = 0;
-	stepsBraggMotor_ = 0;
-	encoderBraggMotor_ = 0;
-	verticalMotor_ = 0;
-	lateralMotor_ = 0;
-	crystalChangeMotor_ = 0;
-	crystal1PitchMotor_ = 0;
-	crystal1RollMotor_ = 0;
-	crystal2PitchMotor_ = 0;
-	crystal2RollMotor_ = 0;
+	encoderBragg_ = 0;
+	stepBragg_ = 0;
+
+	stepEnergy_ = 0;
+	encoderEnergy_ = 0;
+
+	region_ = 0;
+
+	settlingTime_ = 0.01;
 }
 
 BioXASSSRLMonochromator::~BioXASSSRLMonochromator()
@@ -50,50 +46,437 @@ BioXASSSRLMonochromator::~BioXASSSRLMonochromator()
 bool BioXASSSRLMonochromator::isConnected() const
 {
 	bool connected = (
-		encoderEnergy_ && encoderEnergy_->isConnected() &&
-		stepEnergy_ && stepEnergy_->isConnected() &&
-		region_ && region_->isConnected() &&
 
-		upperSlit_ && upperSlit_->isConnected() &&
-		lowerSlit_ && lowerSlit_->isConnected() &&
-		slitsStatus_ && slitsStatus_->isConnected() &&
-		paddle_ && paddle_->isConnected() &&
-		paddleStatus_ && paddleStatus_->isConnected() &&
-		keyStatus_ && keyStatus_->isConnected() &&
-		brakeStatus_ && brakeStatus_->isConnected() &&
-		braggAtCrystalChangePositionStatus_ && braggAtCrystalChangePositionStatus_->isConnected() &&
-		crystalChange_ && crystalChange_->isConnected() &&
-		crystalChangeCWLimitStatus_ && crystalChangeCWLimitStatus_->isConnected() &&
-		crystalChangeCCWLimitStatus_ && crystalChangeCCWLimitStatus_->isConnected() &&
-		regionAStatus_ && regionAStatus_->isConnected() &&
-		regionBStatus_ && regionBStatus_->isConnected() &&
+				upperSlit_ && upperSlit_->isConnected() &&
+				lowerSlit_ && lowerSlit_->isConnected() &&
+				slitsStatus_ && slitsStatus_->isConnected() &&
+				paddle_ && paddle_->isConnected() &&
+				paddleStatus_ && paddleStatus_->isConnected() &&
+				keyStatus_ && keyStatus_->isConnected() &&
+				brakeStatus_ && brakeStatus_->isConnected() &&
+				braggAtCrystalChangePositionStatus_ && braggAtCrystalChangePositionStatus_->isConnected() &&
+				crystalChange_ && crystalChange_->isConnected() &&
+				regionAStatus_ && regionAStatus_->isConnected() &&
+				regionBStatus_ && regionBStatus_->isConnected() &&
+				vertical_ && vertical_->isConnected() &&
+				lateral_ && lateral_->isConnected() &&
+				crystalChange_ && crystalChange_->isConnected() &&
+				crystal1Pitch_ && crystal1Pitch_->isConnected() &&
+				crystal1Roll_ && crystal1Roll_->isConnected() &&
+				crystal2Pitch_ && crystal2Pitch_->isConnected() &&
+				crystal2Roll_ && crystal2Roll_->isConnected() &&
 
-		m1Pitch_ && m1Pitch_->isConnected() &&
+				m1Pitch_ && m1Pitch_->isConnected() &&
 
-		upperSlitMotor_ && upperSlitMotor_->isConnected() &&
-		lowerSlitMotor_ && lowerSlitMotor_->isConnected() &&
-		paddleMotor_ && paddleMotor_->isConnected() &&
-		encoderBraggMotor_ && encoderBraggMotor_->isConnected() &&
-		stepsBraggMotor_ && stepsBraggMotor_->isConnected() &&
-		verticalMotor_ && verticalMotor_->isConnected() &&
-		lateralMotor_ && lateralMotor_->isConnected() &&
-		crystalChangeMotor_ && crystalChangeMotor_->isConnected() &&
-		crystal1PitchMotor_ && crystal1PitchMotor_->isConnected() &&
-		crystal1RollMotor_ && crystal1RollMotor_->isConnected() &&
-		crystal2PitchMotor_ && crystal2PitchMotor_->isConnected() &&
-		crystal2RollMotor_ && crystal2RollMotor_->isConnected()
-	);
+				stepBragg_ && stepBragg_->isConnected() &&
+				encoderBragg_ && encoderBragg_->isConnected() &&
+
+				stepEnergy_ && stepEnergy_->isConnected() &&
+				encoderEnergy_ && encoderEnergy_->isConnected() &&
+
+				region_ && region_->isConnected()
+
+				);
 
 	return connected;
+}
+
+void BioXASSSRLMonochromator::setUpperSlit(CLSMAXvMotor *newControl)
+{
+	if (upperSlit_ != newControl) {
+
+		if (upperSlit_)
+			removeChildControl(upperSlit_);
+
+		upperSlit_ = newControl;
+
+		if (upperSlit_)
+			addChildControl(upperSlit_);
+
+		updateRegion();
+
+		emit upperSlitChanged(upperSlit_);
+	}
+}
+
+void BioXASSSRLMonochromator::setLowerSlit(CLSMAXvMotor *newControl)
+{
+	if (lowerSlit_ != newControl) {
+
+		if (lowerSlit_)
+			removeChildControl(lowerSlit_);
+
+		lowerSlit_ = newControl;
+
+		if (lowerSlit_)
+			addChildControl(lowerSlit_);
+
+		updateRegion();
+
+		emit lowerSlitChanged(lowerSlit_);
+	}
+}
+
+void BioXASSSRLMonochromator::setSlitsStatus(AMControl *newControl)
+{
+	if (slitsStatus_ != newControl) {
+
+		if (slitsStatus_)
+			removeChildControl(slitsStatus_);
+
+		slitsStatus_ = newControl;
+
+		if (slitsStatus_)
+			addChildControl(slitsStatus_);
+
+		updateRegion();
+
+		emit slitsStatusChanged(slitsStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setPaddle(CLSMAXvMotor *newControl)
+{
+	if (paddle_ != newControl) {
+
+		if (paddle_)
+			removeChildControl(paddle_);
+
+		paddle_ = newControl;
+
+		if (paddle_)
+			addChildControl(paddle_);
+
+		updateRegion();
+
+		emit paddleChanged(paddle_);
+	}
+}
+
+void BioXASSSRLMonochromator::setPaddleStatus(AMControl *newControl)
+{
+	if (paddleStatus_ != newControl) {
+
+		if (paddleStatus_)
+			removeChildControl(paddleStatus_);
+
+		paddleStatus_ = newControl;
+
+		if (paddleStatus_)
+			addChildControl(paddleStatus_);
+
+		updateRegion();
+
+		emit paddleStatusChanged(paddleStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setKeyStatus(AMControl *newControl)
+{
+	if (keyStatus_ != newControl) {
+
+		if (keyStatus_)
+			removeChildControl(keyStatus_);
+
+		keyStatus_ = newControl;
+
+		if (keyStatus_)
+			addChildControl(keyStatus_);
+
+		updateRegion();
+
+		emit keyStatusChanged(keyStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setBrakeStatus(AMControl *newControl)
+{
+	if (brakeStatus_ != newControl) {
+
+		if (brakeStatus_)
+			removeChildControl(brakeStatus_);
+
+		brakeStatus_ = newControl;
+
+		if (brakeStatus_)
+			addChildControl(brakeStatus_);
+
+		updateRegion();
+
+		emit brakeStatusChanged(brakeStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setBraggAtCrystalChangePositionStatus(AMControl *newControl)
+{
+	if (braggAtCrystalChangePositionStatus_ != newControl) {
+
+		if (braggAtCrystalChangePositionStatus_)
+			removeChildControl(braggAtCrystalChangePositionStatus_);
+
+		braggAtCrystalChangePositionStatus_ = newControl;
+
+		if (braggAtCrystalChangePositionStatus_)
+			addChildControl(braggAtCrystalChangePositionStatus_);
+
+		updateRegion();
+
+		emit braggAtCrystalChangePositionStatusChanged(braggAtCrystalChangePositionStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setCrystalChange(CLSMAXvMotor *newControl)
+{
+	if (crystalChange_ != newControl) {
+
+		if (crystalChange_)
+			removeChildControl(crystalChange_);
+
+		crystalChange_ = newControl;
+
+		if (crystalChange_)
+			addChildControl(crystalChange_);
+
+		updateRegion();
+
+		emit crystalChangeChanged(crystalChange_);
+	}
+}
+
+void BioXASSSRLMonochromator::setRegionAStatus(AMControl *newControl)
+{
+	if (regionAStatus_ != newControl) {
+
+		if (regionAStatus_)
+			removeChildControl(regionAStatus_);
+
+		regionAStatus_ = newControl;
+
+		if (regionAStatus_)
+			addChildControl(regionAStatus_);
+
+		updateRegion();
+
+		emit regionAStatusChanged(regionAStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setRegionBStatus(AMControl *newControl)
+{
+	if (regionBStatus_ != newControl) {
+
+		if (regionBStatus_)
+			removeChildControl(regionBStatus_);
+
+		regionBStatus_ = newControl;
+
+		if (regionBStatus_)
+			addChildControl(regionBStatus_);
+
+		updateRegion();
+
+		emit regionBStatusChanged(regionBStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setVertical(CLSMAXvMotor *newControl)
+{
+	if (regionBStatus_ != newControl) {
+
+		if (regionBStatus_)
+			removeChildControl(regionBStatus_);
+
+		regionBStatus_ = newControl;
+
+		if (regionBStatus_)
+			addChildControl(regionBStatus_);
+
+		emit regionBStatusChanged(regionBStatus_);
+	}
+}
+
+void BioXASSSRLMonochromator::setLateral(CLSMAXvMotor *newControl)
+{
+	if (lateral_ != newControl) {
+
+		if (lateral_)
+			removeChildControl(lateral_);
+
+		lateral_ = newControl;
+
+		if (lateral_)
+			addChildControl(lateral_);
+
+		emit lateralChanged(lateral_);
+	}
+}
+
+void BioXASSSRLMonochromator::setCrystal1Pitch(CLSMAXvMotor *newControl)
+{
+	if (crystal1Pitch_ != newControl) {
+
+		if (crystal1Pitch_)
+			removeChildControl(crystal1Pitch_);
+
+		crystal1Pitch_ = newControl;
+
+		if (crystal1Pitch_)
+			addChildControl(crystal1Pitch_);
+
+		emit crystal1PitchChanged(crystal1Pitch_);
+	}
+}
+
+void BioXASSSRLMonochromator::setCrystal1Roll(CLSMAXvMotor *newControl)
+{
+	if (crystal1Roll_ != newControl) {
+
+		if (crystal1Roll_)
+			removeChildControl(crystal1Roll_);
+
+		crystal1Roll_ = newControl;
+
+		if (crystal1Roll_)
+			addChildControl(crystal1Roll_);
+
+		emit crystal1RollChanged(crystal1Roll_);
+	}
+}
+
+void BioXASSSRLMonochromator::setCrystal2Pitch(CLSMAXvMotor *newControl)
+{
+	if (crystal2Pitch_ != newControl) {
+
+		if (crystal2Pitch_)
+			removeChildControl(crystal2Pitch_);
+
+		crystal2Pitch_ = newControl;
+
+		if (crystal2Pitch_)
+			addChildControl(crystal2Pitch_);
+
+		emit crystal2PitchChanged(crystal2Pitch_);
+	}
+}
+
+void BioXASSSRLMonochromator::setCrystal2Roll(CLSMAXvMotor *newControl)
+{
+	if (crystal2Roll_ != newControl) {
+
+		if (crystal2Roll_)
+			removeChildControl(crystal2Roll_);
+
+		crystal2Roll_ = newControl;
+
+		if (crystal2Roll_)
+			addChildControl(crystal2Roll_);
+
+		emit crystal2RollChanged(crystal2Roll_);
+	}
 }
 
 void BioXASSSRLMonochromator::setM1MirrorPitchControl(AMControl *newControl)
 {
 	if (m1Pitch_ != newControl) {
+
+		if (m1Pitch_)
+			removeChildControl(m1Pitch_);
+
 		m1Pitch_ = newControl;
-		encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
-		stepEnergy_->setM1MirrorPitchControl(m1Pitch_);
+
+		if (m1Pitch_)
+			addChildControl(m1Pitch_);
+
+		updateStepEnergy();
+		updateEncoderEnergy();
+
 		emit m1MirrorPitchControlChanged(m1Pitch_);
+	}
+}
+
+void BioXASSSRLMonochromator::setStepBragg(CLSMAXvMotor *newControl)
+{
+	if (stepBragg_ != newControl) {
+
+		if (stepBragg_)
+			removeChildControl(stepBragg_);
+
+		stepBragg_ = newControl;
+
+		if (stepBragg_)
+			addChildControl(stepBragg_);
+
+		updateRegion();
+
+		emit stepBraggChanged(stepBragg_);
+	}
+}
+
+void BioXASSSRLMonochromator::setEncoderBragg(CLSMAXvMotor *newControl)
+{
+	if (encoderBragg_ != newControl) {
+
+		if (encoderBragg_)
+			removeChildControl(encoderBragg_);
+
+		encoderBragg_ = newControl;
+
+		if (encoderBragg_)
+			addChildControl(encoderBragg_);
+
+		updateRegion();
+
+		emit encoderBraggChanged(encoderBragg_);
+	}
+}
+
+void BioXASSSRLMonochromator::setStepEnergy(BioXASSSRLMonochromatorEnergyControl *newControl)
+{
+	if (stepEnergy_ != newControl) {
+
+		if (stepEnergy_)
+			removeChildControl(stepEnergy_);
+
+		stepEnergy_ = newControl;
+
+		if (stepEnergy_)
+			addChildControl(stepEnergy_);
+
+		emit stepEnergyChanged(stepEnergy_);
+	}
+}
+
+void BioXASSSRLMonochromator::setEncoderEnergy(BioXASSSRLMonochromatorEnergyControl *newControl)
+{
+	if (encoderEnergy_ != newControl) {
+
+		if (encoderEnergy_)
+			removeChildControl(encoderEnergy_);
+
+		encoderEnergy_ = newControl;
+
+		if (encoderEnergy_)
+			addChildControl(encoderEnergy_);
+
+		emit encoderEnergyChanged(encoderEnergy_);
+	}
+}
+
+void BioXASSSRLMonochromator::setRegion(BioXASSSRLMonochromatorRegionControl *newControl)
+{
+	if (region_ != newControl) {
+
+		if (region_)
+			removeChildControl(region_);
+
+		region_ = newControl;
+
+		if (region_)
+			addChildControl(region_);
+
+		updateRegion();
+
+		emit regionChanged(region_);
 	}
 }
 
@@ -108,11 +491,41 @@ void BioXASSSRLMonochromator::setSettlingTime(double newTimeSeconds)
 	}
 }
 
+void BioXASSSRLMonochromator::updateStepEnergy()
+{
+	if (stepEnergy_)
+		stepEnergy_->setM1MirrorPitchControl(m1Pitch_);
+}
+
+void BioXASSSRLMonochromator::updateEncoderEnergy()
+{
+	if (encoderEnergy_)
+		encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
+}
+
+void BioXASSSRLMonochromator::updateRegion()
+{
+	if (region_) {
+		region_->setUpperSlitControl(upperSlit_);
+		region_->setLowerSlitControl(lowerSlit_);
+		region_->setSlitsStatusControl(slitsStatus_);
+		region_->setPaddleControl(paddle_);
+		region_->setPaddleStatusControl(paddleStatus_);
+		region_->setKeyStatusControl(keyStatus_);
+		region_->setBrakeStatusControl(brakeStatus_);
+		region_->setBraggControl(bragg());
+		region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
+		region_->setCrystalChangeControl(crystalChange_);
+		region_->setRegionAStatusControl(regionAStatus_);
+		region_->setRegionBStatusControl(regionBStatus_);
+	}
+}
+
 void BioXASSSRLMonochromator::updateMotorSettlingTime()
 {
-	if (encoderBraggMotor_)
-		encoderBraggMotor_->setSettlingTime(settlingTime_);
+	if (stepBragg_)
+		stepBragg_->setSettlingTime(settlingTime_);
 
-	if (stepsBraggMotor_)
-		stepsBraggMotor_->setSettlingTime(settlingTime_);
+	if (encoderBragg_)
+		encoderBragg_->setSettlingTime(settlingTime_);
 }

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -492,6 +492,9 @@ void BioXASSSRLMonochromator::setStepEnergy(BioXASSSRLMonochromatorEnergyControl
 		if (stepEnergy_)
 			addChildControl(stepEnergy_);
 
+		updateStepEnergy();
+		updateEnergy();
+
 		emit stepEnergyChanged(stepEnergy_);
 	}
 }
@@ -507,6 +510,9 @@ void BioXASSSRLMonochromator::setEncoderEnergy(BioXASSSRLMonochromatorEnergyCont
 
 		if (encoderEnergy_)
 			addChildControl(encoderEnergy_);
+
+		updateEncoderEnergy();
+		updateEnergy();
 
 		emit encoderEnergyChanged(encoderEnergy_);
 	}

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.h
@@ -38,155 +38,237 @@ public:
 	/// Returns true if the mono is connected, false otherwise.
 	virtual bool isConnected() const;
 
+	/// Returns the upper slit control.
+	CLSMAXvMotor* upperSlit() const { return upperSlit_; }
+	/// Returns the lower slit control.
+	CLSMAXvMotor* lowerSlit() const { return lowerSlit_; }
+	/// Returns the slits status control.
+	AMControl* slitsStatus() const { return slitsStatus_; }
+	/// Returns the paddle control.
+	CLSMAXvMotor* paddle() const { return paddle_; }
+	/// Returns the paddle status control.
+	AMControl* paddleStatus() const { return paddleStatus_; }
+	/// Returns the key status control.
+	AMControl* keyStatus() const { return keyStatus_; }
+	/// Returns the brake status control.
+	AMControl* brakeStatus() const { return brakeStatus_; }
+	/// Returns the bragg motor at crystal change position status control.
+	AMControl* braggAtCrystalChangePositionStatus() const { return braggAtCrystalChangePositionStatus_; }
+	/// Returns the crystal change control.
+	CLSMAXvMotor* crystalChange() const { return crystalChange_; }
+	/// Returns the region A status control.
+	AMControl* regionAStatus() const { return regionAStatus_; }
+	/// Returns the region B status control.
+	AMControl* regionBStatus() const { return regionBStatus_; }
+	/// Returns the vertical motor.
+	CLSMAXvMotor* vertical() const { return vertical_; }
+	/// Returns the lateral motor.
+	CLSMAXvMotor* lateral() const { return lateral_; }
+	/// Returns the crystal 1 pitch motor.
+	CLSMAXvMotor* crystal1Pitch() const { return crystal1Pitch_; }
+	/// Returns the crystal 1 roll motor.
+	CLSMAXvMotor* crystal1Roll() const { return crystal1Roll_; }
+	/// Returns the crystal 2 pitch motor.
+	CLSMAXvMotor* crystal2Pitch() const { return crystal2Pitch_; }
+	/// Returns the crystal 2 roll motor.
+	CLSMAXvMotor* crystal2Roll() const { return crystal2Roll_; }
+
+	/// Returns the m1 mirror pitch control.
+	AMControl* m1MirrorPitch() const { return m1Pitch_; }
+
+	/// Returns the preferred bragg motor.
+	CLSMAXvMotor* bragg() const { return stepBragg_; }
+	/// Returns the step-based bragg position control.
+	CLSMAXvMotor* stepBragg() const { return stepBragg_; }
+	/// Returns the encoder-based bragg position control.
+	CLSMAXvMotor* encoderBragg() const { return encoderBragg_; }
+
+	/// Returns the energy control (the encoder-based, by default).
+	virtual BioXASSSRLMonochromatorEnergyControl* energy() const { return stepEnergy_; }
+	/// Returns the bragg encoder-based energy control.
+	BioXASSSRLMonochromatorEnergyControl* encoderEnergy() const { return encoderEnergy_; }
+	/// Returns the bragg step-based energy control.
+	BioXASSSRLMonochromatorEnergyControl *stepEnergy() const { return stepEnergy_; }
+
+	/// Returns the region control.
+	virtual BioXASSSRLMonochromatorRegionControl* region() const { return region_; }
+
 	/// Returns the mono move settling time.
 	double settlingTime() const { return settlingTime_; }
 
-	/// Returns the energy control (the encoder-based, by default).
-	virtual BioXASSSRLMonochromatorEnergyControl* energyControl() const { return stepEnergy_; }
-	/// Returns the bragg encoder-based energy control.
-	BioXASSSRLMonochromatorEnergyControl* encoderEnergyControl() const { return encoderEnergy_; }
-	/// Returns the bragg step-based energy control.
-	BioXASSSRLMonochromatorEnergyControl *stepEnergyControl() const { return stepEnergy_; }
-	/// Returns the region control.
-	virtual BioXASSSRLMonochromatorRegionControl* regionControl() const { return region_; }
-
-	/// Returns the upper slit control.
-	AMControl* upperSlitControl() const { return upperSlit_; }
-	/// Returns the lower slit control.
-	AMControl* lowerSlitControl() const { return lowerSlit_; }
-	/// Returns the slits status control.
-	AMControl* slitsStatusControl() const { return slitsStatus_; }
-	/// Returns the paddle control.
-	AMControl* paddleControl() const { return paddle_; }
-	/// Returns the paddle status control.
-	AMControl* paddleStatusControl() const { return paddleStatus_; }
-	/// Returns the key status control.
-	AMControl* keyStatusControl() const { return keyStatus_; }
-	/// Returns the brake status control.
-	AMControl* brakeStatusControl() const { return brakeStatus_; }
-	/// Returns the bragg motor at crystal change position status control.
-	AMControl* braggAtCrystalChangePositionStatusControl() const { return braggAtCrystalChangePositionStatus_; }
-	/// Returns the crystal change control.
-	AMControl* crystalChangeControl() const { return crystalChange_; }
-	/// Returns the crystal change cw limit status control.
-	AMControl* crystalChangeCWLimitStatusControl() const { return crystalChangeCWLimitStatus_; }
-	/// Returns the crystal change ccw limit status control.
-	AMControl* crystalChangeCCWLimitStatusControl() const { return crystalChangeCCWLimitStatus_; }
-	/// Returns the region A status control.
-	AMControl* regionAStatusControl() const { return regionAStatus_; }
-	/// Returns the region B status control.
-	AMControl* regionBStatusControl() const { return regionBStatus_; }
-	/// Returns the m1 mirror pitch control.
-	AMControl* m1MirrorPitchControl() const { return m1Pitch_; }
-
-	/// Returns the upper slit blade motor.
-	CLSMAXvMotor* upperSlitBladeMotor() const { return upperSlitMotor_; }
-	/// Returns the lower slit blade motor.
-	CLSMAXvMotor* lowerSlitBladeMotor() const { return lowerSlitMotor_; }
-	/// Returns the phosphor paddle motor.
-	CLSMAXvMotor* paddleMotor() const { return paddleMotor_; }
-	/// Returns the preferred bragg motor.
-	CLSMAXvMotor* braggMotor() const { return stepsBraggMotor_; }
-	/// Returns the step-based bragg position control.
-	CLSMAXvMotor* stepBraggControl() const { return stepsBraggMotor_; }
-	/// Returns the encoder-based bragg position control.
-	CLSMAXvMotor* encoderBraggControl() const { return encoderBraggMotor_; }
-	/// Returns the vertical motor.
-	CLSMAXvMotor* verticalMotor() const { return verticalMotor_; }
-	/// Returns the lateral motor.
-	CLSMAXvMotor* lateralMotor() const { return lateralMotor_; }
-	/// Returns the crystal change motor.
-	CLSMAXvMotor* crystalChangeMotor() const { return crystalChangeMotor_; }
-	/// Returns the crystal 1 pitch motor.
-	CLSMAXvMotor* crystal1PitchMotor() const { return crystal1PitchMotor_; }
-	/// Returns the crystal 1 roll motor.
-	CLSMAXvMotor* crystal1RollMotor() const { return crystal1RollMotor_; }
-	/// Returns the crystal 2 pitch motor.
-	CLSMAXvMotor* crystal2PitchMotor() const { return crystal2PitchMotor_; }
-	/// Returns the crystal 2 roll motor.
-	CLSMAXvMotor* crystal2RollMotor() const { return crystal2RollMotor_; }
-
 signals:
+	/// Notifier that the upper slit control has changed.
+	void upperSlitChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the lower slit control has changed.
+	void lowerSlitChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the slits status has changed.
+	void slitsStatusChanged(AMControl *newControl);
+	/// Notifier that the paddle control has changed.
+	void paddleChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the paddle status control has changed.
+	void paddleStatusChanged(AMControl *newControl);
+	/// Notifier that the key status control has changed.
+	void keyStatusChanged(AMControl *newControl);
+	/// Notifier that the brake status control has changed.
+	void brakeStatusChanged(AMControl *newControl);
+	/// Notifier that the bragg-at-crystal-change-position-status control has changed.
+	void braggAtCrystalChangePositionStatusChanged(AMControl *newControl);
+	/// Notifier that the crystal change control has changed.
+	void crystalChangeChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the region A status control has changed.
+	void regionAStatusChanged(AMControl *newControl);
+	//// Notifier that the region B status control has changed.
+	void regionBStatusChanged(AMControl *newControl);
+	/// Notifier that the vertical control has changed.
+	void verticalChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the lateral control has changed.
+	void lateralChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the crystal 1 pitch control has changed.
+	void crystal1PitchChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the crystal 1 roll control has changed.
+	void crystal1RollChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the crystal 2 pitch control has changed.
+	void crystal2PitchChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the crystal 2 roll control has changed.
+	void crystal2RollChanged(CLSMAXvMotor *newControl);
+
 	/// Notifier that the m1 mirror pitch control has changed.
 	void m1MirrorPitchControlChanged(AMControl *newControl);
+
+	/// Notifier that the step-based bragg control has changed.
+	void stepBraggChanged(CLSMAXvMotor *newControl);
+	/// Notifier that the encoder-based bragg control has changed.
+	void encoderBraggChanged(CLSMAXvMotor *newControl);
+
+	/// Notifier that the step-based energy control has changed.
+	void stepEnergyChanged(BioXASSSRLMonochromatorEnergyControl *newControl);
+	/// Notifier that the encoder-based energy control has changed.
+	void encoderEnergyChanged(BioXASSSRLMonochromatorEnergyControl *newControl);
+
+	/// Notifier that the region control has changed.
+	void regionChanged(BioXASSSRLMonochromatorRegionControl *newControl);
+
 	/// Notifier that the mono move settling time has changed.
 	void settlingTimeChanged(double newTimeSeconds);
 
 public slots:
+	/// Sets the upper slit control.
+	void setUpperSlit(CLSMAXvMotor *newControl);
+	/// Sets the lower slit control.
+	void setLowerSlit(CLSMAXvMotor *newControl);
+	/// Sets the slits status control.
+	void setSlitsStatus(AMControl *newControl);
+	/// Sets the paddle control.
+	void setPaddle(CLSMAXvMotor *newControl);
+	/// Sets the paddle status control.
+	void setPaddleStatus(AMControl *newControl);
+	/// Sets the key status control.
+	void setKeyStatus(AMControl *newControl);
+	/// Sets the brake status control.
+	void setBrakeStatus(AMControl *newControl);
+	/// Sets the bragg-at-crystal-change-position status control.
+	void setBraggAtCrystalChangePositionStatus(AMControl *newControl);
+	/// Sets the crystal change control.
+	void setCrystalChange(CLSMAXvMotor *newControl);
+	/// Sets the region A status control.
+	void setRegionAStatus(AMControl *newControl);
+	/// Sets the region B status control.
+	void setRegionBStatus(AMControl *newControl);
+	/// Sets the vertical control.
+	void setVertical(CLSMAXvMotor *newControl);
+	/// Sets the lateral control.
+	void setLateral(CLSMAXvMotor *newControl);
+	/// Sets the crystal 1 pitch control.
+	void setCrystal1Pitch(CLSMAXvMotor *newControl);
+	/// Sets the crystal 1 roll control.
+	void setCrystal1Roll(CLSMAXvMotor *newControl);
+	/// Sets the crystal 2 pitch control.
+	void setCrystal2Pitch(CLSMAXvMotor *newControl);
+	/// Sets the crystal 2 roll control.
+	void setCrystal2Roll(CLSMAXvMotor *newControl);
 	/// Sets the m1 mirror pitch control.
 	void setM1MirrorPitchControl(AMControl* newControl);
+
+	/// Sets the step-based bragg control.
+	void setStepBragg(CLSMAXvMotor *newControl);
+	/// Sets the encoder-based bragg control.
+	void setEncoderBragg(CLSMAXvMotor *newControl);
+
+	/// Sets the step-based energy control.
+	void setStepEnergy(BioXASSSRLMonochromatorEnergyControl *newControl);
+	/// Sets the encoder-based energy control.
+	void setEncoderEnergy(BioXASSSRLMonochromatorEnergyControl *newControl);
+
+	/// Sets the region control.
+	void setRegion(BioXASSSRLMonochromatorRegionControl *newControl);
+
 	/// Sets the mono move settling time.
 	void setSettlingTime(double newTimeSeconds);
 
 protected slots:
+	/// Handles updating the step-based energy control with the m1 mirror pitch.
+	void updateStepEnergy();
+	/// Handles updating the encoder-based energy control with the m1 mirror pitch.
+	void updateEncoderEnergy();
+	/// Handles updating the region control.
+	void updateRegion();
 	/// Handles updating the motors necessary to produce the desired mono move settling time.
 	void updateMotorSettlingTime();
 
 protected:
-	/// The mono move settling time, in seconds.
-	double settlingTime_;
-
-	/// The bragg encoder-based energy control.
-	BioXASSSRLMonochromatorEnergyControl *encoderEnergy_;
-	/// The bragg step-based energy control.
-	BioXASSSRLMonochromatorEnergyControl *stepEnergy_;
-	/// The region control.
-	BioXASSSRLMonochromatorRegionControl *region_;
-
 	/// The upper slit motor control.
-	AMControl *upperSlit_;
+	CLSMAXvMotor *upperSlit_;
 	/// The lower slit motor control.
-	AMControl *lowerSlit_;
+	CLSMAXvMotor *lowerSlit_;
 	/// The slits status control.
 	AMControl *slitsStatus_;
 	/// The paddle motor control.
-	AMControl *paddle_;
+	CLSMAXvMotor *paddle_;
 	/// The paddle status control.
 	AMControl *paddleStatus_;
 	/// The key status control.
 	AMControl *keyStatus_;
-	/// The bragg motor at crystal change position status control.
-	AMControl *braggAtCrystalChangePositionStatus_;
 	/// The brake status control.
 	AMControl *brakeStatus_;
+	/// The bragg motor at crystal change position status control.
+	AMControl *braggAtCrystalChangePositionStatus_;
 	/// The crystal change motor control.
-	AMControl *crystalChange_;
-	/// The crystal change clockwise limit status control.
-	AMControl *crystalChangeCWLimitStatus_;
-	/// The crystal change counter-clockwise limit status control.
-	AMControl *crystalChangeCCWLimitStatus_;
+	CLSMAXvMotor *crystalChange_;
 	/// The region A status control.
 	AMControl *regionAStatus_;
 	/// The region B status control.
 	AMControl *regionBStatus_;
+	/// Vertical motor.
+	CLSMAXvMotor *vertical_;
+	/// Lateral motor.
+	CLSMAXvMotor *lateral_;
+	/// Crystal 1 pitch motor.
+	CLSMAXvMotor *crystal1Pitch_;
+	/// Crystal 1 roll motor.
+	CLSMAXvMotor *crystal1Roll_;
+	/// Crystal 2 pitch motor.
+	CLSMAXvMotor *crystal2Pitch_;
+	/// Crystal 2 roll motor.
+	CLSMAXvMotor *crystal2Roll_;
 
 	/// The m1 mirror pitch control.
 	AMControl *m1Pitch_;
 
-	/// Upper slit blade motor.
-	CLSMAXvMotor *upperSlitMotor_;
-	/// Lower slit blade motor.
-	CLSMAXvMotor *lowerSlitMotor_;
-	/// Paddle motor.
-	CLSMAXvMotor *paddleMotor_;
-	/// Bragg motor, not using encoder (using steps).
-	CLSMAXvMotor *stepsBraggMotor_;
-	/// Bragg motor, using the encoder.
-	CLSMAXvMotor *encoderBraggMotor_;
-	/// Vertical motor.
-	CLSMAXvMotor *verticalMotor_;
-	/// Lateral motor.
-	CLSMAXvMotor *lateralMotor_;
-	/// Crystal change motor.
-	CLSMAXvMotor *crystalChangeMotor_;
-	/// Crystal 1 pitch motor.
-	CLSMAXvMotor *crystal1PitchMotor_;
-	/// Crystal 1 roll motor.
-	CLSMAXvMotor *crystal1RollMotor_;
-	/// Crystal 2 pitch motor.
-	CLSMAXvMotor *crystal2PitchMotor_;
-	/// Crystal 2 roll motor.
-	CLSMAXvMotor *crystal2RollMotor_;
+	/// The step-based bragg control.
+	CLSMAXvMotor *stepBragg_;
+	/// The encoder-based bragg control.
+	CLSMAXvMotor *encoderBragg_;
+
+	/// The bragg step-based energy control.
+	BioXASSSRLMonochromatorEnergyControl *stepEnergy_;
+	/// The bragg encoder-based energy control.
+	BioXASSSRLMonochromatorEnergyControl *encoderEnergy_;
+
+	/// The region control.
+	BioXASSSRLMonochromatorRegionControl *region_;
+
+	/// The mono move settling time, in seconds.
+	double settlingTime_;
 };
 
 #endif // BIOXASSSRLMONOCHROMATOR_H

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -79,14 +79,14 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		break;
 
 	case BioXASBeamlineDef::M1Motor:	// BioXAS M1 motors
-		matchedMotors.append(m1Mirror_->upstreamInboardMotorControl());
-		matchedMotors.append(m1Mirror_->upstreamOutboardMotorControl());
-		matchedMotors.append(m1Mirror_->downstreamMotorControl());
-		matchedMotors.append(m1Mirror_->stripeSelectMotorControl());
-		matchedMotors.append(m1Mirror_->yawMotorControl());
-		matchedMotors.append(m1Mirror_->benderUpstreamMotorControl());
-		matchedMotors.append(m1Mirror_->benderDownstreamMotorControl());
-		matchedMotors.append(m1Mirror_->upperSlitBladeMotorControl());
+		matchedMotors.append(m1Mirror_->upstreamInboardMotor());
+		matchedMotors.append(m1Mirror_->upstreamOutboardMotor());
+		matchedMotors.append(m1Mirror_->downstreamMotor());
+		matchedMotors.append(m1Mirror_->stripeSelectMotor());
+		matchedMotors.append(m1Mirror_->yawMotor());
+		matchedMotors.append(m1Mirror_->upstreamBenderMotor());
+		matchedMotors.append(m1Mirror_->downstreamBenderMotor());
+		matchedMotors.append(m1Mirror_->upperSlitBladeMotor());
 		break;
 
 	case BioXASBeamlineDef::MaskMotor:	// BioXAS Variable Mask motors
@@ -107,29 +107,29 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		break;
 
 	case BioXASBeamlineDef::M2Motor:	// BioXAS M2 motors
-		matchedMotors.append(m2Mirror_->upstreamInboardMotorControl());
-		matchedMotors.append(m2Mirror_->upstreamOutboardMotorControl());
-		matchedMotors.append(m2Mirror_->downstreamMotorControl());
-		matchedMotors.append(m2Mirror_->stripeSelectMotorControl());
-		matchedMotors.append(m2Mirror_->yawMotorControl());
-		matchedMotors.append(m2Mirror_->benderUpstreamMotorControl());
-		matchedMotors.append(m2Mirror_->benderDownstreamMotorControl());
+		matchedMotors.append(m2Mirror_->upstreamInboardMotor());
+		matchedMotors.append(m2Mirror_->upstreamOutboardMotor());
+		matchedMotors.append(m2Mirror_->downstreamMotor());
+		matchedMotors.append(m2Mirror_->stripeSelectMotor());
+		matchedMotors.append(m2Mirror_->yawMotor());
+		matchedMotors.append(m2Mirror_->upstreamBenderMotor());
+		matchedMotors.append(m2Mirror_->downstreamBenderMotor());
 		break;
 
 	case BioXASBeamlineDef::PseudoM1Motor: // BioXAS Pseudo M1 motor
-		matchedMotors.append(m1Mirror_->rollControl());
-		matchedMotors.append(m1Mirror_->pitchControl());
-		matchedMotors.append(m1Mirror_->heightControl());
-		matchedMotors.append(m1Mirror_->yawControl());
-		matchedMotors.append(m1Mirror_->lateralControl());
+		matchedMotors.append(m1Mirror_->roll());
+		matchedMotors.append(m1Mirror_->pitch());
+		matchedMotors.append(m1Mirror_->height());
+		matchedMotors.append(m1Mirror_->yaw());
+		matchedMotors.append(m1Mirror_->lateral());
 		break;
 
 	case BioXASBeamlineDef::PseudoM2Motor: // BioXAS Pseudo M2 motor
-		matchedMotors.append(m2Mirror_->rollControl());
-		matchedMotors.append(m2Mirror_->pitchControl());
-		matchedMotors.append(m2Mirror_->yawControl());
-		matchedMotors.append(m2Mirror_->heightControl());
-		matchedMotors.append(m2Mirror_->lateralControl());
+		matchedMotors.append(m2Mirror_->roll());
+		matchedMotors.append(m2Mirror_->pitch());
+		matchedMotors.append(m2Mirror_->yaw());
+		matchedMotors.append(m2Mirror_->height());
+		matchedMotors.append(m2Mirror_->lateral());
 		break;
 
 	case BioXASBeamlineDef::PseudoMonoMotor: // BioXAS Pseudo Mono motor
@@ -182,7 +182,7 @@ void BioXASSideBeamline::setupComponents()
 
 	// Mono.
 	mono_ = new BioXASSideMonochromator(this);
-	mono_->setM1MirrorPitchControl(m1Mirror_->pitchControl());
+	mono_->setM1MirrorPitchControl(m1Mirror_->pitch());
 	connect( mono_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// M2 mirror.
@@ -313,21 +313,21 @@ void BioXASSideBeamline::setupExposedControls()
 {
 	// M1 mirror controls
 
-	addExposedControl(m1Mirror_->upstreamInboardMotorControl());
-	addExposedControl(m1Mirror_->upstreamOutboardMotorControl());
-	addExposedControl(m1Mirror_->downstreamMotorControl());
-	addExposedControl(m1Mirror_->stripeSelectMotorControl());
-	addExposedControl(m1Mirror_->yawControl());
-	addExposedControl(m1Mirror_->benderUpstreamMotorControl());
-	addExposedControl(m1Mirror_->benderDownstreamMotorControl());
-	addExposedControl(m1Mirror_->upperSlitBladeMotorControl());
+	addExposedControl(m1Mirror_->upstreamInboardMotor());
+	addExposedControl(m1Mirror_->upstreamOutboardMotor());
+	addExposedControl(m1Mirror_->downstreamMotor());
+	addExposedControl(m1Mirror_->stripeSelectMotor());
+	addExposedControl(m1Mirror_->yaw());
+	addExposedControl(m1Mirror_->upstreamBenderMotor());
+	addExposedControl(m1Mirror_->downstreamBenderMotor());
+	addExposedControl(m1Mirror_->upperSlitBladeMotor());
 
-	addExposedControl(m1Mirror_->rollControl());
-	addExposedControl(m1Mirror_->pitchControl());
-	addExposedControl(m1Mirror_->heightControl());
-	addExposedControl(m1Mirror_->yawControl());
-	addExposedControl(m1Mirror_->lateralControl());
-	addExposedControl(m1Mirror_->bendControl());
+	addExposedControl(m1Mirror_->roll());
+	addExposedControl(m1Mirror_->pitch());
+	addExposedControl(m1Mirror_->height());
+	addExposedControl(m1Mirror_->yaw());
+	addExposedControl(m1Mirror_->lateral());
+	addExposedControl(m1Mirror_->bend());
 
 	// Mono controls.
 
@@ -356,21 +356,21 @@ void BioXASSideBeamline::setupExposedControls()
 
 	// M2 mirror controls.
 
-	addExposedControl(m2Mirror_->upstreamInboardMotorControl());
-	addExposedControl(m2Mirror_->upstreamOutboardMotorControl());
-	addExposedControl(m2Mirror_->downstreamMotorControl());
-	addExposedControl(m2Mirror_->stripeSelectMotorControl());
-	addExposedControl(m2Mirror_->yawMotorControl());
-	addExposedControl(m2Mirror_->benderUpstreamMotorControl());
-	addExposedControl(m2Mirror_->benderDownstreamMotorControl());
-	addExposedControl(m2Mirror_->screenMotorControl());
+	addExposedControl(m2Mirror_->upstreamInboardMotor());
+	addExposedControl(m2Mirror_->upstreamOutboardMotor());
+	addExposedControl(m2Mirror_->downstreamMotor());
+	addExposedControl(m2Mirror_->stripeSelectMotor());
+	addExposedControl(m2Mirror_->yawMotor());
+	addExposedControl(m2Mirror_->upstreamBenderMotor());
+	addExposedControl(m2Mirror_->downstreamBenderMotor());
+	addExposedControl(m2Mirror_->screen());
 
-	addExposedControl(m2Mirror_->rollControl());
-	addExposedControl(m2Mirror_->pitchControl());
-	addExposedControl(m2Mirror_->heightControl());
-	addExposedControl(m2Mirror_->yawControl());
-	addExposedControl(m2Mirror_->lateralControl());
-	addExposedControl(m2Mirror_->bendControl());
+	addExposedControl(m2Mirror_->roll());
+	addExposedControl(m2Mirror_->pitch());
+	addExposedControl(m2Mirror_->height());
+	addExposedControl(m2Mirror_->yaw());
+	addExposedControl(m2Mirror_->lateral());
+	addExposedControl(m2Mirror_->bend());
 
 	// JJ slit controls.
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -90,20 +90,20 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		break;
 
 	case BioXASBeamlineDef::MaskMotor:	// BioXAS Variable Mask motors
-		matchedMotors.append(mono_->upperSlitBladeMotor());
-		matchedMotors.append(mono_->lowerSlitBladeMotor());
+		matchedMotors.append(mono_->upperSlit());
+		matchedMotors.append(mono_->lowerSlit());
 		break;
 
 	case BioXASBeamlineDef::MonoMotor:	// Mono motors
-		matchedMotors.append(mono_->paddleMotor());
-		matchedMotors.append(mono_->braggMotor());
-		matchedMotors.append(mono_->verticalMotor());
-		matchedMotors.append(mono_->lateralMotor());
-		matchedMotors.append(mono_->crystalChangeMotor());
-		matchedMotors.append(mono_->crystal1PitchMotor());
-		matchedMotors.append(mono_->crystal1RollMotor());
-		matchedMotors.append(mono_->crystal2PitchMotor());
-		matchedMotors.append(mono_->crystal2RollMotor());
+		matchedMotors.append(mono_->paddle());
+		matchedMotors.append(mono_->bragg());
+		matchedMotors.append(mono_->vertical());
+		matchedMotors.append(mono_->lateral());
+		matchedMotors.append(mono_->crystalChange());
+		matchedMotors.append(mono_->crystal1Pitch());
+		matchedMotors.append(mono_->crystal1Roll());
+		matchedMotors.append(mono_->crystal2Pitch());
+		matchedMotors.append(mono_->crystal2Roll());
 		break;
 
 	case BioXASBeamlineDef::M2Motor:	// BioXAS M2 motors
@@ -133,8 +133,8 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 		break;
 
 	case BioXASBeamlineDef::PseudoMonoMotor: // BioXAS Pseudo Mono motor
-		matchedMotors.append(mono_->energyControl());
-		matchedMotors.append(mono_->regionControl());
+		matchedMotors.append(mono_->energy());
+		matchedMotors.append(mono_->region());
 		break;
 
 	default:
@@ -152,22 +152,22 @@ AMBasicControlDetectorEmulator* BioXASSideBeamline::scalerDwellTimeDetector() co
 
 AMBasicControlDetectorEmulator* BioXASSideBeamline::encoderEnergyFeedbackDetector() const
 {
-	return detectorForControl(mono_->encoderEnergyControl());
+	return detectorForControl(mono_->encoderEnergy());
 }
 
 AMBasicControlDetectorEmulator* BioXASSideBeamline::stepEnergyFeedbackDetector() const
 {
-	return detectorForControl(mono_->stepEnergyControl());
+	return detectorForControl(mono_->stepEnergy());
 }
 
 AMBasicControlDetectorEmulator* BioXASSideBeamline::braggDetector() const
 {
-	return detectorForControl(mono_->braggMotor());
+	return detectorForControl(mono_->bragg());
 }
 
 AMBasicControlDetectorEmulator* BioXASSideBeamline::braggStepSetpointDetector() const
 {
-	return detectorForControl(mono_->braggMotor()->stepSetpointControl());
+	return detectorForControl(mono_->bragg()->stepSetpointControl());
 }
 
 void BioXASSideBeamline::setupComponents()
@@ -303,10 +303,10 @@ void BioXASSideBeamline::setupComponents()
 void BioXASSideBeamline::setupControlsAsDetectors()
 {
 	addControlAsDetector("ScalerDwellTimeFeedback", "ScalerDwellTimeFeedback", scaler_->dwellTimeControl());
-	addControlAsDetector("MonoEncoderEnergyFeedback", "MonoEncoderEnergyFeedback", mono_->encoderEnergyControl());
-	addControlAsDetector("MonoStepEnergyFeedback", "MonoStepEnergyFeedback", mono_->stepEnergyControl());
-	addControlAsDetector("MonoStepAngleFeedback", "MonoStepAngleFeedback", mono_->stepBraggControl());
-	addControlAsDetector("MonoStepSetpoint", "MonoStepSetpoint", mono_->braggMotor()->stepSetpointControl());
+	addControlAsDetector("MonoEncoderEnergyFeedback", "MonoEncoderEnergyFeedback", mono_->encoderEnergy());
+	addControlAsDetector("MonoStepEnergyFeedback", "MonoStepEnergyFeedback", mono_->stepEnergy());
+	addControlAsDetector("MonoStepAngleFeedback", "MonoStepAngleFeedback", mono_->stepBragg());
+	addControlAsDetector("MonoStepSetpoint", "MonoStepSetpoint", mono_->bragg()->stepSetpointControl());
 }
 
 void BioXASSideBeamline::setupExposedControls()
@@ -331,28 +331,28 @@ void BioXASSideBeamline::setupExposedControls()
 
 	// Mono controls.
 
-	addExposedControl(mono_->encoderEnergyControl());
-	addExposedControl(mono_->stepEnergyControl());
-	addExposedControl(mono_->regionControl());
-	addExposedControl(mono_->braggMotor());
-	addExposedControl(mono_->braggMotor()->EGUVelocityControl());
-	addExposedControl(mono_->braggMotor()->EGUBaseVelocityControl());
-	addExposedControl(mono_->braggMotor()->EGUAccelerationControl());
-	addExposedControl(mono_->braggMotor()->preDeadBandControl());
-	addExposedControl(mono_->braggMotor()->postDeadBandControl());
-	addExposedControl(mono_->braggMotor()->encoderFeedbackControl());
-	addExposedControl(mono_->braggMotor()->encoderMovementTypeControl());
-	addExposedControl(mono_->braggMotor()->encoderStepSoftRatioControl());
-	addExposedControl(mono_->braggMotor()->encoderCalibrationSlopeControl());
-	addExposedControl(mono_->braggMotor()->stepCalibrationSlopeControl());
-	addExposedControl(mono_->braggMotor()->retries());
-	addExposedControl(mono_->braggMotor()->stepMotorFeedbackControl());
-	addExposedControl(mono_->verticalMotor());
-	addExposedControl(mono_->lateralMotor());
-	addExposedControl(mono_->crystal1PitchMotor());
-	addExposedControl(mono_->crystal1RollMotor());
-	addExposedControl(mono_->crystal2PitchMotor());
-	addExposedControl(mono_->crystal2RollMotor());
+	addExposedControl(mono_->encoderEnergy());
+	addExposedControl(mono_->stepEnergy());
+	addExposedControl(mono_->region());
+	addExposedControl(mono_->bragg());
+	addExposedControl(mono_->bragg()->EGUVelocityControl());
+	addExposedControl(mono_->bragg()->EGUBaseVelocityControl());
+	addExposedControl(mono_->bragg()->EGUAccelerationControl());
+	addExposedControl(mono_->bragg()->preDeadBandControl());
+	addExposedControl(mono_->bragg()->postDeadBandControl());
+	addExposedControl(mono_->bragg()->encoderFeedbackControl());
+	addExposedControl(mono_->bragg()->encoderMovementTypeControl());
+	addExposedControl(mono_->bragg()->encoderStepSoftRatioControl());
+	addExposedControl(mono_->bragg()->encoderCalibrationSlopeControl());
+	addExposedControl(mono_->bragg()->stepCalibrationSlopeControl());
+	addExposedControl(mono_->bragg()->retries());
+	addExposedControl(mono_->bragg()->stepMotorFeedbackControl());
+	addExposedControl(mono_->vertical());
+	addExposedControl(mono_->lateral());
+	addExposedControl(mono_->crystal1Pitch());
+	addExposedControl(mono_->crystal1Roll());
+	addExposedControl(mono_->crystal2Pitch());
+	addExposedControl(mono_->crystal2Roll());
 
 	// M2 mirror controls.
 

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -4,68 +4,25 @@
 BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	BioXASM1Mirror("SideM1Mirror", parent)
 {
-	// Initialize inherited variables.
+	setUpstreamLength(-543.77);
+	setDownstreamLength(543.68);
 
-	upstreamLength_ = -543.77;
-	downstreamLength_ = 543.68;
+	setUpstreamInboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I22-01"), QString("SMTR1607-5-I22-01 VERT INB (UPSTREAM)"), true, -619.125, 190.438, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamOutboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I22-02"), QString("SMTR1607-5-I22-02 VERT OUTB (UPSTREAM)"), true, -619.125, -12.763, 0.05, 2.0, this, QString(":mm")));
+	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-03"), QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
+	setStripeSelectionMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-04 STRIPE SELECT"), QString("SMTR1607-5-I22-04"), QString("SMTR1607-5-I22-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
+	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-05 YAW"), QString("SMTR1607-5-I22-05"), QString("SMTR1607-5-I22-05 YAW"), true, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
+	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 
-	upstreamInboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I22-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I22-01"), QString("SMTR1607-5-I22-01 VERT INB (UPSTREAM)"), true, -619.125, 190.438, 0.05, 2.0, this, QString(":mm"));
-	upstreamOutboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I22-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I22-02"), QString("SMTR1607-5-I22-02 VERT OUTB (UPSTREAM)"), true, -619.125, -12.763, 0.05, 2.0, this, QString(":mm"));
-	downstreamMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-03"), QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm"));
-	stripeSelectMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-04 STRIPE SELECT"), QString("SMTR1607-5-I22-04"), QString("SMTR1607-5-I22-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm"));
-	yawMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-05 YAW"), QString("SMTR1607-5-I22-05"), QString("SMTR1607-5-I22-05 YAW"), true, 0.05, 2.0, this, QString(":mm"));
-	benderUpstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	benderDownstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	upperSlitBladeMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-08 UPPER SLIT"), QString("SMTR1607-5-I22-08"), QString("SMTR1607-5-I22-08 UPPER SLIT"), true, 0.05, 2.0, this, QString(":mm"));
+	setPitch(new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this));
+	setRoll(new BioXASMirrorRollControl(name()+"RollControl", "deg", this));
+	setHeight(new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this));
+	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
+	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
+	setBend(new BioXASSideM1MirrorBendControl(name()+"BendControl", "m", this));
 
-	pitch_ = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
-	pitch_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	pitch_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	pitch_->setDownstreamMotor(downstreamMotor_);
-
-	roll_ = new BioXASMirrorRollControl(name()+"RollControl", "deg", this);
-	roll_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	roll_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	roll_->setDownstreamMotor(downstreamMotor_);
-
-	height_ = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
-	height_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	height_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	height_->setDownstreamMotor(downstreamMotor_);
-
-	lateral_ = new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this);
-	lateral_->setStripeSelectionMotor(stripeSelectMotor_);
-	lateral_->setYawMotor(yawMotor_);
-	lateral_->setUpstreamLength(upstreamLength_);
-	lateral_->setDownstreamLength(downstreamLength_);
-
-	yaw_ = new BioXASMirrorYawControl(name()+"YawControl", "deg", this);
-	yaw_->setYawMotor(yawMotor_);
-	yaw_->setStripeSelectionMotor(stripeSelectMotor_);
-	yaw_->setUpstreamLength(upstreamLength_);
-	yaw_->setDownstreamLength(downstreamLength_);
-
-	bend_ = new BioXASSideM1MirrorBendControl(name()+"BendControl", "m", this);
-	bend_->setUpstreamBenderMotor(benderUpstreamMotor_);
-	bend_->setDownstreamBenderMotor(benderDownstreamMotor_);
-
-	// Make connections.
-
-	connect( upstreamInboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( upstreamOutboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( downstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stripeSelectMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yawMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderUpstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderDownstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( upperSlitBladeMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( pitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( roll_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( height_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lateral_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yaw_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( bend_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	setUpperSlitBladeMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-08 UPPER SLIT"), QString("SMTR1607-5-I22-08"), QString("SMTR1607-5-I22-08 UPPER SLIT"), true, 0.05, 2.0, this, QString(":mm")));
 }
 
 BioXASSideM1Mirror::~BioXASSideM1Mirror()

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -1,5 +1,6 @@
 #include "BioXASSideM1Mirror.h"
 #include "beamline/BioXAS/BioXASSideM1MirrorBendControl.h"
+#include "beamline/BioXAS/BioXASMirrorMotor.h"
 
 BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	BioXASM1Mirror("SideM1Mirror", parent)
@@ -10,7 +11,7 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setUpstreamInboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-01 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I22-01"), QString("SMTR1607-5-I22-01 VERT INB (UPSTREAM)"), true, -619.125, 190.438, 0.05, 2.0, this, QString(":mm")));
 	setUpstreamOutboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-02 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I22-02"), QString("SMTR1607-5-I22-02 VERT OUTB (UPSTREAM)"), true, -619.125, -12.763, 0.05, 2.0, this, QString(":mm")));
 	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-03"), QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
-	setStripeSelectionMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-04 STRIPE SELECT"), QString("SMTR1607-5-I22-04"), QString("SMTR1607-5-I22-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
+	setStripeSelectMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-04 STRIPE SELECT"), QString("SMTR1607-5-I22-04"), QString("SMTR1607-5-I22-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
 	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-05 YAW"), QString("SMTR1607-5-I22-05"), QString("SMTR1607-5-I22-05 YAW"), true, 0.05, 2.0, this, QString(":mm")));
 	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));

--- a/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
@@ -1,71 +1,29 @@
 #include "BioXASSideM2Mirror.h"
 #include "beamline/BioXAS/BioXASSideM2MirrorBendControl.h"
+#include "beamline/BioXAS/BioXASMirrorMotor.h"
 
 BioXASSideM2Mirror::BioXASSideM2Mirror(QObject *parent) :
 	BioXASM2Mirror("SideM2Mirror", parent)
 {
-	// Initialize member variables.
+	setUpstreamLength(-543.725);
+	setDownstreamLength(543.725);
 
-	upstreamLength_ = -543.725;
-	downstreamLength_ = 543.725;
+	setUpstreamInboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-15 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I22-15"), QString("SMTR1607-5-I22-15 VERT INB (UPSTREAM)"), true, -619.125, 61.934, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamOutboardMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-16 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I22-16"), QString("SMTR1607-5-I22-16 VERT OUTB (UPSTREAM)"), true, -619.125, -141.266, 0.05, 2.0, this, QString(":mm")));
+	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-17 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-17"), QString("SMTR1607-5-I22-17 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
+	setStripeSelectMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-18 STRIPE SELECT"), QString("SMTR1607-5-I22-18"), QString("SMTR1607-5-I22-18 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
+	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-19 YAW"), QString("SMTR1607-5-I22-19"), QString("SMTR1607-5-I22-19 YAW"), true, 0.05, 2.0, this, QString(":mm")));
+	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-20"), QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
+	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-21"), QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 
-	upstreamInboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I22-15 VERT INB (UPSTREAM)"), QString("SMTR1607-5-I22-15"), QString("SMTR1607-5-I22-15 VERT INB (UPSTREAM)"), true, -619.125, 61.934, 0.05, 2.0, this, QString(":mm"));
-	upstreamOutboardMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I22-16 VERT OUTB (UPSTREAM)"), QString("SMTR1607-5-I22-16"), QString("SMTR1607-5-I22-16 VERT OUTB (UPSTREAM)"), true, -619.125, -141.266, 0.05, 2.0, this, QString(":mm"));
-	downstreamMotor_ = new BioXASMirrorMotor(QString("SMTR1607-5-I22-17 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-17"), QString("SMTR1607-5-I22-17 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm"));
-	stripeSelectMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-18 STRIPE SELECT"), QString("SMTR1607-5-I22-18"), QString("SMTR1607-5-I22-18 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm"));
-	yawMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-19 YAW"), QString("SMTR1607-5-I22-19"), QString("SMTR1607-5-I22-19 YAW"), true, 0.05, 2.0, this, QString(":mm"));
-	benderUpstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-20"), QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	benderDownstreamMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-21"), QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	screenMotor_ = new AMSinglePVControl(name()+"FluorescentScreen", "VSC1607-5-I22-02:InBeam", this);
+	setPitch(new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this));
+	setRoll(new BioXASMirrorRollControl(name()+"RollControl", "deg", this));
+	setHeight(new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this));
+	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
+	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
+	setBend(new BioXASSideM2MirrorBendControl(name()+"BendControl", "m", this));
 
-	pitch_ = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
-	pitch_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	pitch_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	pitch_->setDownstreamMotor(downstreamMotor_);
-
-	roll_ = new BioXASMirrorRollControl(name()+"RollControl", "deg", this);
-	roll_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	roll_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	roll_->setDownstreamMotor(downstreamMotor_);
-
-	height_ = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
-	height_->setUpstreamInboardMotor(upstreamInboardMotor_);
-	height_->setUpstreamOutboardMotor(upstreamOutboardMotor_);
-	height_->setDownstreamMotor(downstreamMotor_);
-
-	lateral_ = new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this);
-	lateral_->setStripeSelectionMotor(stripeSelectMotor_);
-	lateral_->setYawMotor(yawMotor_);
-	lateral_->setUpstreamLength(upstreamLength_);
-	lateral_->setDownstreamLength(downstreamLength_);
-
-	yaw_ = new BioXASMirrorYawControl(name()+"YawControl", "deg", this);
-	yaw_->setYawMotor(yawMotor_);
-	yaw_->setStripeSelectionMotor(stripeSelectMotor_);
-	yaw_->setUpstreamLength(upstreamLength_);
-	yaw_->setDownstreamLength(downstreamLength_);
-
-	bend_ = new BioXASSideM2MirrorBendControl(name()+"BendControl", "m", this);
-	bend_->setUpstreamBenderMotor(benderUpstreamMotor_);
-	bend_->setDownstreamBenderMotor(benderDownstreamMotor_);
-
-	// Make connections.
-
-	connect( upstreamInboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( upstreamOutboardMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( downstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stripeSelectMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yawMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderUpstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( benderDownstreamMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( screenMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( pitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( roll_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( height_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lateral_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( yaw_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( bend_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	setScreen(new AMSinglePVControl(name()+"FluorescentScreen", "VSC1607-5-I22-02:InBeam", this));
 }
 
 BioXASSideM2Mirror::~BioXASSideM2Mirror()

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -29,11 +29,11 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	stepsBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg"));
 	addChildControl(stepsBraggMotor_);
 
-	verticalMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this);
-	lateralMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this);
-	crystalChangeMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHAGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this);
-	crystal1PitchMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), QString("SMTR1607-5-I22-23"), QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V"));
-	crystal1RollMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-24 XTAL 1 ROLL"), QString("SMTR1607-5-I22-24"), QString("SMTR1607-5-I22-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V"));
+	setVertical(new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this));
+	setLateral(new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this));
+	setCrystalChange(new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHAGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this));
+	setCrystal1Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), QString("SMTR1607-5-I22-23"), QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V"));
+	setCrystal1Roll(new CLSMAXvMotor(QString("SMTR1607-5-I22-24 XTAL 1 ROLL"), QString("SMTR1607-5-I22-24"), QString("SMTR1607-5-I22-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V"));
 	crystal2PitchMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), QString("SMTR1607-5-I22-25"), QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V"));
 	crystal2RollMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), QString("SMTR1607-5-I22-26"), QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V"));
 

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -1,5 +1,4 @@
 #include "BioXASSideMonochromator.h"
-#include <QDebug>
 
 BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	BioXASSSRLMonochromator("SideMono", parent)
@@ -22,8 +21,8 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	setCrystal2Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), QString("SMTR1607-5-I22-25"), QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V")));
 	setCrystal2Roll(new CLSMAXvMotor(QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), QString("SMTR1607-5-I22-26"), QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V")));
 
-	setEncoderBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg")));
 	setStepBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg")));
+	setEncoderBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg")));
 
 	setStepEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"StepEnergyControl", this));
 	setEncoderEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"EncoderEnergyControl", this));

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -20,16 +20,10 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	regionAStatus_ = new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I22:Mono:Region:A", this);
 	regionBStatus_ = new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I22:Mono:Region:B", this);
 
-	upperSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this);
-	addChildControl(upperSlitMotor_);
-
-	lowerSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
-	addChildControl(lowerSlitMotor_);
-
-	paddleMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I22-11"), QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), true, 0.05, 2.0, this);
-	addChildControl(paddleMotor_);
-
-	encoderBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg"));
+	setUpperSlit(new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this));
+	setLowerSlit(new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
+	setPaddle(new CLSMAXvMotor(QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I22-11"), QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), true, 0.05, 2.0, this));
+	setEncoderBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg"));
 	addChildControl(encoderBraggMotor_);
 
 	stepsBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg"));
@@ -43,73 +37,16 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	crystal2PitchMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), QString("SMTR1607-5-I22-25"), QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V"));
 	crystal2RollMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), QString("SMTR1607-5-I22-26"), QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V"));
 
-	// Create region control.
 
-	region_ = new BioXASSSRLMonochromatorRegionControl(name()+"RegionControl", this);
-	region_->setUpperSlitControl(upperSlitMotor_);
-	region_->setLowerSlitControl(lowerSlitMotor_);
-	region_->setSlitsStatusControl(slitsStatus_);
-	region_->setPaddleControl(paddleMotor_);
-	region_->setPaddleStatusControl(paddleStatus_);
-	region_->setKeyStatusControl(keyStatus_);
-	region_->setBrakeStatusControl(brakeStatus_);
-	region_->setBraggControl(braggMotor());
-	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
-	region_->setCrystalChangeControl(crystalChangeMotor_);
-	region_->setCrystalChangeCWLimitStatusControl(crystalChangeMotor_->cwLimitControl());
-	region_->setCrystalChangeCCWLimitStatusControl(crystalChangeMotor_->ccwLimitControl());
-	region_->setRegionAStatusControl(regionAStatus_);
-	region_->setRegionBStatusControl(regionBStatus_);
 
 	// Create energy control.
 
-	encoderEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name()+"EncoderEnergyControl", this);
-	encoderEnergy_->setBraggControl(encoderBraggMotor_);
-	encoderEnergy_->setRegionControl(region_);
-	encoderEnergy_->setM1MirrorPitchControl(m1Pitch_);
+	setStepEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"StepEnergyControl", this));
+	setEncoderEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"EncoderEnergyControl", this));
 
-	stepEnergy_ = new BioXASSSRLMonochromatorEnergyControl(name()+"StepEnergyControl", this);
-	stepEnergy_->setBraggControl(stepsBraggMotor_);
-	stepEnergy_->setRegionControl(region_);
-	stepEnergy_->setM1MirrorPitchControl(m1Pitch_);
+	// Create region control.
 
-	// Listen to connection states.
-
-//	connect( upperSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-//	connect( lowerSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( slitsStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-//	connect( paddle_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( paddleStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( keyStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( brakeStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( braggAtCrystalChangePositionStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-//	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-//	connect( crystalChangeCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-//	connect( crystalChangeCCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( regionAStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( regionBStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( upperSlitMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lowerSlitMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( paddleMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( encoderBraggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stepsBraggMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( verticalMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lateralMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChangeMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal1PitchMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal1RollMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal2PitchMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystal2RollMotor_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	connect( region_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( encoderEnergy_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( stepEnergy_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-
-	// Current settings.
-
-	updateConnected();
-	updateMotorSettlingTime();
+	setRegion(new BioXASSSRLMonochromatorRegionControl(name()+"RegionControl", this));
 }
 
 BioXASSideMonochromator::~BioXASSideMonochromator()

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -3,48 +3,30 @@
 
 BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	BioXASSSRLMonochromator("SideMono", parent)
-{
-	// Create components.
-
-//	upperSlit_ = new AMPVwStatusControl("UpperSlitBlade", "SMTR1607-5-I22-09:mm:fbk", "SMTR1607-5-I22-09:mm", "SMTR1607-5-I22-09:status", "SMTR1607-5-I22-09:stop", this);
-//	lowerSlit_ = new AMPVwStatusControl("LowerSlitBlade", "SMTR1607-5-I22-10:mm:fbk", "SMTR1607-5-I22-10:mm", "SMTR1607-5-I22-10:status", "SMTR1607-5-I22-10:stop", this);
-	slitsStatus_ = new AMReadOnlyPVControl("SlitsStatus", "BL1607-5-I22:Mono:SlitsClosed", this);
-//	paddle_ = new AMPVwStatusControl("Paddle", "SMTR1607-5-I22-11:mm:fbk", "SMTR1607-5-I22-11:mm", "SMTR1607-5-I22-11:status", "SMTR1607-5-I22-11:stop", this);
-	paddleStatus_ = new AMReadOnlyPVControl("PaddleStatus", "BL1607-5-I22:Mono:PaddleExtracted", this);
-	keyStatus_ = new AMReadOnlyPVControl("KeyStatus", "BL1607-5-I22:Mono:KeyStatus", this);
-	brakeStatus_ = new AMReadOnlyPVControl("BrakeStatus", "BL1607-5-I22:Mono:BrakeOff", this);
-	braggAtCrystalChangePositionStatus_ = new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I22:Mono:XtalChangePos", this);
-//	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I22-22:mm:fbk", "SMTR1607-5-I22-22:mm", "SMTR1607-5-I22-22:status", "SMTR1607-5-I22-22:stop", this);
-//	crystalChangeCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCWStatus", "SMTR1607-5-I22-22:cw", this);
-//	crystalChangeCCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCCWStatus", "SMTR1607-5-I22-22:ccw", this);
-	regionAStatus_ = new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I22:Mono:Region:A", this);
-	regionBStatus_ = new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I22:Mono:Region:B", this);
-
+{	
 	setUpperSlit(new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this));
-	setLowerSlit(new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
+	setLowerSlit(new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this));
+	setSlitsStatus(new AMReadOnlyPVControl("SlitsStatus", "BL1607-5-I22:Mono:SlitsClosed", this));
 	setPaddle(new CLSMAXvMotor(QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I22-11"), QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), true, 0.05, 2.0, this));
-	setEncoderBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg"));
-	addChildControl(encoderBraggMotor_);
-
-	stepsBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg"));
-	addChildControl(stepsBraggMotor_);
-
+	setPaddleStatus(new AMReadOnlyPVControl("PaddleStatus", "BL1607-5-I22:Mono:PaddleExtracted", this));
+	setKeyStatus(new AMReadOnlyPVControl("KeyStatus", "BL1607-5-I22:Mono:KeyStatus", this));
+	setBrakeStatus(new AMReadOnlyPVControl("BrakeStatus", "BL1607-5-I22:Mono:BrakeOff", this));
+	setBraggAtCrystalChangePositionStatus(new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I22:Mono:XtalChangePos", this));
+	setCrystalChange(new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHAGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this));
+	setRegionAStatus(new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I22:Mono:Region:A", this));
+	setRegionBStatus(new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I22:Mono:Region:B", this));
 	setVertical(new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this));
 	setLateral(new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this));
-	setCrystalChange(new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHAGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this));
-	setCrystal1Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), QString("SMTR1607-5-I22-23"), QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V"));
-	setCrystal1Roll(new CLSMAXvMotor(QString("SMTR1607-5-I22-24 XTAL 1 ROLL"), QString("SMTR1607-5-I22-24"), QString("SMTR1607-5-I22-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V"));
-	crystal2PitchMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), QString("SMTR1607-5-I22-25"), QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V"));
-	crystal2RollMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), QString("SMTR1607-5-I22-26"), QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V"));
+	setCrystal1Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), QString("SMTR1607-5-I22-23"), QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V")));
+	setCrystal1Roll(new CLSMAXvMotor(QString("SMTR1607-5-I22-24 XTAL 1 ROLL"), QString("SMTR1607-5-I22-24"), QString("SMTR1607-5-I22-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V")));
+	setCrystal2Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), QString("SMTR1607-5-I22-25"), QString("SMTR1607-5-I22-25 XTAL 2 PITCH"), true, 0.05, 2.0, this, QString(":V")));
+	setCrystal2Roll(new CLSMAXvMotor(QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), QString("SMTR1607-5-I22-26"), QString("SMTR1607-5-I22-26 XTAL 2 ROLL"), true, 0.05, 2.0, this, QString(":V")));
 
-
-
-	// Create energy control.
+	setEncoderBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg")));
+	setStepBragg(new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg")));
 
 	setStepEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"StepEnergyControl", this));
 	setEncoderEnergy(new BioXASSSRLMonochromatorEnergyControl(name()+"EncoderEnergyControl", this));
-
-	// Create region control.
 
 	setRegion(new BioXASSSRLMonochromatorRegionControl(name()+"RegionControl", this));
 }
@@ -53,15 +35,3 @@ BioXASSideMonochromator::~BioXASSideMonochromator()
 {
 
 }
-
-//bool BioXASSideMonochromator::stop() const
-//{
-//	bool stopped = false;
-
-//	if (lowerSlitMotor_->stop())
-//		stopped = true;
-
-//	qDebug() << "\n\nLower slit stopped:" << stopped;
-
-//	return stopped;
-//}

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -1,29 +1,40 @@
 #include "BioXASSideMonochromator.h"
+#include <QDebug>
 
 BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	BioXASSSRLMonochromator("SideMono", parent)
 {
 	// Create components.
 
-	upperSlit_ = new AMPVwStatusControl("UpperSlitBlade", "SMTR1607-5-I22-09:mm:fbk", "SMTR1607-5-I22-09:mm", "SMTR1607-5-I22-09:status", "SMTR1607-5-I22-09:stop", this);
-	lowerSlit_ = new AMPVwStatusControl("LowerSlitBlade", "SMTR1607-5-I22-10:mm:fbk", "SMTR1607-5-I22-10:mm", "SMTR1607-5-I22-10:status", "SMTR1607-5-I22-10:stop", this);
+//	upperSlit_ = new AMPVwStatusControl("UpperSlitBlade", "SMTR1607-5-I22-09:mm:fbk", "SMTR1607-5-I22-09:mm", "SMTR1607-5-I22-09:status", "SMTR1607-5-I22-09:stop", this);
+//	lowerSlit_ = new AMPVwStatusControl("LowerSlitBlade", "SMTR1607-5-I22-10:mm:fbk", "SMTR1607-5-I22-10:mm", "SMTR1607-5-I22-10:status", "SMTR1607-5-I22-10:stop", this);
 	slitsStatus_ = new AMReadOnlyPVControl("SlitsStatus", "BL1607-5-I22:Mono:SlitsClosed", this);
-	paddle_ = new AMPVwStatusControl("Paddle", "SMTR1607-5-I22-11:mm:fbk", "SMTR1607-5-I22-11:mm", "SMTR1607-5-I22-11:status", "SMTR1607-5-I22-11:stop", this);
+//	paddle_ = new AMPVwStatusControl("Paddle", "SMTR1607-5-I22-11:mm:fbk", "SMTR1607-5-I22-11:mm", "SMTR1607-5-I22-11:status", "SMTR1607-5-I22-11:stop", this);
 	paddleStatus_ = new AMReadOnlyPVControl("PaddleStatus", "BL1607-5-I22:Mono:PaddleExtracted", this);
 	keyStatus_ = new AMReadOnlyPVControl("KeyStatus", "BL1607-5-I22:Mono:KeyStatus", this);
 	brakeStatus_ = new AMReadOnlyPVControl("BrakeStatus", "BL1607-5-I22:Mono:BrakeOff", this);
 	braggAtCrystalChangePositionStatus_ = new AMReadOnlyPVControl("AtCrystalChangePosition", "BL1607-5-I22:Mono:XtalChangePos", this);
-	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I22-22:mm:fbk", "SMTR1607-5-I22-22:mm", "SMTR1607-5-I22-22:status", "SMTR1607-5-I22-22:stop", this);
-	crystalChangeCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCWStatus", "SMTR1607-5-I22-22:cw", this);
-	crystalChangeCCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCCWStatus", "SMTR1607-5-I22-22:ccw", this);
+//	crystalChange_ = new AMPVwStatusControl("CrystalChange", "SMTR1607-5-I22-22:mm:fbk", "SMTR1607-5-I22-22:mm", "SMTR1607-5-I22-22:status", "SMTR1607-5-I22-22:stop", this);
+//	crystalChangeCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCWStatus", "SMTR1607-5-I22-22:cw", this);
+//	crystalChangeCCWLimitStatus_ = new AMReadOnlyPVControl("CrystalChangeCCWStatus", "SMTR1607-5-I22-22:ccw", this);
 	regionAStatus_ = new AMReadOnlyPVControl("RegionAStatus", "BL1607-5-I22:Mono:Region:A", this);
 	regionBStatus_ = new AMReadOnlyPVControl("RegionBStatus", "BL1607-5-I22:Mono:Region:B", this);
 
 	upperSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this);
+	addChildControl(upperSlitMotor_);
+
 	lowerSlitMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
+	addChildControl(lowerSlitMotor_);
+
 	paddleMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), QString("SMTR1607-5-I22-11"), QString("SMTR1607-5-I22-11 PHOSPHOR PADDLE"), true, 0.05, 2.0, this);
+	addChildControl(paddleMotor_);
+
 	encoderBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), true, 0.001, 2.0, this, QString(":deg"));
+	addChildControl(encoderBraggMotor_);
+
 	stepsBraggMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-12 BRAGG"), QString("SMTR1607-5-I22-12"), QString("SMTR1607-5-I22-12 BRAGG"), false, 0.001, 2.0, this, QString(":deg"));
+	addChildControl(stepsBraggMotor_);
+
 	verticalMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this);
 	lateralMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this);
 	crystalChangeMotor_ = new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHAGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this);
@@ -35,18 +46,18 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 	// Create region control.
 
 	region_ = new BioXASSSRLMonochromatorRegionControl(name()+"RegionControl", this);
-	region_->setUpperSlitControl(upperSlit_);
-	region_->setLowerSlitControl(lowerSlit_);
+	region_->setUpperSlitControl(upperSlitMotor_);
+	region_->setLowerSlitControl(lowerSlitMotor_);
 	region_->setSlitsStatusControl(slitsStatus_);
-	region_->setPaddleControl(paddle_);
+	region_->setPaddleControl(paddleMotor_);
 	region_->setPaddleStatusControl(paddleStatus_);
 	region_->setKeyStatusControl(keyStatus_);
 	region_->setBrakeStatusControl(brakeStatus_);
 	region_->setBraggControl(braggMotor());
 	region_->setBraggAtCrystalChangePositionStatusControl(braggAtCrystalChangePositionStatus_);
-	region_->setCrystalChangeControl(crystalChange_);
-	region_->setCrystalChangeCWLimitStatusControl(crystalChangeCWLimitStatus_);
-	region_->setCrystalChangeCCWLimitStatusControl(crystalChangeCCWLimitStatus_);
+	region_->setCrystalChangeControl(crystalChangeMotor_);
+	region_->setCrystalChangeCWLimitStatusControl(crystalChangeMotor_->cwLimitControl());
+	region_->setCrystalChangeCCWLimitStatusControl(crystalChangeMotor_->ccwLimitControl());
 	region_->setRegionAStatusControl(regionAStatus_);
 	region_->setRegionBStatusControl(regionBStatus_);
 
@@ -64,17 +75,17 @@ BioXASSideMonochromator::BioXASSideMonochromator(QObject *parent) :
 
 	// Listen to connection states.
 
-	connect( upperSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( lowerSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+//	connect( upperSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+//	connect( lowerSlit_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( slitsStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( paddle_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+//	connect( paddle_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( paddleStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( keyStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( brakeStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( braggAtCrystalChangePositionStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChangeCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	connect( crystalChangeCCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+//	connect( crystalChange_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+//	connect( crystalChangeCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+//	connect( crystalChangeCCWLimitStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( regionAStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 	connect( regionBStatus_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
@@ -105,3 +116,15 @@ BioXASSideMonochromator::~BioXASSideMonochromator()
 {
 
 }
+
+//bool BioXASSideMonochromator::stop() const
+//{
+//	bool stopped = false;
+
+//	if (lowerSlitMotor_->stop())
+//		stopped = true;
+
+//	qDebug() << "\n\nLower slit stopped:" << stopped;
+
+//	return stopped;
+//}

--- a/source/beamline/BioXAS/BioXASSideMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.h
@@ -1,8 +1,6 @@
 #ifndef BIOXASSIDEMONOCHROMATOR_H
 #define BIOXASSIDEMONOCHROMATOR_H
 
-#include <QObject>
-
 #include "beamline/BioXAS/BioXASSSRLMonochromator.h"
 
 class BioXASSideMonochromator : public BioXASSSRLMonochromator

--- a/source/beamline/BioXAS/BioXASSideMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.h
@@ -14,6 +14,10 @@ public:
 	explicit BioXASSideMonochromator(QObject *parent = 0);
 	/// Destructor.
 	virtual ~BioXASSideMonochromator();
+
+public slots:
+//	/// Reimplemented for testing.
+//	virtual bool stop() const;
 };
 
 #endif // BIOXASSIDEMONOCHROMATOR_H

--- a/source/beamline/BioXAS/BioXASSideMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.h
@@ -14,10 +14,6 @@ public:
 	explicit BioXASSideMonochromator(QObject *parent = 0);
 	/// Destructor.
 	virtual ~BioXASSideMonochromator();
-
-public slots:
-//	/// Reimplemented for testing.
-//	virtual bool stop() const;
 };
 
 #endif // BIOXASSIDEMONOCHROMATOR_H

--- a/source/ui/BioXAS/BioXASM1MirrorView.cpp
+++ b/source/ui/BioXAS/BioXASM1MirrorView.cpp
@@ -9,6 +9,8 @@ BioXASM1MirrorView::BioXASM1MirrorView(BioXASM1Mirror *mirror, QWidget *parent) 
 
 	// Create UI elements.
 
+	stopButton_ = new AMControlStopButton(0);
+
 	mirrorEditor_ = new BioXASMirrorView(0);
 
 	upperSlitEditor_ = new AMExtendedControlEditor(0);
@@ -18,6 +20,11 @@ BioXASM1MirrorView::BioXASM1MirrorView(BioXASM1Mirror *mirror, QWidget *parent) 
 
 	// Create and set layouts.
 
+	QHBoxLayout *buttonLayout = new QHBoxLayout();
+	buttonLayout->addStretch();
+	buttonLayout->addWidget(stopButton_);
+	buttonLayout->addStretch();
+
 	QVBoxLayout *controlsLayout = new QVBoxLayout();
 	controlsLayout->addWidget(mirrorEditor_);
 	controlsLayout->addWidget(upperSlitEditor_);
@@ -26,9 +33,13 @@ BioXASM1MirrorView::BioXASM1MirrorView(BioXASM1Mirror *mirror, QWidget *parent) 
 	bendLayout->addWidget(bendView_);
 	bendLayout->addStretch();
 
-	QHBoxLayout *layout = new QHBoxLayout();
-	layout->addLayout(controlsLayout);
-	layout->addLayout(bendLayout);
+	QHBoxLayout *mirrorLayout = new QHBoxLayout();
+	mirrorLayout->addLayout(controlsLayout);
+	mirrorLayout->addLayout(bendLayout);
+
+	QVBoxLayout *layout = new QVBoxLayout();
+	layout->addLayout(buttonLayout);
+	layout->addLayout(mirrorLayout);
 
 	setLayout(layout);
 
@@ -42,24 +53,50 @@ BioXASM1MirrorView::~BioXASM1MirrorView()
 
 }
 
+void BioXASM1MirrorView::refresh()
+{
+	// Clear view.
+
+	stopButton_->setControl(0);
+	mirrorEditor_->setMirror(0);
+	upperSlitEditor_->setControl(0);
+	bendView_->setMirror(0);
+
+	// Update view elements.
+
+	if (mirror_) {
+		stopButton_->setControl(mirror_);
+		mirrorEditor_->setMirror(mirror_);
+		bendView_->setMirror(mirror_);
+
+		updateUpperSlitEditor();
+	}
+}
+
 void BioXASM1MirrorView::setMirror(BioXASM1Mirror *newMirror)
 {
 	if (mirror_ != newMirror) {
 
-		if (mirror_) {
-			mirrorEditor_->setMirror(0);
-			upperSlitEditor_->setControl(0);
-			bendView_->setMirror(0);
-		}
+		if (mirror_)
+			disconnect( mirror_, 0, this, 0 );
 
 		mirror_ = newMirror;
 
-		if (mirror_) {
-			mirrorEditor_->setMirror(mirror_);
-			upperSlitEditor_->setControl(mirror_->upperSlitBladeMotorControl());
-			bendView_->setMirror(mirror_);
-		}
+		if (mirror_)
+			connect( mirror_, SIGNAL(upperSlitBladeMotorChanged(CLSMAXvMotor*)), this, SLOT(updateUpperSlitEditor()) );
+
+		refresh();
 
 		emit mirrorChanged(mirror_);
 	}
+}
+
+void BioXASM1MirrorView::updateUpperSlitEditor()
+{
+	AMControl *upperSlitControl = 0;
+
+	if (mirror_)
+		upperSlitControl = mirror_->upperSlitBladeMotor();
+
+	upperSlitEditor_->setControl(upperSlitControl);
 }

--- a/source/ui/BioXAS/BioXASM1MirrorView.h
+++ b/source/ui/BioXAS/BioXASM1MirrorView.h
@@ -6,6 +6,7 @@
 #include "ui/BioXAS/BioXASMirrorView.h"
 #include "beamline/BioXAS/BioXASM1Mirror.h"
 #include "ui/BioXAS/BioXASMirrorBendView.h"
+#include "ui/beamline/AMControlStopButton.h"
 
 class BioXASM1MirrorView : public QWidget
 {
@@ -25,20 +26,27 @@ signals:
 	void mirrorChanged(BioXASM1Mirror *newMirror);
 
 public slots:
+	/// Refreshes the view.
+	void refresh();
 	/// Sets the mirror being viewed.
 	void setMirror(BioXASM1Mirror *newMirror);
+
+protected slots:
+	/// Updates the upper slit blade motor editor.
+	void updateUpperSlitEditor();
 
 protected:
 	/// The mirror being viewed.
 	BioXASM1Mirror *mirror_;
 
+	/// The stop button.
+	AMControlStopButton *stopButton_;
 	/// The basic mirror editor.
 	BioXASMirrorView *mirrorEditor_;
 	/// The upper slit blade editor.
 	AMExtendedControlEditor *upperSlitEditor_;
 	/// The mirror bend view.
 	BioXASMirrorBendView *bendView_;
-
 };
 
 #endif // BIOXASM1MIRRORVIEW_H

--- a/source/ui/BioXAS/BioXASM2MirrorView.cpp
+++ b/source/ui/BioXAS/BioXASM2MirrorView.cpp
@@ -10,6 +10,8 @@ BioXASM2MirrorView::BioXASM2MirrorView(BioXASM2Mirror *mirror, QWidget *parent) 
 
 	// Create UI elements.
 
+	stopButton_ = new AMControlStopButton(0);
+
 	mirrorEditor_ = new BioXASMirrorView(0);
 
 	screenEditor_ = new AMExtendedControlEditor(0);
@@ -20,6 +22,11 @@ BioXASM2MirrorView::BioXASM2MirrorView(BioXASM2Mirror *mirror, QWidget *parent) 
 
 	// Create and set layouts.
 
+	QHBoxLayout *stopButtonLayout = new QHBoxLayout();
+	stopButtonLayout->addStretch();
+	stopButtonLayout->addWidget(stopButton_);
+	stopButtonLayout->addStretch();
+
 	QVBoxLayout *controlsLayout = new QVBoxLayout();
 	controlsLayout->addWidget(mirrorEditor_);
 	controlsLayout->addWidget(screenEditor_);
@@ -28,9 +35,13 @@ BioXASM2MirrorView::BioXASM2MirrorView(BioXASM2Mirror *mirror, QWidget *parent) 
 	bendLayout->addWidget(bendView_);
 	bendLayout->addStretch();
 
-	QHBoxLayout *layout = new QHBoxLayout();
-	layout->addLayout(controlsLayout);
-	layout->addLayout(bendLayout);
+	QHBoxLayout *mirrorLayout = new QHBoxLayout();
+	mirrorLayout->addLayout(controlsLayout);
+	mirrorLayout->addLayout(bendLayout);
+
+	QVBoxLayout *layout = new QVBoxLayout();
+	layout->addLayout(stopButtonLayout);
+	layout->addLayout(mirrorLayout);
 
 	setLayout(layout);
 
@@ -44,24 +55,50 @@ BioXASM2MirrorView::~BioXASM2MirrorView()
 
 }
 
+void BioXASM2MirrorView::refresh()
+{
+	// Clear the view.
+
+	stopButton_->setControl(0);
+	mirrorEditor_->setMirror(0);
+	screenEditor_->setControl(0);
+	bendView_->setMirror(0);
+
+	// Update view elements.
+
+	if (mirror_) {
+		stopButton_->setControl(mirror_);
+		mirrorEditor_->setMirror(mirror_);
+		updateScreenEditor();
+		bendView_->setMirror(mirror_);
+	}
+}
+
 void BioXASM2MirrorView::setMirror(BioXASM2Mirror *newMirror)
 {
 	if (mirror_ != newMirror) {
 
-		if (mirror_) {
-			mirrorEditor_->setMirror(mirror_);
-			screenEditor_->setControl(0);
-			bendView_->setMirror(0);
-		}
+		if (mirror_)
+			disconnect( mirror_, 0, this, 0 );
 
 		mirror_ = newMirror;
 
 		if (mirror_) {
-			mirrorEditor_->setMirror(mirror_);
-			screenEditor_->setControl(mirror_->screenMotorControl());
-			bendView_->setMirror(mirror_);
+			connect( mirror_, SIGNAL(screenChanged(AMControl*)), this, SLOT(updateScreenEditor()) );
 		}
+
+		refresh();
 
 		emit mirrorChanged(mirror_);
 	}
+}
+
+void BioXASM2MirrorView::updateScreenEditor()
+{
+	AMControl *screenControl = 0;
+
+	if (mirror_)
+		screenControl = mirror_->screen();
+
+	screenEditor_->setControl(screenControl);
 }

--- a/source/ui/BioXAS/BioXASM2MirrorView.h
+++ b/source/ui/BioXAS/BioXASM2MirrorView.h
@@ -4,6 +4,7 @@
 #include "ui/BioXAS/BioXASMirrorView.h"
 #include "beamline/BioXAS/BioXASM2Mirror.h"
 #include "ui/BioXAS/BioXASMirrorBendView.h"
+#include "ui/beamline/AMControlStopButton.h"
 
 class BioXASM2MirrorView : public QWidget
 {
@@ -23,13 +24,21 @@ signals:
 	void mirrorChanged(BioXASM2Mirror *newMirror);
 
 public slots:
+	/// Refreshes the view.
+	void refresh();
 	/// Sets the mirror being viewed.
 	void setMirror(BioXASM2Mirror *newMirror);
+
+protected slots:
+	/// Updates the screen control editor.
+	void updateScreenEditor();
 
 protected:
 	/// The mirror being viewed.
 	BioXASM2Mirror *mirror_;
 
+	/// The stop button.
+	AMControlStopButton *stopButton_;
 	/// The basic mirror editor.
 	BioXASMirrorView *mirrorEditor_;
 	/// The editor for the screen control.

--- a/source/ui/BioXAS/BioXASMirrorBendView.cpp
+++ b/source/ui/BioXAS/BioXASMirrorBendView.cpp
@@ -41,23 +41,28 @@ BioXASMirrorBendView::~BioXASMirrorBendView()
 
 }
 
+void BioXASMirrorBendView::refresh()
+{
+	// Clear the view.
+
+	bendEditor_->setControl(0);
+	upstreamEditor_->setControl(0);
+	downstreamEditor_->setControl(0);
+
+	// Update view element.
+
+	if (mirror_) {
+		bendEditor_->setControl(mirror_->bend());
+		upstreamEditor_->setControl(mirror_->upstreamBenderMotor());
+		downstreamEditor_->setControl(mirror_->downstreamBenderMotor());
+	}
+}
+
 void BioXASMirrorBendView::setMirror(BioXASMirror *newMirror)
 {
 	if (mirror_ != newMirror) {
-
-		if (mirror_) {
-			bendEditor_->setControl(0);
-			upstreamEditor_->setControl(0);
-			downstreamEditor_->setControl(0);
-		}
-
 		mirror_ = newMirror;
-
-		if (mirror_) {
-			bendEditor_->setControl(mirror_->bendControl());
-			upstreamEditor_->setControl(mirror_->benderUpstreamMotorControl());
-			downstreamEditor_->setControl(mirror_->benderDownstreamMotorControl());
-		}
+		refresh();
 
 		emit mirrorChanged(mirror_);
 	}

--- a/source/ui/BioXAS/BioXASMirrorBendView.h
+++ b/source/ui/BioXAS/BioXASMirrorBendView.h
@@ -16,6 +16,7 @@ public:
 	explicit BioXASMirrorBendView(BioXASMirror *mirror, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~BioXASMirrorBendView();
+
 	/// Returns the mirror being viewed.
 	BioXASMirror* mirror() const { return mirror_; }
 
@@ -24,6 +25,8 @@ signals:
 	void mirrorChanged(BioXASMirror *newMirror);
 
 public slots:
+	/// Refreshes the view.
+	void refresh();
 	/// Sets the mirror being viewed.
 	void setMirror(BioXASMirror *newMirror);
 

--- a/source/ui/BioXAS/BioXASMirrorView.cpp
+++ b/source/ui/BioXAS/BioXASMirrorView.cpp
@@ -51,27 +51,45 @@ BioXASMirrorView::~BioXASMirrorView()
 
 }
 
+void BioXASMirrorView::refresh()
+{
+	// Clear the view.
+
+	pitchEditor_->setControl(0);
+	rollEditor_->setControl(0);
+	yawEditor_->setControl(0);
+	heightEditor_->setControl(0);
+	lateralEditor_->setControl(0);
+
+	// Update view elements.
+
+	if (mirror_) {
+		pitchEditor_->setControl(mirror_->pitch());
+		rollEditor_->setControl(mirror_->roll());
+		yawEditor_->setControl(mirror_->yaw());
+		heightEditor_->setControl(mirror_->height());
+		lateralEditor_->setControl(mirror_->lateral());
+	}
+}
+
 void BioXASMirrorView::setMirror(BioXASMirror *newMirror)
 {
 	if (mirror_ != newMirror) {
 
-		if (mirror_) {
-			pitchEditor_->setControl(0);
-			rollEditor_->setControl(0);
-			yawEditor_->setControl(0);
-			heightEditor_->setControl(0);
-			lateralEditor_->setControl(0);
-		}
+		if (mirror_)
+			disconnect( mirror_, 0, this, 0 );
 
 		mirror_ = newMirror;
 
 		if (mirror_) {
-			pitchEditor_->setControl(mirror_->pitchControl());
-			rollEditor_->setControl(mirror_->rollControl());
-			yawEditor_->setControl(mirror_->yawControl());
-			heightEditor_->setControl(mirror_->heightControl());
-			lateralEditor_->setControl(mirror_->lateralControl());
+			connect( mirror_, SIGNAL(pitchChanged(BioXASMirrorPitchControl*)), this, SLOT(refresh()) );
+			connect( mirror_, SIGNAL(rollChanged(BioXASMirrorRollControl*)), this, SLOT(refresh()) );
+			connect( mirror_, SIGNAL(yawChanged(BioXASMirrorYawControl*)), this, SLOT(refresh()) );
+			connect( mirror_, SIGNAL(heightChanged(BioXASMirrorHeightControl*)), this, SLOT(refresh()) );
+			connect( mirror_, SIGNAL(lateralChanged(BioXASMirrorLateralControl*)), this, SLOT(refresh()) );
 		}
+
+		refresh();
 
 		emit mirrorChanged(mirror_);
 	}

--- a/source/ui/BioXAS/BioXASMirrorView.h
+++ b/source/ui/BioXAS/BioXASMirrorView.h
@@ -25,6 +25,8 @@ signals:
 	void mirrorChanged(BioXASMirror *newMirror);
 
 public slots:
+	/// Refreshes the view.
+	void refresh();
 	/// Sets the mirror being viewed.
 	void setMirror(BioXASMirror *newMirror);
 

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -71,9 +71,9 @@ void BioXASPersistentView::setMono(BioXASSSRLMonochromator *newMono)
 		mono_ = newMono;
 
 		if (mono_) {
-			energyEditor_->setControl(mono_->energyControl());
-			regionEditor_->setControl(mono_->regionControl());
-			braggEditor_->setControl(mono_->braggMotor());
+			energyEditor_->setControl(mono_->energy());
+			regionEditor_->setControl(mono_->region());
+			braggEditor_->setControl(mono_->bragg());
 		}
 
 		emit monoChanged(mono_);

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -218,26 +218,26 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 
 			// Update UI elements.
 
-			upperSlitEditor_->setControl(mono_->upperSlitBladeMotor());
-			lowerSlitEditor_->setControl(mono_->lowerSlitBladeMotor());
-			heightEditor_->setControl(mono_->verticalMotor());
-			lateralEditor_->setControl(mono_->lateralMotor());
-			paddleEditor_->setControl(mono_->paddleMotor());
-			crystal1PitchEditor_->setControl(mono_->crystal1PitchMotor());
-			crystal1RollEditor_->setControl(mono_->crystal1RollMotor());
-			crystal2PitchEditor_->setControl(mono_->crystal2PitchMotor());
-			crystal2RollEditor_->setControl(mono_->crystal2RollMotor());
+			upperSlitEditor_->setControl(mono_->upperSlit());
+			lowerSlitEditor_->setControl(mono_->lowerSlit());
+			heightEditor_->setControl(mono_->vertical());
+			lateralEditor_->setControl(mono_->lateral());
+			paddleEditor_->setControl(mono_->paddle());
+			crystal1PitchEditor_->setControl(mono_->crystal1Pitch());
+			crystal1RollEditor_->setControl(mono_->crystal1Roll());
+			crystal2PitchEditor_->setControl(mono_->crystal2Pitch());
+			crystal2RollEditor_->setControl(mono_->crystal2Roll());
 
-			regionEditor_->setControl(mono_->regionControl());
-			regionStatusWidget_->setRegionControl(mono_->regionControl());
+			regionEditor_->setControl(mono_->region());
+			regionStatusWidget_->setRegionControl(mono_->region());
 
-			stepEnergyEditor_->setControl(mono_->stepEnergyControl());
-			encoderEnergyEditor_->setControl(mono_->encoderEnergyControl());
-			stepBraggEditor_->setControl(mono_->stepBraggControl());
-			encoderBraggEditor_->setControl(mono_->encoderBraggControl());
-			m1PitchEditor_->setControl(mono_->m1MirrorPitchControl());
+			stepEnergyEditor_->setControl(mono_->stepEnergy());
+			encoderEnergyEditor_->setControl(mono_->encoderEnergy());
+			stepBraggEditor_->setControl(mono_->stepBragg());
+			encoderBraggEditor_->setControl(mono_->encoderBragg());
+			m1PitchEditor_->setControl(mono_->m1MirrorPitch());
 
-			braggConfigWidget_->setBraggMotor(mono_->braggMotor());
+			braggConfigWidget_->setBraggMotor(mono_->bragg());
 		}
 
 		emit monoChanged(mono_);
@@ -247,7 +247,7 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 void BioXASSSRLMonochromatorConfigurationView::onCalibrateEnergyButtonClicked()
 {
 	if (mono_) {
-		AMControl *energyControl = mono_->energyControl();
+		AMControl *energyControl = mono_->energy();
 
 		if (energyControl) {
 			bool inputOK = false;
@@ -263,7 +263,7 @@ void BioXASSSRLMonochromatorConfigurationView::onCalibrateEnergyButtonClicked()
 void BioXASSSRLMonochromatorConfigurationView::onCalibrateGoniometerButtonClicked()
 {
 	if (mono_) {
-		AMControl *braggMotor = mono_->braggMotor();
+		AMControl *braggMotor = mono_->bragg();
 
 		if (braggMotor) {
 			bool inputOK = false;

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -218,11 +218,11 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 
 			// Update UI elements.
 
-			upperSlitEditor_->setControl(mono_->upperSlitControl());
-			lowerSlitEditor_->setControl(mono_->lowerSlitControl());
+			upperSlitEditor_->setControl(mono_->upperSlitBladeMotor());
+			lowerSlitEditor_->setControl(mono_->lowerSlitBladeMotor());
 			heightEditor_->setControl(mono_->verticalMotor());
 			lateralEditor_->setControl(mono_->lateralMotor());
-			paddleEditor_->setControl(mono_->paddleControl());
+			paddleEditor_->setControl(mono_->paddleMotor());
 			crystal1PitchEditor_->setControl(mono_->crystal1PitchMotor());
 			crystal1RollEditor_->setControl(mono_->crystal1RollMotor());
 			crystal2PitchEditor_->setControl(mono_->crystal2PitchMotor());

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -228,8 +228,8 @@ void BioXASSSRLMonochromatorConfigurationView::setMono(BioXASSSRLMonochromator *
 			crystal2PitchEditor_->setControl(mono_->crystal2Pitch());
 			crystal2RollEditor_->setControl(mono_->crystal2Roll());
 
-			regionEditor_->setControl(mono_->region());
-			regionStatusWidget_->setRegionControl(mono_->region());
+			regionEditor_->setControl(qobject_cast<BioXASSSRLMonochromatorRegionControl*>(mono_->region()));
+			regionStatusWidget_->setRegionControl(qobject_cast<BioXASSSRLMonochromatorRegionControl*>(mono_->region()));
 
 			stepEnergyEditor_->setControl(mono_->stepEnergy());
 			encoderEnergyEditor_->setControl(mono_->encoderEnergy());

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorEnergyCalibrationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorEnergyCalibrationView.cpp
@@ -111,17 +111,17 @@ void BioXASSSRLMonochromatorEnergyCalibrationView::setMono(BioXASSSRLMonochromat
 {
 	if (mono_ != newMono) {
 
-		if (mono_ && mono_->energyControl()) {
-			disconnect( mono_->energyControl(), 0, this, 0 );
+		if (mono_ && mono_->energy()) {
+			disconnect( mono_->energy(), 0, this, 0 );
 		}
 
 		mono_ = newMono;
 
-		if (mono_ && mono_->energyControl()) {
-			connect( mono_->energyControl(), SIGNAL(movingChanged(bool)), this, SLOT(updateCalibrateButton()) );
-			connect( mono_->energyControl(), SIGNAL(calibrationStarted()), this, SLOT(onCalibrationStarted()) );
-			connect( mono_->energyControl(), SIGNAL(calibrationFailed(int)), this, SLOT(onCalibrationFailed()) );
-			connect( mono_->energyControl(), SIGNAL(calibrationSucceeded()), this, SLOT(onCalibrationSucceeded()) );
+		if (mono_ && mono_->energy()) {
+			connect( mono_->energy(), SIGNAL(movingChanged(bool)), this, SLOT(updateCalibrateButton()) );
+			connect( mono_->energy(), SIGNAL(calibrationStarted()), this, SLOT(onCalibrationStarted()) );
+			connect( mono_->energy(), SIGNAL(calibrationFailed(int)), this, SLOT(onCalibrationFailed()) );
+			connect( mono_->energy(), SIGNAL(calibrationSucceeded()), this, SLOT(onCalibrationSucceeded()) );
 		}
 
 		update();
@@ -347,8 +347,8 @@ void BioXASSSRLMonochromatorEnergyCalibrationView::onCalibrateButtonClicked()
 {
 	// Start calibration.
 
-	if (mono_ && mono_->energyControl()) {
-		mono_->energyControl()->calibrate(monoEnergy_, desiredEnergy_);
+	if (mono_ && mono_->energy()) {
+		mono_->energy()->calibrate(monoEnergy_, desiredEnergy_);
 	}
 }
 
@@ -364,7 +364,7 @@ void BioXASSSRLMonochromatorEnergyCalibrationView::updateScanView()
 {
 	bool cursorVisible = false;
 
-	if (currentScan_ && mono_ && mono_->energyControl()) {
+	if (currentScan_ && mono_ && mono_->energy()) {
 		cursorVisible = true;
 	}
 
@@ -383,7 +383,7 @@ void BioXASSSRLMonochromatorEnergyCalibrationView::updateMonoEnergySpinbox()
 {
 	bool isEnabled = false;
 
-	if (currentScan_ && mono_ && mono_->energyControl()) {
+	if (currentScan_ && mono_ && mono_->energy()) {
 		isEnabled = true;
 	}
 
@@ -398,7 +398,7 @@ void BioXASSSRLMonochromatorEnergyCalibrationView::updateDesiredEnergySpinbox()
 {
 	bool isEnabled = false;
 
-	if (currentScan_ && mono_ && mono_->energyControl()) {
+	if (currentScan_ && mono_ && mono_->energy()) {
 		isEnabled = true;
 	}
 
@@ -413,7 +413,7 @@ void BioXASSSRLMonochromatorEnergyCalibrationView::updateCalibrateButton()
 {
 	bool isEnabled = false;
 
-	if (currentScan_ && mono_ && mono_->energyControl() && !mono_->energyControl()->isMoving())
+	if (currentScan_ && mono_ && mono_->energy() && !mono_->energy()->isMoving())
 		isEnabled = true;
 
 	if (isEnabled != calibrateButton_->isEnabled())

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorView.cpp
@@ -1,0 +1,67 @@
+#include "BioXASSSRLMonochromatorView.h"
+#include "beamline/BioXAS/BioXASSSRLMonochromator.h"
+#include "ui/beamline/AMControlStopButton.h"
+#include "ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.h"
+
+BioXASSSRLMonochromatorView::BioXASSSRLMonochromatorView(BioXASSSRLMonochromator *mono, QWidget *parent) :
+    QWidget(parent)
+{
+	// Initialize class variables.
+
+	mono_ = 0;
+
+	// Create UI elements.
+
+	stopButton_ = new AMControlStopButton(0);
+
+	configurationView_ = new BioXASSSRLMonochromatorConfigurationView(0);
+
+	// Create and set layouts.
+
+	QHBoxLayout *stopButtonLayout = new QHBoxLayout();
+	stopButtonLayout->addStretch();
+	stopButtonLayout->addWidget(stopButton_);
+	stopButtonLayout->addStretch();
+
+	QVBoxLayout *layout = new QVBoxLayout();
+	layout->addLayout(stopButtonLayout);
+	layout->addWidget(configurationView_);
+
+	setLayout(layout);
+
+	// Current settings.
+
+	setMono(mono);
+
+	refresh();
+}
+
+BioXASSSRLMonochromatorView::~BioXASSSRLMonochromatorView()
+{
+
+}
+
+void BioXASSSRLMonochromatorView::refresh()
+{
+	// Clear the view.
+
+	stopButton_->setControl(0);
+
+	configurationView_->setMono(0);
+
+	// Update view elements.
+
+	stopButton_->setControl(mono_);
+
+	configurationView_->setMono(mono_);
+}
+
+void BioXASSSRLMonochromatorView::setMono(BioXASSSRLMonochromator *newMono)
+{
+	if (mono_ != newMono) {
+		mono_ = newMono;
+		refresh();
+
+		emit monoChanged(mono_);
+	}
+}

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorView.cpp
@@ -46,13 +46,11 @@ void BioXASSSRLMonochromatorView::refresh()
 	// Clear the view.
 
 	stopButton_->setControl(0);
-
 	configurationView_->setMono(0);
 
 	// Update view elements.
 
 	stopButton_->setControl(mono_);
-
 	configurationView_->setMono(mono_);
 }
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorView.h
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorView.h
@@ -1,0 +1,44 @@
+#ifndef BIOXASSSRLMONOCHROMATORVIEW_H
+#define BIOXASSSRLMONOCHROMATORVIEW_H
+
+#include <QWidget>
+#include <QLayout>
+
+class AMControlStopButton;
+class BioXASSSRLMonochromatorConfigurationView;
+class BioXASSSRLMonochromator;
+
+class BioXASSSRLMonochromatorView : public QWidget
+{
+    Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit BioXASSSRLMonochromatorView(BioXASSSRLMonochromator *mono, QWidget *parent = 0);
+	/// Destructor.
+	virtual ~BioXASSSRLMonochromatorView();
+
+	/// Returns the mono being viewed.
+	BioXASSSRLMonochromator* mono() const { return mono_; }
+
+signals:
+	/// Notifier that the mono being viewed has changed.
+	void monoChanged(BioXASSSRLMonochromator *newMono);
+
+public slots:
+	/// Refreshes the view.
+	void refresh();
+	/// Sets the mono being viewed.
+	void setMono(BioXASSSRLMonochromator *newMono);
+
+protected:
+	/// The mono being viewed.
+	BioXASSSRLMonochromator *mono_;
+
+	/// The mono stop button.
+	AMControlStopButton *stopButton_;
+	/// The mono configuration view.
+	BioXASSSRLMonochromatorConfigurationView *configurationView_;
+};
+
+#endif // BIOXASSSRLMONOCHROMATORVIEW_H

--- a/source/ui/beamline/AMControlStopButton.cpp
+++ b/source/ui/beamline/AMControlStopButton.cpp
@@ -1,0 +1,67 @@
+#include "AMControlStopButton.h"
+#include "beamline/AMControl.h"
+
+AMControlStopButton::AMControlStopButton(AMControl *control, QWidget *parent) :
+    QWidget(parent)
+{
+	// Initialize class variables.
+
+	control_ = 0;
+
+	// Create UI elements.
+
+	stopButton_ = new QPushButton();
+	stopButton_->setText("Stop");
+
+	connect( stopButton_, SIGNAL(clicked()), this, SLOT(onStopButtonClicked()) );
+
+	// Create and set layouts.
+
+	QVBoxLayout *layout = new QVBoxLayout();
+	layout->setMargin(0);
+	layout->addWidget(stopButton_);
+
+	setLayout(layout);
+
+	// Current settings.
+
+	setControl(control);
+
+	refresh();
+}
+
+AMControlStopButton::~AMControlStopButton()
+{
+
+}
+
+void AMControlStopButton::refresh()
+{
+	bool enabled = false;
+
+	if (control_)
+		enabled = true;
+
+	stopButton_->setEnabled(enabled);
+}
+
+void AMControlStopButton::setControl(AMControl *newControl)
+{
+	if (control_ != newControl) {
+		control_ = newControl;
+		refresh();
+
+		emit controlChanged(control_);
+	}
+}
+
+void AMControlStopButton::setStyleSheet(const QString &styleSheet)
+{
+	stopButton_->setStyleSheet(styleSheet);
+}
+
+void AMControlStopButton::onStopButtonClicked()
+{
+	if (control_)
+		control_->stop();
+}

--- a/source/ui/beamline/AMControlStopButton.cpp
+++ b/source/ui/beamline/AMControlStopButton.cpp
@@ -1,6 +1,5 @@
 #include "AMControlStopButton.h"
 #include "beamline/AMControl.h"
-#include <QDebug>
 
 AMControlStopButton::AMControlStopButton(AMControl *control, QWidget *parent) :
     QWidget(parent)
@@ -63,8 +62,6 @@ void AMControlStopButton::setStyleSheet(const QString &styleSheet)
 
 void AMControlStopButton::onStopButtonClicked()
 {
-	qDebug() << "\n\nStop button clicked.";
-
 	if (control_ && control_->canStop())
 		control_->stop();
 }

--- a/source/ui/beamline/AMControlStopButton.cpp
+++ b/source/ui/beamline/AMControlStopButton.cpp
@@ -1,5 +1,6 @@
 #include "AMControlStopButton.h"
 #include "beamline/AMControl.h"
+#include <QDebug>
 
 AMControlStopButton::AMControlStopButton(AMControl *control, QWidget *parent) :
     QWidget(parent)
@@ -39,7 +40,7 @@ void AMControlStopButton::refresh()
 {
 	bool enabled = false;
 
-	if (control_)
+	if (control_ && control_->canStop())
 		enabled = true;
 
 	stopButton_->setEnabled(enabled);
@@ -62,6 +63,8 @@ void AMControlStopButton::setStyleSheet(const QString &styleSheet)
 
 void AMControlStopButton::onStopButtonClicked()
 {
-	if (control_)
+	qDebug() << "\n\nStop button clicked.";
+
+	if (control_ && control_->canStop())
 		control_->stop();
 }

--- a/source/ui/beamline/AMControlStopButton.cpp
+++ b/source/ui/beamline/AMControlStopButton.cpp
@@ -40,7 +40,7 @@ void AMControlStopButton::refresh()
 {
 	bool enabled = false;
 
-	if (control_ && control_->canStop())
+	if (control_)
 		enabled = true;
 
 	stopButton_->setEnabled(enabled);

--- a/source/ui/beamline/AMControlStopButton.h
+++ b/source/ui/beamline/AMControlStopButton.h
@@ -1,0 +1,46 @@
+#ifndef AMCONTROLSTOPBUTTON_H
+#define AMCONTROLSTOPBUTTON_H
+
+#include <QWidget>
+#include <QPushButton>
+#include <QLayout>
+
+class AMControl;
+
+class AMControlStopButton : public QWidget
+{
+    Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit AMControlStopButton(AMControl *control, QWidget *parent = 0);
+	/// Destructor.
+	virtual ~AMControlStopButton();
+
+	/// Returns the control.
+	AMControl* control() const { return control_; }
+
+signals:
+	/// Notifier that the control has changed.
+	void controlChanged(AMControl *newControl);
+
+public slots:
+	/// Refreshes the view.
+	void refresh();
+	/// Sets the control.
+	void setControl(AMControl *newControl);
+	/// Sets the button's stylesheet.
+	void setStyleSheet(const QString &styleSheet);
+
+protected slots:
+	/// Handles situation when the stop button is clicked.
+	void onStopButtonClicked();
+
+protected:
+	/// The control being viewed.
+	AMControl *control_;
+	/// The stop button.
+	QPushButton *stopButton_;
+};
+
+#endif // AMCONTROLSTOPBUTTON_H


### PR DESCRIPTION
The M1, mono, and M2 classes all already inherit from BioXASBeamline Component, which is a direct descendent of AMControl. Each should be able to implement the stop() functionality that AMControl provides. I refactored the classes, developed a simple stop button for stopping controls, and added it to the views for each.