### PR TITLE
Pull Request for Issue1864: Add storage space monitor to dataman applications

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -441,7 +441,8 @@ HEADERS += \
 	source/beamline/AMExclusiveStatesEnumeratedControl.h \
 	source/ui/beamline/AMControlStopButton.h \
     source/ui/beamline/AMControlToolButton.h \
-    $$PWD/source/ui/AMToolButton.h
+    $$PWD/source/ui/AMToolButton.h \
+    source/util/AMStorageInfo.h
 
 FORMS += \
 
@@ -844,7 +845,8 @@ SOURCES += \
 	source/beamline/AMExclusiveStatesEnumeratedControl.cpp \
     source/ui/beamline/AMControlStopButton.cpp \
     source/ui/beamline/AMControlToolButton.cpp \
-    $$PWD/source/ui/AMToolButton.cpp
+    $$PWD/source/ui/AMToolButton.cpp \
+    source/util/AMStorageInfo.cpp
 
 RESOURCES *= source/icons/icons.qrc \
 		source/configurationFiles/configurationFiles.qrc \
@@ -861,3 +863,5 @@ contains(DEFINES, AM_BUILD_REPORTER_ENABLED){
 
 	SOURCES *= source/util/AMRunTimeBuildInfo.cpp
 }
+
+

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -1973,7 +1973,8 @@ void AMDatamanAppController::updateStorageProgressBar()
 				storageWarningLabel_->setVisible(true);
 			}
 
-			if(storageWarningCount_ % 30 == 0) {
+			// Only show the warning every 60 minutes
+			if(storageWarningCount_ % 60 == 0) {
 				double percentageRemaining = 100 - percentageUsed;
 				AMErrorMon::alert(this,
 				                  AMDATAMANAPPCONTROLLER_LOCAL_STORAGE_RUNNING_LOW, QString("Warning: Local storage space is at %1%. Please inform the beamline staff.").arg(percentageRemaining),

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -443,7 +443,7 @@ bool AMDatamanAppController::startupOnFirstTime()
 			storageInfo_ = AMStorageInfo(AMUserSettings::userDataFolder);
 
 			// start timer for updates every 1 minute
-			timerInterval_ = startTimer(60000);
+			timerIntervalID_ = startTimer(60000);
 		}
 
 		AMErrorMon::information(this, AMDATAMANAPPCONTROLLER_STARTUP_MESSAGES, "Acquaman Startup: First-Time Successful");
@@ -492,7 +492,7 @@ bool AMDatamanAppController::startupOnEveryTime()
 		storageInfo_ = AMStorageInfo(AMUserSettings::userDataFolder);
 
 		// start timer for updates every 1 minute
-		timerInterval_ = startTimer(60000);
+		timerIntervalID_ = startTimer(60000);
 	}
 
 	qApp->processEvents();

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -62,6 +62,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QInputDialog>
 #include <QStringBuilder>
 #include <QFileDialog>
+#include <QFrame>
 
 #include "util/AMSettings.h"
 #include "dataman/AMScan.h"
@@ -147,6 +148,7 @@ AMDatamanAppController::AMDatamanAppController(QObject *parent) :
 {
 	isStarting_ = true;
 	isShuttingDown_ = false;
+	storageWarningProvided_ = false;
 
 	overrideCloseCheck_ = false;
 
@@ -436,6 +438,14 @@ bool AMDatamanAppController::startupOnFirstTime()
 				QFile::copy(allDatabaseFiles.at(x).absoluteFilePath(), QString("%1/%2").arg(AMUserSettings::remoteDataFolder).arg(allDatabaseFiles.at(x).fileName()));
 		}
 
+		if(usingLocalStorage()) {
+
+			storageInfo_ = AMStorageInfo(AMUserSettings::userDataFolder);
+
+			// start timer for updates every 1 minute
+			timerInterval_ = startTimer(60000);
+		}
+
 		AMErrorMon::information(this, AMDATAMANAPPCONTROLLER_STARTUP_MESSAGES, "Acquaman Startup: First-Time Successful");
 		qApp->processEvents();
 	}
