### PR TITLE
Pull Request for Issue1861: Fast shutter doesn't turn on in scan initialization actions for XAS

### DIFF
--- a/source/acquaman/VESPERS/VESPERSScanController.cpp
+++ b/source/acquaman/VESPERS/VESPERSScanController.cpp
@@ -64,6 +64,9 @@ AMAction3 *VESPERSScanController::buildBaseInitializationAction(double firstRegi
 //	initializationAction->addSubAction(stage3);
 	initializationAction->addSubAction(scaler->createDwellTimeAction3(firstRegionTime));
 
+	if (VESPERSBeamline::vespers()->endstation()->shutterControl()->value() == 0)
+		initializationAction->addSubAction(AMActionSupport::buildControlMoveAction(VESPERSBeamline::vespers()->endstation()->shutterControl(), 1.0));
+
 	return initializationAction;
 }
 

--- a/source/beamline/VESPERS/VESPERSEndstation.cpp
+++ b/source/beamline/VESPERS/VESPERSEndstation.cpp
@@ -100,10 +100,6 @@ void VESPERSEndstation::onLaserPositionValidityChanged(double value)
 bool VESPERSEndstation::loadConfiguration()
 {
 	QString filePath = VESPERS::getHomeDirectory() % "/acquaman/build/endstation.config";
-
-	if (filePath.contains("hunterd"))
-		filePath = "/home/hunterd/beamline/programming/VESPERSAcquaman-build-desktop/build";
-
 	QFile file(filePath);
 
 	if (!file.open(QFile::ReadOnly | QFile::Text))

--- a/source/ui/VESPERS/VESPERSEndstationView.cpp
+++ b/source/ui/VESPERS/VESPERSEndstationView.cpp
@@ -376,10 +376,6 @@ VESPERSEndstationLimitsView::VESPERSEndstationLimitsView(QWidget *parent)
 void VESPERSEndstationLimitsView::saveFile()
 {
 	QString filePath = VESPERS::getHomeDirectory() % "/acquaman/build/endstation.config";
-
-	if (filePath.contains("hunterd"))
-		filePath = "/home/hunterd/beamline/programming/VESPERSAcquaman-build-desktop/build/endstation.config";
-
 	QFile file(filePath);
 
 	if (!file.open(QFile::WriteOnly | QFile::Text)){
@@ -425,10 +421,6 @@ void VESPERSEndstationLimitsView::saveFile()
 void VESPERSEndstationLimitsView::loadFile()
 {
 	QString filePath = VESPERS::getHomeDirectory() % "/acquaman/build/endstation.config";
-
-	if (filePath.contains("hunterd"))
-		filePath = "/home/hunterd/beamline/programming/VESPERSAcquaman-build-desktop/build/endstation.config";
-
 	QFile file(filePath);
 
 	// If there is no configuration file, then it creates a file with some default values.


### PR DESCRIPTION
Pretty straight forward.  It needed to check the shutter state and open it if it is closed.