### PR TITLE
Pull Request for Issue1851: Add missing Q_PROPERTY calls to AMActionInfo3 Classes

### DIFF
--- a/source/actions3/actions/AMAxisFinishedActionInfo.cpp
+++ b/source/actions3/actions/AMAxisFinishedActionInfo.cpp
@@ -47,4 +47,5 @@ AMActionInfo3 *AMAxisFinishedActionInfo::createCopy() const
 void AMAxisFinishedActionInfo::setAxisName(const QString &axisName)
 {
 	axisName_ = axisName;
+	setModified(true);
 }

--- a/source/actions3/actions/AMAxisFinishedActionInfo.cpp
+++ b/source/actions3/actions/AMAxisFinishedActionInfo.cpp
@@ -43,3 +43,8 @@ AMActionInfo3 *AMAxisFinishedActionInfo::createCopy() const
 	info->dissociateFromDb(true);
 	return info;
 }
+
+void AMAxisFinishedActionInfo::setAxisName(const QString &axisName)
+{
+	axisName_ = axisName;
+}

--- a/source/actions3/actions/AMAxisFinishedActionInfo.h
+++ b/source/actions3/actions/AMAxisFinishedActionInfo.h
@@ -27,6 +27,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMAxisFinishedActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+
+	Q_PROPERTY(QString axisName READ axisName WRITE setAxisName)
 public:
 	/// Constructor
 	Q_INVOKABLE AMAxisFinishedActionInfo(const QString &axisName = "", QObject *parent = 0);
@@ -42,9 +44,14 @@ public:
 	/// This should describe the type of the action
 	virtual QString typeDescription() const { return "Start Axis"; }
 
+	/// The name of the axis which has finished.
 	QString axisName() const { return axisName_; }
 
 protected:
+
+	/// Sets the name of the axis which has finished.
+	void setAxisName(const QString& axisName);
+
 	QString axisName_;
 };
 