@@ -444,7 +454,7 @@ bool AMDatamanAppController::startupOnFirstTime()
 
 bool AMDatamanAppController::startupOnEveryTime()
 {
-	if(AMUserSettings::remoteDataFolder.isEmpty() && defaultUseLocalStorage_){
+	if(!usingLocalStorage() && defaultUseLocalStorage_){
 		int retVal = QMessageBox::question(0, "Use Local Storage?", "Acquaman has detected that you are not using local storage.\nLocal storage can significantly improve speed and reliability.\n If you wish to use local storage select \"Yes\" and your data will automatically be synchronized to the network for long term storage.\n\n Use local storage?", QMessageBox::Yes, QMessageBox::No);
 		if(retVal == QMessageBox::Yes){
 			QString currentUserDataFolder = AMUserSettings::userDataFolder;
@@ -476,6 +486,14 @@ bool AMDatamanAppController::startupOnEveryTime()
 	// check for and run any database upgrades we require...
 	if(!startupDatabaseUpgrades())
 		return false;
+
+	if(usingLocalStorage()) {
+
+		storageInfo_ = AMStorageInfo(AMUserSettings::userDataFolder);
+
+		// start timer for updates every 1 minute
+		timerInterval_ = startTimer(60000);
+	}
 
 	qApp->processEvents();
 
@@ -1009,9 +1027,43 @@ bool AMDatamanAppController::startupInstallActions()
 	//////////////////////////////////////
 #ifdef Q_WS_MAC
 	menuBar_ = new QMenuBar(0);
+	internalStorageRemainingBar_ = 0;
 #else
+	// Construct the menu and, if using local storage, the space remaining progress bar
 	menuBar_ = new QMenuBar();
-	mw_->addTopWidget(menuBar_);
+	if(usingLocalStorage()) {
+
+		QHBoxLayout* topWidgetLayout = new QHBoxLayout();
+		topWidgetLayout->setContentsMargins(0,0,0,0);
+		QSizePolicy menuBarSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+		menuBarSizePolicy.setHorizontalStretch(10);
+		menuBar_->setSizePolicy(menuBarSizePolicy);
+
+		topWidgetLayout->addWidget(menuBar_);
+
+		internalStorageRemainingBar_ = new QProgressBar();
+		internalStorageRemainingBar_->setFormat(QString("Space Used: %p%"));
+		QSizePolicy progressSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+		progressSizePolicy.setHorizontalStretch(2);
+		internalStorageRemainingBar_->setSizePolicy(progressSizePolicy);
+
+		topWidgetLayout->addWidget(internalStorageRemainingBar_);
+
+
+		QFrame* topWidgetFrame = new QFrame();
+		topWidgetFrame->setLayout(topWidgetLayout);
+
+
+		mw_->addTopWidget(topWidgetFrame);
+
+		updateStorageProgressBar();
+	} else {
+
+		internalStorageRemainingBar_ = 0;
+		mw_->addTopWidget(menuBar_);
+	}
+
+
 #endif
 
 	fileMenu_ = menuBar_->addMenu("File");
@@ -1442,6 +1494,11 @@ bool AMDatamanAppController::canCloseScanEditors() const
 		}
 	}
 	return true;
+}
+
+bool AMDatamanAppController::usingLocalStorage() const
+{
+	return !(AMUserSettings::remoteDataFolder.isEmpty());
 }
 
 bool AMDatamanAppController::defaultUseLocalStorage() const{
@@ -1875,3 +1932,33 @@ void AMDatamanAppController::onOpenOtherDatabaseClicked()
 		connect(newScanDataView, SIGNAL(launchScanConfigurationsFromDb(QList<QUrl>)), this, SLOT(onLaunchScanConfigurationsFromDb(QList<QUrl>)));
 	}
 }
