### PR TITLE
Pull Request for Issue1644: Big beam stages are not propagated into XAS scan configurations

### DIFF
--- a/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
@@ -218,6 +218,12 @@ AMAction3* VESPERSXASScanActionController::createInitializationActions()
 			initializationAction->addSubAction(VESPERSBeamline::vespers()->realSampleStageMotorGroupObject()->horizontalAxis()->createTranslateMoveAction(configuration_->x()));
 			initializationAction->addSubAction(VESPERSBeamline::vespers()->realSampleStageMotorGroupObject()->verticalAxis()->createTranslateMoveAction(configuration_->y()));
 		}
+
+		else if (motor.testFlag(VESPERS::BigBeamX) && motor.testFlag(VESPERS::BigBeamZ)){
+
+			initializationAction->addSubAction(VESPERSBeamline::vespers()->bigBeamMotorGroupObject()->horizontalAxis()->createTranslateMoveAction(configuration_->x()));
+			initializationAction->addSubAction(VESPERSBeamline::vespers()->bigBeamMotorGroupObject()->verticalAxis()->createTranslateMoveAction(configuration_->y()));
+		}
 	}
 
 	return initializationAction;

--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -791,7 +791,8 @@ bool VESPERSAppController::exafsMotorAcceptable(int motor) const
 	return (motor == (VESPERS::H | VESPERS::V)
 			|| motor == (VESPERS::X | VESPERS::Z)
 			|| motor == (VESPERS::AttoH | VESPERS::AttoV)
-			|| motor == (VESPERS::AttoX | VESPERS::AttoZ));
+			|| motor == (VESPERS::AttoX | VESPERS::AttoZ)
+			|| motor == (VESPERS::BigBeamX | VESPERS::BigBeamZ));
 }
 
 bool VESPERSAppController::energyScanMotorAcceptable(int motor) const

--- a/source/ui/VESPERS/VESPERSEXAFSScanConfigurationView.cpp
+++ b/source/ui/VESPERS/VESPERSEXAFSScanConfigurationView.cpp
@@ -380,7 +380,7 @@ void VESPERSEXAFSScanConfigurationView::onMotorsUpdated(int id)
 		savedYPosition_->setText(QString("V: %1 mm").arg(0.0, 0, 'g', 3));
 	}
 
-	else if (id == int(VESPERS::X | VESPERS::Z) || id == (VESPERS::AttoX | VESPERS::AttoZ)){
+	else if (id == int(VESPERS::X | VESPERS::Z) || id == (VESPERS::AttoX | VESPERS::AttoZ) || id == (VESPERS::BigBeamX | VESPERS::BigBeamZ)){
 
 		savedXPosition_->setText(QString("X: %1 mm").arg(0.0, 0, 'g', 3));
 		savedYPosition_->setText(QString("Z: %1 mm").arg(0.0, 0, 'g', 3));
@@ -426,6 +426,14 @@ void VESPERSEXAFSScanConfigurationView::setScanPosition()
 
 		x = VESPERSBeamline::vespers()->realAttocubeStageMotorGroupObject()->horizontalAxis()->translationMotor()->value();
 		y = VESPERSBeamline::vespers()->realAttocubeStageMotorGroupObject()->verticalAxis()->translationMotor()->value();
+		savedXPosition_->setText(QString("X: %1 mm").arg(x, 0, 'g', 3));
+		savedYPosition_->setText(QString("Z: %1 mm").arg(y, 0, 'g', 3));
+	}
+
+	else if (motor == (VESPERS::BigBeamX | VESPERS::BigBeamZ)){
+
+		x = VESPERSBeamline::vespers()->bigBeamMotorGroupObject()->horizontalAxis()->translationMotor()->value();
+		y = VESPERSBeamline::vespers()->bigBeamMotorGroupObject()->verticalAxis()->translationMotor()->value();
 		savedXPosition_->setText(QString("X: %1 mm").arg(x, 0, 'g', 3));
 		savedYPosition_->setText(QString("Z: %1 mm").arg(y, 0, 'g', 3));
 	}


### PR DESCRIPTION
Added the Big Beam motors to the XAS _Go To Position_ which only required updating the app controller, the configuration view, and the scan controller.