### PR TITLE
Pull Request for Issue1817: Adding userRate.ESLO control to CLSSIS3820ScalerChannel

### DIFF
--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -228,18 +228,24 @@ void BioXASMainBeamline::setupComponents()
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
 	scaler_->channelAt(16)->setDetector(i0Detector_);
+	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
 
 	// I1 channel amplifier
 	i1Keithley_ = new CLSKeithley428("I1 Channel", "AMP1607-702", this);
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
 	scaler_->channelAt(17)->setDetector(i1Detector_);
+	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
 
 	// I2 channel amplifier
 	i2Keithley_ = new CLSKeithley428("I2 Channel", "AMP1607-703", this);
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
 	scaler_->channelAt(18)->setDetector(i2Detector_);
+	scaler_->channelAt(18)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(18)->setCountsVoltsSlopePreference(0.00001);
 
 	// Utilities
 	utilities_ = new BioXASBeamlineUtilities(this);

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -271,6 +271,7 @@ void BioXASSideBeamline::setupComponents()
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
 	scaler_->channelAt(16)->setDetector(i0Detector_);
 	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
 
 	// I1 channel amplifier.
 	i1Keithley_ = new CLSKeithley428("I1 Channel", "AMP1607-602", this);
@@ -280,6 +281,7 @@ void BioXASSideBeamline::setupComponents()
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
 	scaler_->channelAt(17)->setDetector(i1Detector_);
 	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
 
 	// I2 channel amplifier.
 	i2Keithley_ = new CLSKeithley428("I2 Channel", "AMP1607-603", this);
@@ -289,6 +291,7 @@ void BioXASSideBeamline::setupComponents()
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
 	scaler_->channelAt(18)->setDetector(i2Detector_);
 	scaler_->channelAt(18)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(18)->setCountsVoltsSlopePreference(0.00001);
 
 	// The germanium detector.
 	ge32ElementDetector_ = new BioXAS32ElementGeDetector("Ge32Element", "Ge 32 Element", this);

--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -519,6 +519,9 @@ CLSSIS3820ScalerChannel::CLSSIS3820ScalerChannel(const QString &baseName, int in
 
 	wasConnected_ = false;
 
+	haveCountsVoltsSlopePreference_ = false;
+	countsVoltsSlopePreference_ = 1;
+
 	// No SR570 or detector to start with.
 	currentAmplifier_ = 0;
 	voltageRange_ = AMRange();
@@ -531,15 +534,18 @@ CLSSIS3820ScalerChannel::CLSSIS3820ScalerChannel(const QString &baseName, int in
 	channelEnable_ = new AMPVControl(QString("Channel%1Enable").arg(index), fullBaseName%":enable", fullBaseName+":enable", QString(), this, 0.1);
 	channelReading_ = new AMReadOnlyPVControl(QString("Channel%1Reading").arg(index), fullBaseName%":fbk", this);
 	channelVoltage_ = new AMReadOnlyPVControl(QString("Channel%1Voltage").arg(index), fullBaseName%":userRate", this);
+	countsVoltsSlopeControl_ = new AMSinglePVControl(QString("Channel%1VoltageConversion").arg(index), fullBaseName%":userRate.ESLO", this);
 
 	allControls_ = new AMControlSet(this);
 	allControls_->addControl(channelEnable_);
 	allControls_->addControl(channelReading_);
 	allControls_->addControl(channelVoltage_);
+	allControls_->addControl(countsVoltsSlopeControl_);
 
 	connect(channelEnable_, SIGNAL(valueChanged(double)), this, SLOT(onChannelEnabledChanged()));
 	connect(channelReading_, SIGNAL(valueChanged(double)), this, SLOT(onChannelReadingChanged(double)));
 	connect(channelVoltage_, SIGNAL(valueChanged(double)), this, SIGNAL(voltageChanged(double)));
+	connect( countsVoltsSlopeControl_, SIGNAL(connected(bool)), this, SLOT(updateCountsVoltsSlopeControl()) );
 	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()));
 }
 