+
+void AMDatamanAppController::timerEvent(QTimerEvent *)
+{
+	updateStorageProgressBar();
+}
+
+void AMDatamanAppController::updateStorageProgressBar()
+{
+	if(usingLocalStorage() && storageInfo_.isValid()) {
+
+		storageInfo_.refresh();
+		double storageUsed = double(storageInfo_.bytesTotal() - storageInfo_.bytesAvailable());
+		double percentageUsed = (storageUsed / storageInfo_.bytesTotal()) * 100;
+
+		if(percentageUsed > 85) {
+
+			if(!storageWarningProvided_) {
+				double percentageRemaining = 100 - percentageUsed;
+				AMErrorMon::alert(this, AMDATAMANAPPCONTROLLER_LOCAL_STORAGE_RUNNING_LOW, QString("Warning: Local storage space is at %1%. Please inform the beamline staff.").arg(percentageRemaining));
+				storageWarningProvided_ = true;
+			}
+		}
+
+		if(internalStorageRemainingBar_) {
+
+			internalStorageRemainingBar_->setValue(int(percentageUsed));
+		}
+	}
+}
+

--- a/source/application/AMDatamanAppController.h
+++ b/source/application/AMDatamanAppController.h
@@ -27,8 +27,10 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QList>
 #include <QModelIndex>
 #include <QStringList>
+#include <QProgressBar>
 
 #include "util/AMOrderedSet.h"
+#include "util/AMStorageInfo.h"
 
 class AMMainWindow;
 class AMBottomPanel;
@@ -89,6 +91,8 @@ class AMScanEditorsCloseView;
 
 #define AMDATAMANAPPCONTROLLER_STARTUP_ERROR_ISFIRSTTIME 270228
 #define AMDATAMANAPPCONTROLLER_CANT_CREATE_EXPORT_FOLDER 270229
+
+#define AMDATAMANAPPCONTROLLER_LOCAL_STORAGE_RUNNING_LOW 270230
 
 /// This class takes the role of the main application controller for your particular version of the Acquaman program. It marshalls communication between separate widgets/objects, handles menus and menu actions, and all other cross-cutting issues that don't reside within a specific view or controller.  It creates and knows about all top-level GUI objects, and manages them within an AMMainWindow.
 /// This is the bare bones version of the GUI framework because it has no acquisition code inside and therefore forms the basis of a take home Dataman program for users.  It contains the ability to scan through the database, create experiments, and view scans using the scan editor.
@@ -313,6 +317,9 @@ protected slots:
 	void onScanEditorsCloseViewClosed();
 
 protected:
+	/// Whether the application is currently using local storage
+	bool usingLocalStorage() const;
+
 	/// Returns whether or not this application intends to use local storage as the default
 	bool defaultUseLocalStorage() const;
 
@@ -350,6 +357,12 @@ protected:
 	/// Helper method that returns the scan associated with an editor for the scanEditorsScanMapping list.  Returns 0 if not found.
 	AMScan *scanFromEditor(AMGenericScanEditor *editor) const;
 
+	/// The QObject timer event which handles refreshing the storage info.
+	void timerEvent(QTimerEvent *);
+
+	/// Helper function which updates the progress bar with the current usage, if local storage is used.
+	void updateStorageProgressBar();
+
 	/// UI structure components
 	AMMainWindow* mw_;
 
@@ -358,6 +371,7 @@ protected:
 	QMenu *fileMenu_;
 	QMenu *viewMenu_;
 	QMenu *helpMenu_;
+	QProgressBar* internalStorageRemainingBar_;
 	/// The action that triggers saving the current AMScanView image.
 	QAction* exportGraphicsAction_;
 	QAction* printGraphicsAction_;
@@ -414,6 +428,15 @@ protected:
 
 	/// Window to handle closing of multiple scan editors
 	AMScanEditorsCloseView *scanEditorCloseView_;
+
+	/// The storage info for the volume used to store the data.
+	AMStorageInfo storageInfo_;
+
+	/// The interval (ms) used to set the period over which the storage info will be updated.
+	int timerInterval_;
+
+	/// Used to stop error mons being spammed each time we check the storage usage and find it running out. This is set to true after the first warning is provided.
+	bool storageWarningProvided_;
 
 private:
 	/// Holds the QObject whose signal is currently being used to connect to the onStartupFinished slot

