### PR TITLE
Pull Request for Issue1845: Make SGM Default to Using Local Storage

### DIFF
--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -58,6 +58,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 SGMAppController::SGMAppController(QObject *parent) :
 	AMAppController(parent)
 {
+	// Ensure we're using local storage by default.
+	setDefaultUseLocalStorage(true);
+
 	userConfiguration_ = 0;
 }
 
@@ -66,9 +69,6 @@ bool SGMAppController::startup() {
 	// Run all of the Acquaman App startup routines. Some of these are reimplemented in this class.
 	if(!AMAppController::startup())
 		return false;
-
-	// Ensure we're using local storage by default.
-	setDefaultUseLocalStorage(true);
 
 	// Creates the SGM Beamline object
 	SGMBeamline::sgm();

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -67,6 +67,9 @@ bool SGMAppController::startup() {
 	if(!AMAppController::startup())
 		return false;
 
+	// Ensure we're using local storage by default.
+	setDefaultUseLocalStorage(true);
+
 	// Creates the SGM Beamline object
 	SGMBeamline::sgm();
 


### PR DESCRIPTION
Added setDefaultUseLocalStorage(true) to the SGMAppController constructor.

Had to play around with adding a AcquamanLocalData directory to my machine, as I couldn't figure out why the option still wasn't appearing. :/