### PR TITLE
Pull Request for Issue1660 alt: Adding stop capabilities to control editors on BioXAS

### DIFF
--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -111,7 +111,8 @@ HEADERS += \
     source/ui/BioXAS/BioXASValvesButton.h \
 	source/ui/BioXAS/BioXASBeamlineStatusBar.h \
     source/ui/BioXAS/BioXASSSRLMonochromatorCalibrationView.h \
-    source/ui/BioXAS/BioXASSSRLMonochromatorMaskView.h
+    source/ui/BioXAS/BioXASSSRLMonochromatorMaskView.h \
+    source/ui/BioXAS/BioXASControlEditor.h
 
 SOURCES += \
 	source/acquaman/BioXAS/BioXASXRFScanConfiguration.cpp \
@@ -217,4 +218,7 @@ SOURCES += \
     source/ui/BioXAS/BioXASValvesButton.cpp \
 	source/ui/BioXAS/BioXASBeamlineStatusBar.cpp \
     source/ui/BioXAS/BioXASSSRLMonochromatorCalibrationView.cpp \
-    source/ui/BioXAS/BioXASSSRLMonochromatorMaskView.cpp
+    source/ui/BioXAS/BioXASSSRLMonochromatorMaskView.cpp \
+    source/ui/BioXAS/BioXASControlEditor.cpp
+
+

--- a/source/ui/BioXAS/BioXASControlEditor.cpp
+++ b/source/ui/BioXAS/BioXASControlEditor.cpp
@@ -1,0 +1,119 @@
+#include "BioXASControlEditor.h"
+#include "beamline/AMControl.h"
+
+BioXASControlEditor::BioXASControlEditor(AMControl *control, QWidget *parent) :
+	AMExtendedControlEditor(control, 0, false, false, parent)
+{
+	// Initialize class variables.
+
+	moveAction_ = new QAction("Move", this);
+	moveAction_->setEnabled(false);
+
+	connect( moveAction_, SIGNAL(triggered()), this, SLOT(onMoveActionTriggered()) );
+
+	stopAction_ = new QAction("Stop", this);
+	stopAction_->setEnabled(false);
+
+	connect( stopAction_, SIGNAL(triggered()), this, SLOT(onStopActionTriggered()) );
+
+	calibrateAction_ = new QAction("Calibrate", this);
+	calibrateAction_->setEnabled(false);
+
+	connect( calibrateAction_, SIGNAL(triggered()), this, SLOT(onCalibrateActionTriggered()) );
+
+	// Current settings.
+
+	setContextMenuPolicy(Qt::CustomContextMenu);
+	connect( this, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onContextMenuRequested(QPoint)) );
+}
+
+BioXASControlEditor::~BioXASControlEditor()
+{
+
+}
+
+void BioXASControlEditor::updateActions()
+{
+	updateMoveAction();
+	updateStopAction();
+	updateCalibrateAction();
+}
+
+void BioXASControlEditor::updateMoveAction()
+{
+	bool enabled = false;
+
+	if (control_ && control_->canMove())
+		enabled = true;
+
+	moveAction_->setEnabled(enabled);
+}
+
+void BioXASControlEditor::updateStopAction()
+{
+	bool enabled = false;
+
+	if (control_ && control_->canStop())
+		enabled = true;
+
+	stopAction_->setEnabled(enabled);
+}
+
+void BioXASControlEditor::updateCalibrateAction()
+{
+	bool enabled = false;
+
+	if (control_ && control_->canCalibrate())
+		enabled = true;
+
+	calibrateAction_->setEnabled(enabled);
+}
+
+void BioXASControlEditor::onMoveActionTriggered()
+{
+	onEditStart();
+}
+
+void BioXASControlEditor::onStopActionTriggered()
+{
+	if (control_ && control_->canStop())
+		control_->stop();
+	else
+		QApplication::beep();
+}
+
+void BioXASControlEditor::onCalibrateActionTriggered()
+{
+	if (control_ && control_->canCalibrate()) {
+		bool inputOK = false;
+		double oldValue = control_->value();
+		double newValue = QInputDialog::getDouble(this, QString("Calibrate %1").arg(control_->name()), "Enter calibrated value:", oldValue, DBL_MIN, DBL_MAX, 3, &inputOK);
+
+		if (inputOK)
+			control_->calibrate(oldValue, newValue);
+
+	} else {
+		QApplication::beep();
+	}
+}
+
+void BioXASControlEditor::onContextMenuRequested(const QPoint &clickPosition)
+{
+	// Update the actions to reflect current control settings.
+
+	updateActions();
+
+	// Create context menu.
+
+	QMenu contextMenu;
+
+	contextMenu.addAction(moveAction_);
+	contextMenu.addAction(stopAction_);
+	contextMenu.addAction(calibrateAction_);
+
+	// Show menu.
+
+	contextMenu.exec(mapToGlobal(clickPosition));
+}
+
+