--- a/source/application/AMDatamanAppController.h
+++ b/source/application/AMDatamanAppController.h
@@ -25,6 +25,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QObject>
 #include <QUrl>
 #include <QList>
+#include <QLabel>
 #include <QModelIndex>
 #include <QStringList>
 #include <QProgressBar>
@@ -436,8 +437,11 @@ protected:
 	/// in the event queue, should it need to be stopped.
 	int timerIntervalID_;
 
-	/// Used to stop error mons being spammed each time we check the storage usage and find it running out. This is set to true after the first warning is provided.
-	bool storageWarningProvided_;
+	/// Used to stop error mons being spammed each time we check the storage usage and find it running out. Iterated each time the storage is checked and it over 85%. A message is displayed every 30 iterations (30 minutes)
+	int storageWarningCount_;
+
+	/// Icon label used to warn users the local storage space is running low.
+	QLabel* storageWarningLabel_;
 
 private:
 	/// Holds the QObject whose signal is currently being used to connect to the onStartupFinished slot

--- a/source/application/AMDatamanAppController.h
+++ b/source/application/AMDatamanAppController.h
@@ -432,8 +432,9 @@ protected:
 	/// The storage info for the volume used to store the data.
 	AMStorageInfo storageInfo_;
 
-	/// The interval (ms) used to set the period over which the storage info will be updated.
-	int timerInterval_;
+	/// The timer id of the object. Used to keep a reference to this objects timer
+	/// in the event queue, should it need to be stopped.
+	int timerIntervalID_;
 
 	/// Used to stop error mons being spammed each time we check the storage usage and find it running out. This is set to true after the first warning is provided.
 	bool storageWarningProvided_;

--- a/source/util/AMStorageInfo.cpp
+++ b/source/util/AMStorageInfo.cpp
@@ -4,8 +4,7 @@
 #include <QFileInfo>
 #include <QDirIterator>
 
-#ifdef Q_WS_MAC
-#else
+#ifndef Q_WS_MAC
 #include <mntent.h>
 #include <errno.h>
 #include <sys/statvfs.h>

--- a/source/util/AMStorageInfo.cpp
+++ b/source/util/AMStorageInfo.cpp
@@ -3,9 +3,13 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDirIterator>
+
+#ifdef Q_WS_MAC
+#else
 #include <mntent.h>
 #include <errno.h>
 #include <sys/statvfs.h>
