### PR TITLE
Pull Request for Issue1844: Ge detector regions of interest not set with XAS scans.

### DIFF
--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -201,12 +201,8 @@ void BioXASXASScanActionController::createScanAssembler()
 	scanAssembler_ = new AMEXAFSScanActionControllerAssembler(this);
 }
 
-#include <QDebug>
-
 void BioXASXASScanActionController::buildScanControllerImplementation()
 {
-	qDebug() << "\n\nBuilding scan controller.";
-
 	// Identify data sources for the scaler channels.
 
 	AMDataSource *i0DetectorSource = 0;
@@ -215,7 +211,6 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 	if (i0Detector) {
 		int i0DetectorIndex = scan_->indexOfDataSource(i0Detector->name());
 		if (i0DetectorIndex != -1) {
-			qDebug() << "I0 detector used in scan.";
 			i0DetectorSource = scan_->dataSourceAt(i0DetectorIndex);
 		}
 	}
@@ -291,8 +286,6 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 			connect( i0Detector, SIGNAL(darkCurrentValueChanged(double)), i0CorrectedDetectorSource, SLOT(setDarkCurrent(double)) );
 
 			scan_->addAnalyzedDataSource(i0CorrectedDetectorSource, true, false);
-
-			qDebug() << "I0 Detector (dark current corrected) used in scan.";
 		}
 
 		if (dwellTimeSource && i1DetectorSource) {

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -4,7 +4,7 @@
 #include "beamline/CLS/CLSStorageRing.h"
 
 #include "dataman/BioXAS/BioXASDbUpgrade1Pt1.h"
-#include <QDebug>
+
 BioXASAppController::BioXASAppController(QObject *parent) :
     AMAppController(parent)
 {	
@@ -65,21 +65,15 @@ bool BioXASAppController::startup()
 		setupScanConfigurations();
 		setupUserInterface();
 
-		qDebug() << "\n\nBioXASAppController::startup().";
 		if (userConfiguration_) {
 
 			connect( userConfiguration_, SIGNAL(loadedFromDb()), this, SLOT(onUserConfigurationLoadedFromDb()) );
 
-			qDebug() << "Startup user configuration is valid.";
 			bool loaded = userConfiguration_->loadFromDb(AMDatabase::database("user"), 1);
 
 			if (!loaded) {
-				qDebug() << "Startup user configuration is valid, not loaded. Loading user configuration...";
 				userConfiguration_->storeToDb(AMDatabase::database("user"));
 				onUserConfigurationLoadedFromDb();
-
-			} else {
-				qDebug() << "Startup user configuration is loaded. Startup complete.";
 			}
 		}
 
@@ -99,15 +93,12 @@ void BioXASAppController::shutdown()
 
 void BioXASAppController::onUserConfigurationLoadedFromDb()
 {
-	qDebug() << "onUserConfigurationLoadedFromDb()...";
-
 	if (userConfiguration_) {
 
-		qDebug() << "User configuration valid.";
-
 		BioXAS32ElementGeDetector *geDetector = BioXASBeamline::bioXAS()->ge32ElementDetector();
+
 		if (geDetector) {
-			qDebug() << "Ge detector valid.";
+
 			foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 				AMRegionOfInterest *newRegion = region->createCopy();
 				geDetector->addRegionOfInterest(newRegion);
@@ -116,11 +107,7 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 
 			connect(geDetector, SIGNAL(addedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestAdded(AMRegionOfInterest*)));
 			connect(geDetector, SIGNAL(removedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestRemoved(AMRegionOfInterest*)));
-		} else {
-			qDebug() << "Ge detector NOT valid.";
 		}
-	} else {
-		qDebug() << "User configuration NOT valid.";
 	}
 }
 


### PR DESCRIPTION
The problem ended up being with a misplaced connect statement: user configurations were connected to after they would have emitted their loadedFromDb() signals. This issue exposed another problem in BioXASXASScanActionController where the Ge detector's normalization ABs were being passed invalid data sources. This problem was fixed in this issue as well.