### PR TITLE
Pull Request for Issue1801: Number of repeats in duplicated loops is not indicated correctly in workflow

### DIFF
--- a/source/actions3/AMLoopActionInfo3.cpp
+++ b/source/actions3/AMLoopActionInfo3.cpp
@@ -20,11 +20,19 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "AMLoopActionInfo3.h"
 
- AMLoopActionInfo3::~AMLoopActionInfo3(){}
+AMLoopActionInfo3::~AMLoopActionInfo3(){}
+
 AMLoopActionInfo3::AMLoopActionInfo3(int iterations, const QString &shortDescription, const QString &longDescription, const QString &iconFileName, QObject *parent)
 	: AMListActionInfo3(QString("%1 (repeat %2 time%3)").arg(shortDescription).arg(iterations).arg(iterations > 1 ? "s" : ""), longDescription, iconFileName, parent)
 {
 	loopCount_ = iterations;
+	connect(this, SIGNAL(loopCountChanged(int)), this, SLOT(onLoopCountChanged(int)));
+}
+
+AMLoopActionInfo3::AMLoopActionInfo3(const AMLoopActionInfo3 &other)
+	: AMListActionInfo3(other)
+{
+	loopCount_ = other.loopCount_;
 	connect(this, SIGNAL(loopCountChanged(int)), this, SLOT(onLoopCountChanged(int)));
 }
 

--- a/source/actions3/AMLoopActionInfo3.h
+++ b/source/actions3/AMLoopActionInfo3.h
@@ -32,11 +32,10 @@ class AMLoopActionInfo3 : public AMListActionInfo3
 public:
 	/// Constructor. Specify the \c loopCount: number of iterations you want to loop for
 	Q_INVOKABLE AMLoopActionInfo3(int iterations = 3, const QString& shortDescription = "Loop", const QString& longDescription = "Loop of Actions to Run", const QString& iconFileName = ":/32x32/media-playlist-repeat.png", QObject *parent = 0);
+	/// Copy Constructor
+	AMLoopActionInfo3(const AMLoopActionInfo3& other);
 	/// Destructor.
 	virtual ~AMLoopActionInfo3();
-
-	/// Copy Constructor
-	AMLoopActionInfo3(const AMLoopActionInfo3& other) : AMListActionInfo3(other), loopCount_(other.loopCount_) {}
 
 	/// This function is used as a virtual copy constructor
 	virtual AMActionInfo3* createCopy() const;


### PR DESCRIPTION
There was a missing connect statement in the copy constructor, which is why it updated properly for created actions but not in duplicated ones.