+#endif
 AMStorageInfo::AMStorageInfo()
 {
 	bytesTotal_ = -1;

--- a/source/util/AMStorageInfo.cpp
+++ b/source/util/AMStorageInfo.cpp
@@ -1,0 +1,292 @@
+#include "AMStorageInfo.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QDirIterator>
+#include <mntent.h>
+#include <errno.h>
+#include <sys/statvfs.h>
+AMStorageInfo::AMStorageInfo()
+{
+	bytesTotal_ = -1;
+	bytesFree_ = -1;
+	bytesAvailable_ = -1;
+	blockSize_ = -1;
+	isReadOnly_ = false;
+	isReady_ = false;
+	isValid_ = false;
+}
+
+AMStorageInfo::AMStorageInfo(const QString& path)
+{
+	bytesTotal_ = -1;
+	bytesFree_ = -1;
+	bytesAvailable_ = -1;
+	blockSize_ = -1;
+	isReadOnly_ = false;
+	isReady_ = false;
+	isValid_ = false;
+
+	setPath(path);
+}
+
+AMStorageInfo::AMStorageInfo(const QDir& directory)
+{
+	bytesTotal_ = -1;
+	bytesFree_ = -1;
+	bytesAvailable_ = -1;
+	blockSize_ = -1;
+	isReadOnly_ = false;
+	isReady_ = false;
+	isValid_ = false;
+
+	setPath(directory.absolutePath());
+}
+
+AMStorageInfo::AMStorageInfo(const AMStorageInfo& other)
+{
+	(*this) = other;
+}
+
+AMStorageInfo::~AMStorageInfo()
+{
+	// Class holds no resources.
+}
+
+AMStorageInfo &AMStorageInfo::operator =(const AMStorageInfo& other)
+{
+	bytesTotal_ = other.bytesTotal_;
+	bytesFree_ = other.bytesFree_;
+	bytesAvailable_ = other.bytesAvailable_;
+	blockSize_ = other.blockSize_;
+	isReadOnly_ = other.isReadOnly_;
+	isReady_ = other.isReady_;
+	isValid_ = other.isValid_;
+
+	setPath(other.rootPath_);
+
+	return *this;
+}
+
+void AMStorageInfo::setPath(const QString &path)
+{
+	if(rootPath_ != path) {
+
+		rootPath_ = path;
+		refresh();
+	}
+}
+
+QString AMStorageInfo::rootPath() const
+{
+	return rootPath_;
+}
+
+QByteArray AMStorageInfo::device() const
+{
+	return device_;
+}
+
+QByteArray AMStorageInfo::fileSystemType() const
+{
+	return fileSystemType_;
+}
+
+QString AMStorageInfo::name() const
+{
+	return name_;
+}
+
+QString AMStorageInfo::displayName() const
+{
+	if(name_.isEmpty()) {
+
+		return rootPath_;
+	} else {
+
+		return name_;
+	}
+}
+
+qint64 AMStorageInfo::bytesTotal() const
+{
+	return bytesTotal_;
+}
+
+qint64 AMStorageInfo::bytesFree() const
+{
+	return bytesFree_;
+}
+
+qint64 AMStorageInfo::bytesAvailable() const
+{
+	return bytesAvailable_;
+}
+
+int AMStorageInfo::blockSize() const
+{
+	return blockSize_;
+}
+
+
+bool AMStorageInfo::isRoot() const
+{
+	return *this == AMStorageInfo::root();
+}
+
+bool AMStorageInfo::isReadOnly() const
+{
+	return isReadOnly_;
+}
+
+bool AMStorageInfo::isReady() const
+{
+	return isReady_;
+}
+
+bool AMStorageInfo::isValid() const
+{
+	return isValid_;
+}
+
+void AMStorageInfo::refresh()
+{
+	// Initialize root path
+
+	rootPath_ = QFileInfo(rootPath_).canonicalFilePath();
+
+	if(!rootPath_.isEmpty()) {
+
+		QByteArray buffer = QByteArray(1024, 0);
+		mntent mountEntry;
+
+		FILE* filePointer = ::setmntent("/etc/mtab", "r");
+
+		int maxLength = 0;
+		const QString oldRootPath = rootPath_;
+		rootPath_.clear();
+
+		while(::getmntent_r(filePointer,
+		                    &mountEntry,
+		                    buffer.data(),
+		                    buffer.size()) != 0) {
+
+			const QString currentMountDirectory = QFile::decodeName(mountEntry.mnt_dir);
+			const QByteArray fileSystemType = QByteArray(mountEntry.mnt_fsname);
+
+			if(isPseudoFs(currentMountDirectory, fileSystemType)) {
+
+				continue;
+			}
+
+			if(oldRootPath.startsWith(currentMountDirectory) &&
+			        maxLength < currentMountDirectory.length()) {
+
+				maxLength = currentMountDirectory.length();
+				rootPath_ = currentMountDirectory;
+				device_ = QByteArray(mountEntry.mnt_fsname);
+				fileSystemType_ = fileSystemType;
+			}
+		}
+	}
+
+	if(rootPath_.isEmpty()) {
+		return;
+	}
+
+	// Get file system stats
+
+	struct statvfs64 statFileSystemBuffer;
+	int result;
+
+	do {
+		result = ::statvfs64(QFile::encodeName(rootPath_).constData(),
+		                     &statFileSystemBuffer);
+
+	} while (result == -1 && (*__errno_location ()) == 4);
+
+	if(result == 0) {
+
+		isValid_ = true;
+		isReady_ = true;
+
+		bytesTotal_ = statFileSystemBuffer.f_blocks * statFileSystemBuffer.f_frsize;
+		bytesFree_ = statFileSystemBuffer.f_bfree * statFileSystemBuffer.f_frsize;
+		bytesAvailable_ = statFileSystemBuffer.f_bavail * statFileSystemBuffer.f_frsize;
+		blockSize_ = statFileSystemBuffer.f_bsize;
+		isReadOnly_ = (statFileSystemBuffer.f_flag & ST_RDONLY) != 0;
+	}
+
+	// Get the file name
+
+	const char pathDiskByLabel[] = "/dev/disk/by-label";
+
+	QDirIterator directoryIterator(pathDiskByLabel, QDir::NoDotAndDotDot);
+
+	while(directoryIterator.hasNext()) {
+
+		directoryIterator.next();
+		QFileInfo fileInfo(directoryIterator.fileInfo());
+
+		if(fileInfo.isSymLink() && fileInfo.symLinkTarget().toLocal8Bit() == device_) {
+
+			name_ = fileInfo.fileName();
+		}
+	}
+
+}
+
+QList<AMStorageInfo> AMStorageInfo::mountedVolumes()
+{
+	QByteArray buffer = QByteArray(1024, 0);
+	mntent mountEntry;
+
+	FILE* filePointer = ::setmntent("/etc/mtab", "r");
+
+	QList<AMStorageInfo> volumes;
+
+	while(::getmntent_r(filePointer,
+	                    &mountEntry,
+	                    buffer.data(),
+	                    buffer.size()) != 0) {
+
+		const QString currentMountDir = QFile::decodeName(mountEntry.mnt_dir);
+		const QByteArray fileSystemType = QByteArray(mountEntry.mnt_fsname);
+
+		if(!isPseudoFs(currentMountDir, fileSystemType)) {
+
+			volumes.append(AMStorageInfo(currentMountDir));
+		}
+
+	}
+
+	return volumes;
+
+}
+
+AMStorageInfo AMStorageInfo::root()
+{
+	return AMStorageInfo("/");
+}
+
+bool AMStorageInfo::isPseudoFs(const QString &mountPath, const QByteArray &mountType)
+{
+	if(mountPath.startsWith("/dev")
+	        || mountPath.startsWith("/proc")
+	        || mountPath.startsWith("/sys")
+	        || mountPath.startsWith("/var/run")
+	        || mountPath.startsWith("/var/lock")) {
+
+		return true;
+	}
+
+	if(mountType == "tmpfs"
+	        || mountType == "rootfs"
+	        || mountType == "rpc_pipefs") {
+
+		return true;
+	}
+
+	return false;
+}
+

--- a/source/util/AMStorageInfo.cpp
+++ b/source/util/AMStorageInfo.cpp
@@ -14,7 +14,7 @@ AMStorageInfo::AMStorageInfo()
 	blockSize_ = -1;
 	isReadOnly_ = false;
 	isReady_ = false;
-	isValid_ = false;
+	isValid_ = false;	
 }
 
 AMStorageInfo::AMStorageInfo(const QString& path)
