### PR TITLE
Pull Request for Issue 1824: Fix from SGM Scaler View

### DIFF
--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -273,6 +273,8 @@ void SGMAppController::setupUserInterface()
 	mw_->addRightWidget(persistentView);
 
 	CLSAMDSScalerView *amdsScalerView = new CLSAMDSScalerView(SGMBeamline::sgm()->amdsScaler());
+	amdsScalerView->setAmplifierViewFormat('g');
+	amdsScalerView->setAmplifierViewPrecision(3);
 
 	mw_->insertHeading("Components", 0);
 


### PR DESCRIPTION
Changed format of the SGM Scaler view to display int values instead of doubles.