### PR TITLE
Pull Request for Issue1794: Exporter bug for incomplete scans

### DIFF
--- a/source/dataman/export/AMExporter2DAscii.cpp
+++ b/source/dataman/export/AMExporter2DAscii.cpp
@@ -65,7 +65,7 @@ bool AMExporter2DAscii::prepareDataSources()
 		currentScan_->dataSourceAt(0)->values(AMnDIndex(xRange-1,0), AMnDIndex(xRange-1, yRange-1), fillerData.data());
 
 		for (int j = 0; j < yRange && yRange_ == -1; j++)
-			if (int(fillerData.at(j)) == -1)
+			if (fillerData.at(j) == -1)
 				yRange_ = j+1;	// The +1 is because we want the next row.
 
 		if (yRange_ != -1){
@@ -74,7 +74,7 @@ bool AMExporter2DAscii::prepareDataSources()
 			currentScan_->dataSourceAt(0)->values(AMnDIndex(0, yRange_-1), AMnDIndex(xRange-1, yRange_-1), fillerData.data());
 
 			for (int i = 0; i < xRange && xIndex_ == -1; i++)
-				if (int(fillerData.at(i)) == -1)
+				if (fillerData.at(i) == -1)
 					xIndex_ = i;
 		}
 	}

--- a/source/dataman/export/AMSMAKExporter.cpp
+++ b/source/dataman/export/AMSMAKExporter.cpp
@@ -65,7 +65,7 @@ bool AMSMAKExporter::prepareDataSources()
 		currentScan_->dataSourceAt(0)->values(AMnDIndex(xRange-1,0), AMnDIndex(xRange-1, yRange-1), fillerData.data());
 
 		for (int j = 0; j < yRange && yRange_ == -1; j++)
-			if (int(fillerData.at(j)) == -1)
+			if (fillerData.at(j) == -1)
 				yRange_ = j+1;	// The +1 is because we want the next row.
 
 		if (yRange_ != -1){
@@ -74,7 +74,7 @@ bool AMSMAKExporter::prepareDataSources()
 			currentScan_->dataSourceAt(0)->values(AMnDIndex(0, yRange_-1), AMnDIndex(xRange-1, yRange_-1), fillerData.data());
 
 			for (int i = 0; i < xRange && xIndex_ == -1; i++)
-				if (int(fillerData.at(i)) == -1)
+				if (fillerData.at(i) == -1)
 					xIndex_ = i;
 
 			if (xIndex_ != xRange){


### PR DESCRIPTION
Turns out the problem was a random occurrence where if the x-axis values were -1.XYZ that the cast would be the same.  I removed the cast, which is safe for these cases because the values are set as -1 and are not manipulated in any way - therefore the double comparison isn't super shady. 

@iainworkman, can you look at this one for me?