### PR TITLE
Pull Request for Issue1867: Advanced check box in AMChooseFolderDialog doesn't allow you to check it if the line edit isn't empty

### DIFF
--- a/source/ui/util/AMChooseDataFolderDialog.h
+++ b/source/ui/util/AMChooseDataFolderDialog.h
@@ -47,8 +47,6 @@ protected:
 
 	/// The line edit that holds the proposal number or the path to a folder.
 	QComboBox *pathComboBox_;
-	/// The check box for the advanced choice.
-	QCheckBox *advancedCheckBox_;
 	/// The actual path stored as a string.
 	QString folder_;
 	/// The list of all the folders in the users folder.

--- a/source/ui/util/AMChooseDataFolderDialog.h
+++ b/source/ui/util/AMChooseDataFolderDialog.h
@@ -31,15 +31,13 @@ public:
 	/// Returns the current path.
 	QString filePath() const { return folder_; }
 	/// Returns the state of the advanced check box.
-	bool isFullPath() const { return advancedCheckBox_->isChecked(); }
+	bool isFullPath() const;
 
 protected slots:
 	/// Slot that does the work of opening a file dialog and getting the new file path.
 	void getFilePath();
 	/// Slot that handles when the path text changes.
 	void onTextChanged(const QString &text);
-	/// Slot that handles when the advanced checkbox clicked.
-	void onAdvancedCheckboxToggled(bool);
 
 protected:
 	/// Method that checks whether the input is valid or not.  Takes into account whether in advanced or not-advanced mode.


### PR DESCRIPTION
I have updated the choose folder dialog and removed the advanced check because it is no longer necessary.  I believe that the messages and the disabled state of the okay button should be sufficient for proper usage.