@@ -151,6 +151,11 @@ bool AMStorageInfo::isValid() const
 
 void AMStorageInfo::refresh()
 {
+#ifdef Q_WS_MAC
+	return;
+#else
+
+
 	// Initialize root path
 
 	rootPath_ = QFileInfo(rootPath_).canonicalFilePath();
@@ -234,10 +239,15 @@ void AMStorageInfo::refresh()
 		}
 	}
 
+#endif
 }
 
 QList<AMStorageInfo> AMStorageInfo::mountedVolumes()
 {
+#ifdef Q_WS_MAC
+	return QList<AMStorageInfo>();
+#else
+
 	QByteArray buffer = QByteArray(1024, 0);
 	mntent mountEntry;
 
@@ -261,7 +271,7 @@ QList<AMStorageInfo> AMStorageInfo::mountedVolumes()
 	}
 
 	return volumes;
-
+#endif
 }
 
 AMStorageInfo AMStorageInfo::root()

--- a/source/util/AMStorageInfo.h
+++ b/source/util/AMStorageInfo.h
@@ -4,43 +4,169 @@
 #include <QDir>
 #include <QByteArray>
 
+/*!
+  * A class which provides information about the storage volume at the provided
+  * path. The class is based heavily on AMStorageInfo from Qt5.4 (see http://doc.qt.io/qt-5/AMStorageInfo.html)
+  * , but without the d-pointer pattern used in Qt implementations.
+  * Owing to the low level nature of the class it contains a lot of linux specific
+  * implementation details, and will not work (but will compile) on non linux machines.
+  * As such a lot of conditional compilation is used to return stub values on Macs
+  */
 class AMStorageInfo
 {
 public:
+
+	/*!
+	  * Constructs an empty AMStorageInfo object.
+
+	  * Objects created with the default constructor will be invalid and therefore
+	  * not ready for use.
+	  */
     AMStorageInfo();
+
+	/*!
+	  * Constructs a new AMStorageInfo object that gives information about the volume
+	  * mounted at path.
+	  *
+	  * If you pass a directory or file, the AMStorageInfo object will refer to the
+	  * volume where this directory or file is located. You can check if the created
+	  * object is correct using the isValid() method.
+	  */
 	explicit AMStorageInfo(const QString& path);
+
+	/*!
+	  * Constructs a new AMStorageInfo object that gives information about the volume
+	  * containing the dir folder.
+	  */
 	explicit AMStorageInfo(const QDir& directory);
+
+	/*!
+	  * Constructs a new AMStorageInfo object that is a copy of the other AMStorageInfo
+	  * object.
+	  */
 	AMStorageInfo(const AMStorageInfo& other);
 
+	/*!
+	  * Destroys the AMStorageInfo object and frees its resources.
+	  */
 	~AMStorageInfo();
 
 	AMStorageInfo &operator=(const AMStorageInfo& other);
 
+	/*!
+	  * Sets this AMStorageInfo object to the filesystem mounted where path is located.
+	  * path can either be a root path of the filesystem, a directory, or a file
+	  * within that filesystem.
+	  */
 	void setPath(const QString& path);
 
+	/*!
+	  * Returns the mount point of the filesystem this AMStorageInfo object represents.
+	  * NOTE: The value returned by rootPath() is the real mount point of a volume,
+	  * and may not be equal to the value passed to the constructor or setPath()
+	  * method. For example, if you have only the root volume in the system, and
+	  * pass '/directory' to setPath(), then this method will return '/'.
+	  */
 	QString rootPath() const;
+
+	/*!
+	  * Returns the device for this volume.
+	  * For example this returns the devpath like /dev/sda0 for local storages.
+	  */
 	QByteArray device() const;
+
+	/*!
+	  * Returns the type name of the filesystem.
+	  */
 	QByteArray fileSystemType() const;
+
+	/*!
+	  * Returns the human-readable name of a filesystem, usually called label.
+	  * NOTE: Requires udev to be present in the system.
+	  */
 	QString name() const;
+
+	/*!
+	  * Returns the volume's name, if available, or the root path if not.
+	  */
 	QString displayName() const;
 
+	/*!
+	  * Returns the total volume size in bytes.
+	  * Returns -1 if AMStorageInfo object is not valid.
+	  */
 	qint64 bytesTotal() const;
+
+	/*!
+	  * Returns the number of free bytes in a volume. Note that if there are quotas
+	  * on the filesystem, this value can be larger than the value returned by
+	  * bytesAvailable().
+	  * Returns -1 if AMStorageInfo object is not valid.
+	  */
 	qint64 bytesFree() const;
+
+	/*!
+	  * Returns the size (in bytes) available for the current user. It returns
+	  * the total size available if the user is the root user or a system
+	  * administrator.
+	  * This size can be less than or equal to the free size returned by bytesFree()
+	  * function.
+	  */
 	qint64 bytesAvailable() const;
+
+	/*!
+	  * The size of blocks of the current filesystem.
+	  */
 	int blockSize() const;
 
-	inline bool isRoot() const;
+	/*!
+	  * Returns true if this AMStorageInfo represents the system root volume;
+	  * false otherwise.
+	  */
+	bool isRoot() const;
 
+	/*!
+	  * Returns true if the current filesystem is protected from writing; false
+	  * otherwise.
+	  */
 	bool isReadOnly() const;
+
+	/*!
+	  * Returns true if the current filesystem is ready to work; false otherwise.
+	  * For example, false is returned if the CD volume is not inserted.
+	  */
 	bool isReady() const;
+
+	/*!
+	  * Returns true if the AMStorageInfo specified by rootPath exists and is
+	  * mounted correctly.
+	  */
 	bool isValid() const;
 
+	/*!
+	  * Resets AMStorageInfo's internal cache.
+	  * AMStorageInfo caches information about storage to speed up performance.
+	  * AMStorageInfo retrieves information during object construction and/or when
+	  * calling the setPath() method. You have to manually reset the cache by calling
+	  * this function to update storage information.
+	  */
 	void refresh();
 
+	/*!
+	  * Returns the list of AMStorageInfo objects that corresponds to the list of
+	  * currently mounted filesystems.
+	  */
 	static QList<AMStorageInfo> mountedVolumes();
+
+	/*!
+	  * Returns a AMStorageInfo object that represents the system root volume.
+	  */
 	static AMStorageInfo root();
 
 protected:
+
+	// Returns true if the provided mount path and type represent a pseudo file
+	// system.
 	static bool isPseudoFs(const QString& mountPath, const QByteArray& mountType);
 
 	QString rootPath_;

--- a/source/util/AMStorageInfo.h
+++ b/source/util/AMStorageInfo.h
@@ -1,0 +1,68 @@
+#ifndef AMSTORAGEINFO_H
+#define AMSTORAGEINFO_H
+
+#include <QDir>
+#include <QByteArray>
+
+class AMStorageInfo
+{
+public:
+    AMStorageInfo();
+	explicit AMStorageInfo(const QString& path);
+	explicit AMStorageInfo(const QDir& directory);
+	AMStorageInfo(const AMStorageInfo& other);
+
+	~AMStorageInfo();
+
+	AMStorageInfo &operator=(const AMStorageInfo& other);
+
+	void setPath(const QString& path);
+
+	QString rootPath() const;
+	QByteArray device() const;
+	QByteArray fileSystemType() const;
+	QString name() const;
+	QString displayName() const;
+
+	qint64 bytesTotal() const;
+	qint64 bytesFree() const;
+	qint64 bytesAvailable() const;
+	int blockSize() const;
+
+	inline bool isRoot() const;
+
+	bool isReadOnly() const;
+	bool isReady() const;
+	bool isValid() const;
+
+	void refresh();
+
+	static QList<AMStorageInfo> mountedVolumes();
+	static AMStorageInfo root();
+
+protected:
+	static bool isPseudoFs(const QString& mountPath, const QByteArray& mountType);
+
+	QString rootPath_;
+	QByteArray device_;
+	QByteArray fileSystemType_;
+	QString name_;
+
+	qint64 bytesTotal_;
+	qint64 bytesFree_;
+	qint64 bytesAvailable_;
+	int blockSize_;
+
+	bool isReadOnly_;
+	bool isReady_;
+	bool isValid_;
+
+
+};
+
+inline bool operator==(const AMStorageInfo& first, const AMStorageInfo& second)
+{
+	return first.device() == second.device();
+}
+
+#endif // AMSTORAGEINFO_H


### PR DESCRIPTION
- Created a class, AMStorageInfo, which takes a lot of code from Qt5.4's QStorageInfo and provides space information on a given volume.
- Added a storage info class to AMDatamanAppController if local storage is being used.
- Created a timer mechanism in AMDatamanAppController which checks storage usage on a minute frequency when local storage is being used
- Added a progress bar to AMDatamanAppController to visualize storage usage when local storage is being used.
- Added an error mon call when the storage usage gets above 85% (suppressed after being shown once, so the user isn't spammed every minute with error mons).