--- a/source/ui/BioXAS/BioXASControlEditor.h
+++ b/source/ui/BioXAS/BioXASControlEditor.h
@@ -1,0 +1,50 @@
+#ifndef BIOXASCONTROLEDITOR_H
+#define BIOXASCONTROLEDITOR_H
+
+#include <QMenu>
+#include <QAction>
+#include <QInputDialog>
+#include <QApplication>
+
+#include "ui/beamline/AMExtendedControlEditor.h"
+
+class BioXASControlEditor : public AMExtendedControlEditor
+{
+    Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit BioXASControlEditor(AMControl *control, QWidget *parent = 0);
+	/// Destructor.
+	virtual ~BioXASControlEditor();
+
+protected slots:
+	/// Updates the actions.
+	void updateActions();
+	/// Updates the move action.
+	void updateMoveAction();
+	/// Updates the stop action.
+	void updateStopAction();
+	/// Updates the calibrate action.
+	void updateCalibrateAction();
+
+	/// Handles initiating a move, when the move action is triggered.
+	void onMoveActionTriggered();
+	/// Handles initiating a stop, when the stop action is triggered.
+	void onStopActionTriggered();
+	/// Handles initiating a calibration, when the calibrate action is triggered.
+	void onCalibrateActionTriggered();
+
+	/// Handles displaying context menu options when requested.
+	void onContextMenuRequested(const QPoint &clickPosition);
+
+protected:
+	/// The move action.
+	QAction *moveAction_;
+	/// The stop action.
+	QAction *stopAction_;
+	/// The calibrate action.
+	QAction *calibrateAction_;
+};
+
+#endif // BIOXASCONTROLEDITOR_H

--- a/source/ui/BioXAS/BioXASM1MirrorMaskView.cpp
+++ b/source/ui/BioXAS/BioXASM1MirrorMaskView.cpp
@@ -1,5 +1,5 @@
 #include "BioXASM1MirrorMaskView.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 #include "beamline/BioXAS/BioXASM1MirrorMask.h"
 #include "beamline/BioXAS/BioXASM1MirrorMaskState.h"
 