--- a/source/actions3/actions/AMControlCalibrateActionInfo.h
+++ b/source/actions3/actions/AMControlCalibrateActionInfo.h
@@ -9,6 +9,9 @@ class AMControlCalibrateActionInfo : public AMActionInfo3
 {
 	Q_OBJECT
 
+	Q_PROPERTY(AMDbObject* controlInfo READ dbReadControlInfo WRITE dbLoadControlInfo)
+	Q_PROPERTY(double oldValue READ dbReadOldValue WRITE dbLoadOldValue)
+	Q_PROPERTY(double newValue READ dbReadNewValue WRITE dbLoadNewValue)
 public:
 	/// Constructor.
 	explicit AMControlCalibrateActionInfo(const AMControlInfo &control = AMControlInfo(), const AMNumber &oldValue = AMNumber::InvalidError, const AMNumber &newValue = AMNumber::InvalidError, QObject *parent = 0);
@@ -50,10 +53,18 @@ protected:
 	/// Updates the description.
 	void updateDescriptionText();
 
-	/// For database storing only.
+	/// For database storing of the control info only.
 	AMControlInfo* dbReadControlInfo() { return &controlInfo_; }
-	/// For database loading only.
+	/// For database loading of the control info only.
 	void dbLoadControlInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
+	/// For database storing of the old value only.
+	double dbReadOldValue() { return double(oldValue_); }
+	/// For database loading of the old value only.
+	void dbLoadOldValue(double oldValue) { oldValue_ = AMNumber(oldValue); }
+	/// For database storing of the new value only.
+	double dbReadNewValue() { return double(newValue_); }
+	/// For database loading of the new value only.
+	void dbLoadNewValue(double newValue) { newValue_ = AMNumber(newValue); }
 
 protected:
 	/// The control info.

--- a/source/actions3/actions/AMDetectorAcquisitionActionInfo.h
+++ b/source/actions3/actions/AMDetectorAcquisitionActionInfo.h
@@ -28,7 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorAcquisitionActionInfo : public AMActionInfo3
 {
 Q_OBJECT
-	Q_PROPERTY(AMDetectorInfo* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
 	Q_PROPERTY(int readMode READ dbReadReadMode WRITE dbLoadReadMode)
 
 public:

--- a/source/actions3/actions/AMDetectorAcquisitionActionInfo.h
+++ b/source/actions3/actions/AMDetectorAcquisitionActionInfo.h
@@ -28,6 +28,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorAcquisitionActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+	Q_PROPERTY(AMDetectorInfo* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(int readMode READ dbReadReadMode WRITE dbLoadReadMode)
+
 public:
 	/// Constructor
 	virtual ~AMDetectorAcquisitionActionInfo();
@@ -48,12 +51,18 @@ public:
 	/// Returns the read mode for this acquisition
 	AMDetectorDefinitions::ReadMode readMode() const { return readMode_; }
 
+protected:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
-protected:
+	/// For storing the read mode to the database only.
+	int dbReadReadMode() { return int(readMode_); }
+
+	/// For loading the read mode from the database only.
+	void dbLoadReadMode(int readMode) { readMode_ = AMDetectorDefinitions::ReadMode(readMode); }
+
 	/// The AMDetectorInfo that specifies which detector to acquire
 	AMDetectorInfo detectorInfo_;
 

--- a/source/actions3/actions/AMDetectorCleanupActionInfo.h
+++ b/source/actions3/actions/AMDetectorCleanupActionInfo.h
@@ -28,6 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorCleanupActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
 public:
 	/// Constructor
 	virtual ~AMDetectorCleanupActionInfo();

--- a/source/actions3/actions/AMDetectorDwellTimeActionInfo.cpp
+++ b/source/actions3/actions/AMDetectorDwellTimeActionInfo.cpp
@@ -46,3 +46,9 @@ AMActionInfo3 *AMDetectorDwellTimeActionInfo::createCopy() const
 	info->dissociateFromDb(true);
 	return info;
 }
+
+void AMDetectorDwellTimeActionInfo::setDwellSeconds(double dwellSeconds)
+{
+	 dwellSeconds_ = dwellSeconds;
+	 setModified(true);
+}

--- a/source/actions3/actions/AMDetectorDwellTimeActionInfo.h
+++ b/source/actions3/actions/AMDetectorDwellTimeActionInfo.h
@@ -28,6 +28,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorDwellTimeActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(double dwellSeconds READ dwellSeconds WRITE setDwellSeconds)
 public:
 	/// Constructor
 	virtual ~AMDetectorDwellTimeActionInfo();
@@ -48,12 +50,16 @@ public:
 	/// Returns the requested dwell time
 	double dwellSeconds() const { return dwellSeconds_; }
 
+
+protected:
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
-protected:
+	/// Sets the dwell seconds to the provided value. Used in database loading.
+	void setDwellSeconds(double dwellSeconds) { dwellSeconds_ = dwellSeconds; }
+
 	/// The AMDetectorInfo that specifies which detector to acquire
 	AMDetectorInfo detectorInfo_;
 

--- a/source/actions3/actions/AMDetectorDwellTimeActionInfo.h
+++ b/source/actions3/actions/AMDetectorDwellTimeActionInfo.h
@@ -58,7 +58,7 @@ protected:
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 	/// Sets the dwell seconds to the provided value. Used in database loading.
-	void setDwellSeconds(double dwellSeconds) { dwellSeconds_ = dwellSeconds; }
+	void setDwellSeconds(double dwellSeconds);
 
 	/// The AMDetectorInfo that specifies which detector to acquire
 	AMDetectorInfo detectorInfo_;

--- a/source/actions3/actions/AMDetectorInitializeActionInfo.h
+++ b/source/actions3/actions/AMDetectorInitializeActionInfo.h
@@ -28,6 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorInitializeActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
 public:
 	/// Constructor
 	virtual ~AMDetectorInitializeActionInfo();

--- a/source/actions3/actions/AMDetectorReadActionInfo.h
+++ b/source/actions3/actions/AMDetectorReadActionInfo.h
@@ -28,6 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorReadActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
 public:
 	/// Constructor
 	virtual ~AMDetectorReadActionInfo();

--- a/source/actions3/actions/AMDetectorSetDarkCurrentTimeActionInfo.cpp
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentTimeActionInfo.cpp
@@ -28,3 +28,9 @@ AMActionInfo3* AMDetectorSetDarkCurrentTimeActionInfo::createCopy() const
 	info->dissociateFromDb(true);
 	return info;
 }
+
+void AMDetectorSetDarkCurrentTimeActionInfo::setDarkCurrentTime(double darkCurrentTime)
+{
+	 darkCurrentTime_ = darkCurrentTime;
+	 setModified(true);
+}

--- a/source/actions3/actions/AMDetectorSetDarkCurrentTimeActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentTimeActionInfo.h
@@ -34,7 +34,7 @@ protected:
 	/// For database loading only.
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 	/// Sets the dark curren time. For database loading only.
-	void setDarkCurrentTime(double darkCurrentTime) { darkCurrentTime_ = darkCurrentTime; }
+	void setDarkCurrentTime(double darkCurrentTime);
 
 	/// The AMDetectorInfo.
 	AMDetectorInfo detectorInfo_;

--- a/source/actions3/actions/AMDetectorSetDarkCurrentTimeActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentTimeActionInfo.h
@@ -7,7 +7,8 @@
 class AMDetectorSetDarkCurrentTimeActionInfo : public AMActionInfo3
 {
     Q_OBJECT
-
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(double darkCurrentTime READ darkCurrentTime WRITE setDarkCurrentTime)
 public:
 	/// Constructor.
 	Q_INVOKABLE AMDetectorSetDarkCurrentTimeActionInfo(double secondsDwell = 0, const AMDetectorInfo &detectorInfo = AMDetectorInfo(), QObject *parent = 0);
@@ -26,12 +27,15 @@ public:
 	/// Returns the dark current time to be set, in seconds.
 	double darkCurrentTime() const { return darkCurrentTime_; }
 
+
+protected:
 	/// Returns the detector info for database storing.
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only.
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
+	/// Sets the dark curren time. For database loading only.
+	void setDarkCurrentTime(double darkCurrentTime) { darkCurrentTime_ = darkCurrentTime; }
 
-protected:
 	/// The AMDetectorInfo.
 	AMDetectorInfo detectorInfo_;
 	/// The desired dark current time.

--- a/source/actions3/actions/AMDetectorSetDarkCurrentValidStateActionInfo.cpp
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentValidStateActionInfo.cpp
@@ -28,3 +28,9 @@ AMActionInfo3* AMDetectorSetDarkCurrentValidStateActionInfo::createCopy() const
 	info->dissociateFromDb(true);
 	return info;
 }
+
+void AMDetectorSetDarkCurrentValidStateActionInfo::setDarkCurrentState(bool darkCurrentState)
+{
+	 darkCurrentState_ = darkCurrentState;
+	 setModified(true);
+}

--- a/source/actions3/actions/AMDetectorSetDarkCurrentValidStateActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentValidStateActionInfo.h
@@ -7,7 +7,8 @@
 class AMDetectorSetDarkCurrentValidStateActionInfo : public AMActionInfo3
 {
     Q_OBJECT
-
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(bool darkCurrentState READ darkCurrentState WRITE setDarkCurrentState)
 public:
 	/// Constructor.
 	Q_INVOKABLE AMDetectorSetDarkCurrentValidStateActionInfo(bool newState = false, const AMDetectorInfo &detectorInfo = AMDetectorInfo(), QObject *parent = 0);
@@ -26,12 +27,18 @@ public:
 	/// Returns the info for the detector to be changed.
 	const AMDetectorInfo* detectorInfo() const { return &detectorInfo_; }
 
+
+
+protected:
+
 	/// Returns the detector info for database storing.
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only.
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
-protected:
+	/// Sets the dark current state. For database loading only
+	void setDarkCurrentState(bool darkCurrentState) { darkCurrentState_ = darkCurrentState; }
+
 	/// The new dark current valid state to be set.
 	bool darkCurrentState_;
 	/// The info for the detector to be changed.

--- a/source/actions3/actions/AMDetectorSetDarkCurrentValidStateActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentValidStateActionInfo.h
@@ -37,7 +37,7 @@ protected:
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
 	/// Sets the dark current state. For database loading only
-	void setDarkCurrentState(bool darkCurrentState) { darkCurrentState_ = darkCurrentState; }
+	void setDarkCurrentState(bool darkCurrentState);
 
 	/// The new dark current valid state to be set.
 	bool darkCurrentState_;

--- a/source/actions3/actions/AMDetectorSetDarkCurrentValueActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetDarkCurrentValueActionInfo.h
@@ -8,6 +8,8 @@ class AMDetectorSetDarkCurrentValueActionInfo : public AMActionInfo3
 {
     Q_OBJECT
 
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(double darkCurrentValue READ darkCurrentValue WRITE setDarkCurrentValue)
 public:
 	/// Constructor.
 	Q_INVOKABLE AMDetectorSetDarkCurrentValueActionInfo(double newValue = 0, const AMDetectorInfo &detectorInfo = AMDetectorInfo(), QObject *parent = 0);
@@ -26,12 +28,15 @@ public:
 	/// Returns the dark current value to be set.
 	double darkCurrentValue() const { return darkCurrentValue_; }
 
+protected:
 	/// Returns the detector info for database storing.
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only.
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
-protected:
+	/// Sets the dark current value. For loading from the database.
+	void setDarkCurrentValue(double darkCurrentValue) { darkCurrentValue_ = darkCurrentValue; }
+
 	/// The AMDetectorInfo.
 	AMDetectorInfo detectorInfo_;
 	/// The desired dark current value.

--- a/source/actions3/actions/AMDetectorSetLastMeasurementAsDarkCurrentActionInfo.h
+++ b/source/actions3/actions/AMDetectorSetLastMeasurementAsDarkCurrentActionInfo.h
@@ -7,6 +7,7 @@
 class AMDetectorSetLastMeasurementAsDarkCurrentActionInfo : public AMActionInfo3
 {
     Q_OBJECT
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
 
 public:
 	/// Constructor.
@@ -23,12 +24,13 @@ public:
 	/// Returns the detector info.
 	const AMDetectorInfo* detectorInfo() const { return &detectorInfo_; }
 
+protected:
+
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
-protected:
 	/// The detector info.
 	AMDetectorInfo detectorInfo_;
 };

--- a/source/actions3/actions/AMDetectorTriggerActionInfo.h
+++ b/source/actions3/actions/AMDetectorTriggerActionInfo.h
@@ -28,6 +28,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMDetectorTriggerActionInfo : public AMActionInfo3
 {
 Q_OBJECT
+	Q_PROPERTY(AMDbObject* detectorInfo READ dbReadDetectorInfo WRITE dbLoadDetectorInfo)
+	Q_PROPERTY(int readMode READ dbReadReadMode WRITE dbLoadReadMode)
 public:
 	/// Constructor
 	virtual ~AMDetectorTriggerActionInfo();
@@ -48,12 +50,19 @@ public:
 	/// Returns the read mode for this acquisition
 	AMDetectorDefinitions::ReadMode readMode() const { return readMode_; }
 
+protected:
+
 	/// For database storing only
 	AMDetectorInfo* dbReadDetectorInfo() { return &detectorInfo_; }
 	/// For database loading only. This function will never be called since dbReadDetectorInfo() always returns a valid pointer
 	void dbLoadDetectorInfo(AMDbObject *newLoadedObject) { newLoadedObject->deleteLater(); }
 
-protected:
+	/// For storing the read mode to the database.
+	int dbReadReadMode() { return int(readMode_); }
+
+	/// For loading the read mode from the database.
+	void dbLoadReadMode(int readMode) { readMode_ = AMDetectorDefinitions::ReadMode(readMode); }
+
 	/// The AMDetectorInfo that specifies which detector to acquire
 	AMDetectorInfo detectorInfo_;
 

--- a/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.cpp
+++ b/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.cpp
@@ -1,10 +1,10 @@
 #include "CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.h"
 #include "beamline/CLS/CLSBeamline.h"
 
-CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(double secondsDwell, QObject *parent) :
+CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(double dwellTime, QObject *parent) :
 	AMListActionInfo3(QString(), QString(), QString(), parent)
 {
-	secondsDwell_ = secondsDwell;
+	dwellTime_ = secondsDwell;
 
 	setShortDescription(typeDescription());
 	setLongDescription(typeDescription());
@@ -13,7 +13,7 @@ CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::CLSSIS3820ScalerDarkCurrentMea
 CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(const CLSSIS3820ScalerDarkCurrentMeasurementActionInfo &other) :
 	AMListActionInfo3(other)
 {
-	secondsDwell_ = other.dwellTime();
+	dwellTime_ = other.dwellTime();
 }
 
 CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::~CLSSIS3820ScalerDarkCurrentMeasurementActionInfo()

--- a/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.cpp
+++ b/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.cpp
@@ -4,7 +4,7 @@
 CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(double dwellTime, QObject *parent) :
 	AMListActionInfo3(QString(), QString(), QString(), parent)
 {
-	dwellTime_ = secondsDwell;
+	dwellTime_ = dwellTime;
 
 	setShortDescription(typeDescription());
 	setLongDescription(typeDescription());

--- a/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.cpp
+++ b/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.cpp
@@ -27,3 +27,9 @@ AMActionInfo3* CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::createCopy() co
 	info->dissociateFromDb(true);
 	return info;
 }
+
+void CLSSIS3820ScalerDarkCurrentMeasurementActionInfo::setDwellTime(double dwellTime)
+{
+	dwellTime_ = dwellTime;
+	setModified(true);
+}

--- a/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.h
+++ b/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.h
@@ -8,9 +8,10 @@ class CLSSIS3820ScalerDarkCurrentMeasurementActionInfo : public AMListActionInfo
 {
     Q_OBJECT
 
+	Q_PROPERTY(double dwellTime READ dwellTime WRITE setDwellTime)
 public:
 	/// Constructor.
-	Q_INVOKABLE CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(double secondsDwell = 0, QObject *parent = 0);
+	Q_INVOKABLE CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(double dwellTime = 0, QObject *parent = 0);
 	/// Copy constructor.
 	CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(const CLSSIS3820ScalerDarkCurrentMeasurementActionInfo &other);
 	/// Destructor.
@@ -22,11 +23,14 @@ public:
 	virtual QString typeDescription() const { return "Make scaler channel dark current measurement"; }
 
 	/// Returns the dwell time to use for the dark current measurement, in seconds.
-	double dwellTime() const { return secondsDwell_; }
+	double dwellTime() const { return dwellTime_; }
 
 protected:
+	/// Sets the seconds dwell time. Used in loading values from the database.
+	void setDwellTime(double dwellTime) { dwellTime_ = dwellTime; }
+
 	/// The time to use for the dark current measurement, in seconds.
-	double secondsDwell_;
+	double dwellTime_;
 
 };
 

--- a/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.h
+++ b/source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementActionInfo.h
@@ -27,7 +27,7 @@ public:
 
 protected:
 	/// Sets the seconds dwell time. Used in loading values from the database.
-	void setDwellTime(double dwellTime) { dwellTime_ = dwellTime; }
+	void setDwellTime(double dwellTime);
 
 	/// The time to use for the dark current measurement, in seconds.
 	double dwellTime_;


### PR DESCRIPTION
Added Q_PROPERTY calls to all AMActionInfo3 classes for which they were missing.
In some cases this required adding the necessary setters for the WRITE argument.
In cases where the existing dbRead...() or dbLoad...() functions were public, I made them protected.