@@ -579,6 +585,12 @@ void CLSSIS3820ScalerChannel::onConnectedChanged()
 {
 	if (wasConnected_ != isConnected())
 		emit connected(wasConnected_ = isConnected());
+}
+
+void CLSSIS3820ScalerChannel::updateCountsVoltsSlopeControl()
+{
+	if (countsVoltsSlopeControl_ && countsVoltsSlopeControl_->isConnected() && haveCountsVoltsSlopePreference_)
+		countsVoltsSlopeControl_->move(countsVoltsSlopePreference_);
 }
 
 AMAction3* CLSSIS3820ScalerChannel::createEnableAction3(bool setEnabled){
@@ -659,6 +671,18 @@ void CLSSIS3820ScalerChannel::setVoltagRange(const AMRange &range)
 void CLSSIS3820ScalerChannel::setVoltagRange(double min, double max)
 {
 	setVoltagRange(AMRange(min, max));
+}
+
+void CLSSIS3820ScalerChannel::setCountsVoltsSlopePreference(double newValue)
+{
+	if (countsVoltsSlopePreference_ != newValue) {
+
+		haveCountsVoltsSlopePreference_ = true; // A preference has been specified.
+		countsVoltsSlopePreference_ = newValue; // Update the preference value.
+		updateCountsVoltsSlopeControl(); // Update the control with the new preference value, if the control is connected.
+
+		emit countsVoltsSlopePreferenceChanged(countsVoltsSlopePreference_);
+	}
 }
 
 void CLSSIS3820ScalerChannel::setDetector(AMDetector *detector)

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -28,6 +28,7 @@ class CLSSIS3820ScalerModeControl;
 class AMAction3;
 class AMControl;
 class AMReadOnlyPVControl;
+class AMSinglePVControl;
 class AMDetectorTriggerSource;
 class AMDetectorDwellTimeSource;
 class AMCurrentAmplifier;
@@ -260,6 +261,11 @@ public:
 	/// Specific helper function that returns whether the voltage is too high.  Returns false if withinLinearRange is true.
 	virtual bool voltageTooHigh() const { return !withinLinearRange() && voltage() > maximumVoltage(); }
 
+	/// Returns the counts-to-volts slope parameter preference.
+	double countsVoltsSlopePreference() const { return countsVoltsSlopePreference_; }
+	/// Returns the counts-to-volts conversion slope parameter control.
+	AMSinglePVControl* countsVoltsSlopeControl() const { return countsVoltsSlopeControl_; }
+
 public slots:
 	/// Sets whether the channel is enabled or not.
 	void setEnabled(bool isEnabled);
@@ -274,6 +280,8 @@ public slots:
 	void setVoltagRange(const AMRange &range);
 	/// Overloaded.  Sets the linear voltage range.
 	void setVoltagRange(double min, double max);
+	/// Sets the counts-to-volts slope parameter preference.
+	void setCountsVoltsSlopePreference(double newValue);
 
 	/// Sets an AMDetector to this particular channel. This connection grants us access to the detector's dark current measurement/correction abilities.
 	void setDetector(AMDetector *detector);
@@ -297,7 +305,8 @@ signals:
 	void sensitivityChanged();
 	/// Notifier that the detector for this channel has changed.
 	void detectorChanged(AMDetector *newDetector);
-
+	/// Notifier that the counts-to-volts slope parameter preference has changed.
+	void countsVoltsSlopePreferenceChanged(double newValue);
 
 protected slots:
 	/// Helper slot that emits the enabledChanged() signal.
@@ -306,6 +315,9 @@ protected slots:
 	void onChannelReadingChanged(double reading);
 	/// Handles figuring out whether the entire scalar channel is connected or not.
 	void onConnectedChanged();
+
+	/// Updates the counts-to-volts slope parameter control with the preferred value, if a preference has been specified and the control is connected.
+	void updateCountsVoltsSlopeControl();
 
 protected:
 	/// Index of this scaler channel.
@@ -333,6 +345,13 @@ protected:
 
 	/// The channel detector.
 	AMDetector *detector_;
+
+	/// The counts-to-volts slope parameter control.
+	AMSinglePVControl *countsVoltsSlopeControl_;
+	/// Flag indicating whether a counts-to-volts slope parameter value preference has been specified. Initially false.
+	bool haveCountsVoltsSlopePreference_;
+	/// The counts-to-volts slope parameter value preference. Initially 1.
+	double countsVoltsSlopePreference_;
 };
 
 #endif // CLSSIS3820SCALER_H


### PR DESCRIPTION
Added a new control to CLSSIS3820ScalerChannel, for the counts-to-volts conversion slope value. Added the ability to set a slope value preference to the scaler channel class--a preference because at the time this value would be specified (ie in AMBeamline::setupComponents()) the control may not be connected. The control is updated with the preference when it reports as connected. Added calls to set the preference to the scaler channels on BioXAS Side and Main.