@@ -12,10 +12,10 @@ BioXASM1MirrorMaskView::BioXASM1MirrorMaskView(BioXASM1MirrorMask *mask, QWidget
 
 	// Create UI elements.
 
-	upperBladeEditor_ = new AMExtendedControlEditor(0);
+	upperBladeEditor_ = new BioXASControlEditor(0);
 	upperBladeEditor_->setTitle("Upper blade");
 
-	stateEditor_ = new AMExtendedControlEditor(0);
+	stateEditor_ = new BioXASControlEditor(0);
 	stateEditor_->setTitle("State");
 	stateEditor_->setNoUnitsBox(true);
 

--- a/source/ui/BioXAS/BioXASM1MirrorView.h
+++ b/source/ui/BioXAS/BioXASM1MirrorView.h
@@ -2,6 +2,7 @@
 #define BIOXASM1MIRRORVIEW_H
 
 #include <QWidget>
+#include <QGroupBox>
 
 #include "ui/BioXAS/BioXASMirrorView.h"
 #include "beamline/BioXAS/BioXASM1Mirror.h"

--- a/source/ui/BioXAS/BioXASM2MirrorView.cpp
+++ b/source/ui/BioXAS/BioXASM2MirrorView.cpp
@@ -1,5 +1,5 @@
 #include "BioXASM2MirrorView.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 BioXASM2MirrorView::BioXASM2MirrorView(BioXASM2Mirror *mirror, QWidget *parent) :
     QWidget(parent)
@@ -12,7 +12,7 @@ BioXASM2MirrorView::BioXASM2MirrorView(BioXASM2Mirror *mirror, QWidget *parent) 
 
 	stopButton_ = new AMControlStopButton(0);
 
-	screenEditor_ = new AMExtendedControlEditor(0);
+	screenEditor_ = new BioXASControlEditor(0);
 	screenEditor_->setNoUnitsBox(true);
 	screenEditor_->setTitle("Fluorescent screen");
 

--- a/source/ui/BioXAS/BioXASMirrorBendView.cpp
+++ b/source/ui/BioXAS/BioXASMirrorBendView.cpp
@@ -1,4 +1,5 @@
 #include "BioXASMirrorBendView.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 BioXASMirrorBendView::BioXASMirrorBendView(BioXASMirror *mirror, QWidget *parent) :
     QWidget(parent)
@@ -9,17 +10,17 @@ BioXASMirrorBendView::BioXASMirrorBendView(BioXASMirror *mirror, QWidget *parent
 
 	// Create bend editor.
 
-	bendEditor_ = new AMExtendedControlEditor(0);
+	bendEditor_ = new BioXASControlEditor(0);
 	bendEditor_->setControlFormat('f', 2);
 	bendEditor_->setTitle("Radius");
 
 	// Create bender view.
 
-	upstreamEditor_ = new AMExtendedControlEditor(0);
+	upstreamEditor_ = new BioXASControlEditor(0);
 	upstreamEditor_->setControlFormat('f', 2);
 	upstreamEditor_->setTitle("Upstream bender");
 
-	downstreamEditor_ = new AMExtendedControlEditor(0);
+	downstreamEditor_ = new BioXASControlEditor(0);
 	downstreamEditor_->setControlFormat('f', 2);
 	downstreamEditor_->setTitle("Downstream bender");
 

--- a/source/ui/BioXAS/BioXASMirrorBendView.h
+++ b/source/ui/BioXAS/BioXASMirrorBendView.h
@@ -5,7 +5,8 @@
 #include <QLayout>
 
 #include "beamline/BioXAS/BioXASMirror.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+
+class AMExtendedControlEditor;
 
 class BioXASMirrorBendView : public QWidget
 {

--- a/source/ui/BioXAS/BioXASMirrorView.cpp
+++ b/source/ui/BioXAS/BioXASMirrorView.cpp
@@ -1,7 +1,7 @@
 #include "BioXASMirrorView.h"
 #include "beamline/BioXAS/BioXASMirror.h"
 #include "ui/BioXAS/BioXASMirrorBendView.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 BioXASMirrorView::BioXASMirrorView(BioXASMirror *mirror, QWidget *parent) :
     QWidget(parent)
@@ -12,23 +12,23 @@ BioXASMirrorView::BioXASMirrorView(BioXASMirror *mirror, QWidget *parent) :
 
 	// Create basic controls view.
 
-	pitchEditor_ = new AMExtendedControlEditor(0);
+	pitchEditor_ = new BioXASControlEditor(0);
 	pitchEditor_->setControlFormat('f', 3);
 	pitchEditor_->setTitle("Pitch");
 
-	rollEditor_ = new AMExtendedControlEditor(0);
+	rollEditor_ = new BioXASControlEditor(0);
 	rollEditor_->setControlFormat('f', 3);
 	rollEditor_->setTitle("Roll");
 
-	yawEditor_ = new AMExtendedControlEditor(0);
+	yawEditor_ = new BioXASControlEditor(0);
 	yawEditor_->setControlFormat('f', 3);
 	yawEditor_->setTitle("Yaw");
 
-	heightEditor_ = new AMExtendedControlEditor(0);
+	heightEditor_ = new BioXASControlEditor(0);
 	heightEditor_->setControlFormat('f', 3);
 	heightEditor_->setTitle("Height");
 
-	lateralEditor_ = new AMExtendedControlEditor(0);
+	lateralEditor_ = new BioXASControlEditor(0);
 	lateralEditor_->setControlFormat('f', 3);
 	lateralEditor_->setTitle("Lateral");
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorBasicView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorBasicView.cpp
@@ -1,6 +1,6 @@
 #include "BioXASSSRLMonochromatorBasicView.h"
 #include "beamline/BioXAS/BioXASSSRLMonochromator.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 #include "ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.h"
 
 BioXASSSRLMonochromatorBasicView::BioXASSSRLMonochromatorBasicView(BioXASSSRLMonochromator *mono, QWidget *parent) :
@@ -12,11 +12,11 @@ BioXASSSRLMonochromatorBasicView::BioXASSSRLMonochromatorBasicView(BioXASSSRLMon
 
 	// Create UI elements.
 
-	energyEditor_ = new AMExtendedControlEditor(0);
+	energyEditor_ = new BioXASControlEditor(0);
 	energyEditor_->setTitle("Energy");
 	energyEditor_->setControlFormat('f', 2);
 
-	braggAngleEditor_ = new AMExtendedControlEditor(0);
+	braggAngleEditor_ = new BioXASControlEditor(0);
 	braggAngleEditor_->setTitle("Goniometer angle");
 	braggAngleEditor_->setControlFormat('f', 2);
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorConfigurationView.cpp
@@ -1,6 +1,6 @@
 #include "BioXASSSRLMonochromatorConfigurationView.h"
 #include "beamline/BioXAS/BioXASSSRLMonochromator.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 #include "ui/BioXAS/BioXASSSRLMonochromatorEnergyView.h"
 #include "ui/BioXAS/BioXASSSRLMonochromatorCalibrationView.h"
 #include "ui/BioXAS/BioXASSSRLMonochromatorMaskView.h"
@@ -29,15 +29,15 @@ BioXASSSRLMonochromatorConfigurationView::BioXASSSRLMonochromatorConfigurationVi
 	maskBox->setTitle("Mask");
 	maskBox->setLayout(maskBoxLayout);
 
-	heightEditor_ = new AMExtendedControlEditor(0);
+	heightEditor_ = new BioXASControlEditor(0);
 	heightEditor_->setTitle("Height");
 	heightEditor_->setControlFormat('f', 3);
 
-	lateralEditor_ = new AMExtendedControlEditor(0);
+	lateralEditor_ = new BioXASControlEditor(0);
 	lateralEditor_->setTitle("Lateral");
 	lateralEditor_->setControlFormat('f', 3);
 
-	paddleEditor_ = new AMExtendedControlEditor(0);
+	paddleEditor_ = new BioXASControlEditor(0);
 	paddleEditor_->setTitle("Paddle");
 
 	QVBoxLayout *motorsBoxLayout = new QVBoxLayout();

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorCrystalsView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorCrystalsView.cpp
@@ -1,6 +1,6 @@
 #include "BioXASSSRLMonochromatorCrystalsView.h"
 #include "beamline/BioXAS/BioXASSSRLMonochromator.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 BioXASSSRLMonochromatorCrystalsView::BioXASSSRLMonochromatorCrystalsView(BioXASSSRLMonochromator *mono, QWidget *parent) :
     QWidget(parent)
@@ -11,10 +11,10 @@ BioXASSSRLMonochromatorCrystalsView::BioXASSSRLMonochromatorCrystalsView(BioXASS
 
 	// Create crystal 1 view.
 
-	crystal1PitchEditor_ = new AMExtendedControlEditor(0);
+	crystal1PitchEditor_ = new BioXASControlEditor(0);
 	crystal1PitchEditor_->setTitle("Pitch motor");
 
-	crystal1RollEditor_ = new AMExtendedControlEditor(0);
+	crystal1RollEditor_ = new BioXASControlEditor(0);
 	crystal1RollEditor_->setTitle("Roll motor");
 
 	QVBoxLayout *crystal1BoxLayout = new QVBoxLayout();
@@ -28,10 +28,10 @@ BioXASSSRLMonochromatorCrystalsView::BioXASSSRLMonochromatorCrystalsView(BioXASS
 
 	// Create crystal 2 view.
 
-	crystal2PitchEditor_ = new AMExtendedControlEditor(0);
+	crystal2PitchEditor_ = new BioXASControlEditor(0);
 	crystal2PitchEditor_->setTitle("Pitch motor");
 
-	crystal2RollEditor_ = new AMExtendedControlEditor(0);
+	crystal2RollEditor_ = new BioXASControlEditor(0);
 	crystal2RollEditor_->setTitle("Roll motor");
 
 	QVBoxLayout *crystal2BoxLayout = new QVBoxLayout();

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorEnergyView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorEnergyView.cpp
@@ -1,6 +1,6 @@
 #include "BioXASSSRLMonochromatorEnergyView.h"
 #include "beamline/BioXAS/BioXASSSRLMonochromator.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 #include "ui/CLS/CLSMAXvMotorConfigurationView.h"
 
 BioXASSSRLMonochromatorEnergyView::BioXASSSRLMonochromatorEnergyView(BioXASSSRLMonochromator *mono, QWidget *parent) :
@@ -12,23 +12,23 @@ BioXASSSRLMonochromatorEnergyView::BioXASSSRLMonochromatorEnergyView(BioXASSSRLM
 
 	// Create energy editors.
 
-	stepEnergyEditor_ = new AMExtendedControlEditor(0);
+	stepEnergyEditor_ = new BioXASControlEditor(0);
 	stepEnergyEditor_->setTitle("Energy (step)");
 	stepEnergyEditor_->setControlFormat('f', 2);
 
-	encoderEnergyEditor_ = new AMExtendedControlEditor(0);
+	encoderEnergyEditor_ = new BioXASControlEditor(0);
 	encoderEnergyEditor_->setTitle("Energy (encoder)");
 	encoderEnergyEditor_->setControlFormat('f', 2);
 
-	stepBraggEditor_ = new AMExtendedControlEditor(0);
+	stepBraggEditor_ = new BioXASControlEditor(0);
 	stepBraggEditor_->setTitle("Goniometer (step)");
 	stepBraggEditor_->setControlFormat('f', 2);
 
-	encoderBraggEditor_ = new AMExtendedControlEditor(0);
+	encoderBraggEditor_ = new BioXASControlEditor(0);
 	encoderBraggEditor_->setTitle("Goniometer (encoder)");
 	encoderBraggEditor_->setControlFormat('f', 2);
 
-	mirrorPitchEditor_ = new AMExtendedControlEditor(0);
+	mirrorPitchEditor_ = new BioXASControlEditor(0);
 	mirrorPitchEditor_->setTitle("M1 mirror pitch");
 	mirrorPitchEditor_->setControlFormat('f', 2);
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorMaskView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorMaskView.cpp
@@ -1,7 +1,7 @@
 #include "BioXASSSRLMonochromatorMaskView.h"
 #include "beamline/BioXAS/BioXASSSRLMonochromatorMask.h"
 #include "beamline/BioXAS/BioXASSSRLMonochromatorMaskState.h"
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 BioXASSSRLMonochromatorMaskView::BioXASSSRLMonochromatorMaskView(BioXASSSRLMonochromatorMask *mask, QWidget *parent) :
     QWidget(parent)
@@ -12,15 +12,15 @@ BioXASSSRLMonochromatorMaskView::BioXASSSRLMonochromatorMaskView(BioXASSSRLMonoc
 
 	// Create UI elements.
 
-	stateEditor_ = new AMExtendedControlEditor(0);
+	stateEditor_ = new BioXASControlEditor(0);
 	stateEditor_->setTitle("State");
 	stateEditor_->setNoUnitsBox(true);
 
-	upperBladeEditor_ = new AMExtendedControlEditor(0);
+	upperBladeEditor_ = new BioXASControlEditor(0);
 	upperBladeEditor_->setTitle("Upper blade");
 	upperBladeEditor_->setControlFormat('f', 3);
 
-	lowerBladeEditor_ = new AMExtendedControlEditor(0);
+	lowerBladeEditor_ = new BioXASControlEditor(0);
 	lowerBladeEditor_->setTitle("Lower blade");
 	lowerBladeEditor_->setControlFormat('f', 3);
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.cpp
@@ -2,7 +2,7 @@
 #include "beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.h"
 
 BioXASSSRLMonochromatorRegionControlEditor::BioXASSSRLMonochromatorRegionControlEditor(BioXASSSRLMonochromatorRegionControl *regionControl, QWidget *parent) :
-	AMExtendedControlEditor(regionControl, 0, false, false, parent)
+	BioXASControlEditor(regionControl, parent)
 {
 	setNoUnitsBox(true);
 }

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.h
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.h
@@ -7,11 +7,11 @@
 #include <QDialogButtonBox>
 #include <QProgressBar>
 
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 class BioXASSSRLMonochromatorRegionControl;
 
-class BioXASSSRLMonochromatorRegionControlEditor : public AMExtendedControlEditor
+class BioXASSSRLMonochromatorRegionControlEditor : public BioXASControlEditor
 {
 	Q_OBJECT
 public:


### PR DESCRIPTION
Created a new class BioXASControlEditor, a subclass of AMExtendedControlEditor. This editor provides a context menu with the available action options that can be performed with a control: move, stop, calibrate. The action options are enabled if that option is available for that particular control, disabled otherwise. Replaced instances of AMExtendedControlEditor with the new editor for all controls in the mono, m1 mirror, and m2 mirror views.