### PR TITLE
Pull Request for Issue1878: EXAFS regions don't produce the right time when the time and maximum time are equal

### DIFF
--- a/source/acquaman/VESPERS/VESPERSEXAFSScanConfiguration.cpp
+++ b/source/acquaman/VESPERS/VESPERSEXAFSScanConfiguration.cpp
@@ -188,24 +188,8 @@ void VESPERSEXAFSScanConfiguration::computeTotalTimeImplementation()
 	double time = 0;
 
 	// Some region stuff.
-	foreach (AMScanAxisRegion *region, scanAxisAt(0)->regions().toList()){
-
-		AMScanAxisEXAFSRegion *exafsRegion = qobject_cast<AMScanAxisEXAFSRegion *>(region);
-		int numberOfPoints = exafsRegion->numberOfPoints();
-
-		if (exafsRegion->inKSpace() && exafsRegion->maximumTime().isValid()){
-
-			QVector<double> regionTimes = QVector<double>(numberOfPoints);
-			AMVariableIntegrationTime calculator(exafsRegion->equation(), exafsRegion->regionTime(), exafsRegion->maximumTime(), exafsRegion->regionStart(), exafsRegion->regionStep(), exafsRegion->regionEnd(), exafsRegion->a2());
-			calculator.variableTime(regionTimes.data());
-
-			for (int i = 0; i < numberOfPoints; i++)
-				time += regionTimes.at(i);
-		}
-
-		else
-			time += double(exafsRegion->regionTime())*numberOfPoints;
-	}
+	foreach (AMScanAxisRegion *region, scanAxisAt(0)->regions().toList())
+		time += region->timePerRegion();
 
 	totalTime_ = time + 9; // There is a 9 second miscellaneous startup delay.
 	setExpectedDuration(totalTime_);

--- a/source/util/AMVariableIntegrationTime.cpp
+++ b/source/util/AMVariableIntegrationTime.cpp
@@ -353,7 +353,7 @@ bool AMVariableIntegrationTime::variableTime(double *times) const
 bool AMVariableIntegrationTime::computeCoefficients() const
 {
 	bool configured = true;
-	configured &= (t0_ >= 0 && tf_ > t0_);
+	configured &= (t0_ >= 0 && tf_ >= t0_);
 	configured &= (k0_ >= 0 && kf_ > k0_);
 
 	if (configured){


### PR DESCRIPTION
This was mostly a simple logic comparison bug, but I also made the VESPERS XAS code easier to read.