### PR TITLE
Pull Request for Issue1882: Workflow crash when cancelling non scan or list action

### DIFF
--- a/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
+++ b/source/ui/actions3/AMActionRunnerCurrentViewBase.cpp
@@ -153,7 +153,7 @@ void AMActionRunnerCurrentViewBase::onCancelButtonClicked()
 {
 	AMScanAction *scanAction = qobject_cast<AMScanAction *>(actionRunner_->currentAction());
 	AMListAction3 *listAction = qobject_cast<AMListAction3 *>(actionRunner_->currentAction());
-	bool scanActionRunning = (scanAction != 0) || (qobject_cast<AMScanAction *>(listAction->currentSubAction()) != 0);
+	bool scanActionRunning = (scanAction != 0) || (listAction != 0 && (qobject_cast<AMScanAction *>(listAction->currentSubAction()) != 0));
 
 	if (scanActionRunning && showCancelPrompt_){
 


### PR DESCRIPTION
- Altered the logic of the check for scan action in AMActionRunnerCurrentViewBase::onCancelButtonClicked() to prevent a possible segfault