### PR TITLE
Pull Request for Issue1877: Updating bend equations for the M1 and M2 on Main

### DIFF
--- a/source/beamline/BioXAS/BioXASMainM1MirrorBendControl.cpp
+++ b/source/beamline/BioXAS/BioXASMainM1MirrorBendControl.cpp
@@ -19,24 +19,26 @@ BioXASMainM1MirrorBendControl::~BioXASMainM1MirrorBendControl()
 
 }
 
-double BioXASMainM1MirrorBendControl::calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const
+double BioXASMainM1MirrorBendControl::calculateUpstreamBendRadius(double upstreamForce) const
 {
-	double radius1 = -7334.49 + 110164.0/upstreamBenderValue + 1908.99 * log(upstreamBenderValue);
-	double radius2 = -12614.2 + 120562.0/downstreamBenderValue + 3932.91 * log(downstreamBenderValue);
+	double result = 14911.5 - 1210.49/upstreamForce - 4025.05 * log(upstreamForce);
+	return result;
+}
 
-	double radius = (radius1 + radius2) / 2.0;
-
-	return radius;
+double BioXASMainM1MirrorBendControl::calculateDownstreamBendRadius(double downstreamForce) const
+{
+	double result = 16056.7 - 2216.81/downstreamForce - 4452.2 * log(downstreamForce);
+	return result;
 }
 
 double BioXASMainM1MirrorBendControl::calculateUpstreamBenderValue(double bendRadius) const
 {
-	double result = 17.6012 + 49019.4/bendRadius - 1.53696 * log(bendRadius);
+	double result = -10.9632 + 88056.8/bendRadius + 0.57913 * log(bendRadius);
 	return result;
 }
 
 double BioXASMainM1MirrorBendControl::calculateDownstreamBenderValue(double bendRadius) const
 {
-	double result = 3.27884 + 78691.3/bendRadius -0.265485 * log(bendRadius);
+	double result = 4.94817 + 76131.6/bendRadius - 0.992059 * log(bendRadius);
 	return result;
 }

--- a/source/beamline/BioXAS/BioXASMainM1MirrorBendControl.h
+++ b/source/beamline/BioXAS/BioXASMainM1MirrorBendControl.h
@@ -14,13 +14,15 @@ public:
 	virtual ~BioXASMainM1MirrorBendControl();
 
 protected:
-	/// Calculates and returns the mirror bend radius, for the given bender values.
-	virtual double calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const;
+	/// Calculates and returns the mirror bend radius for the upstream bender value.
+	virtual double calculateUpstreamBendRadius(double upstreamForce) const;
+	/// Calculates and returns the mirror bend radius for the downstream bender value.
+	virtual double calculateDownstreamBendRadius(double downstreamForce) const;
 
 	/// Calculates and returns the upstream bender value, for the given bend radius.
-	virtual double calculateUpstreamBenderValue(double bend) const;
+	virtual double calculateUpstreamBenderValue(double bendRadius) const;
 	/// Calculates and returns the downstream bender value, for the given bend radius.
-	virtual double calculateDownstreamBenderValue(double bend) const;
+	virtual double calculateDownstreamBenderValue(double bendRadius) const;
 };
 
 #endif // BIOXASMAINM1MIRRORBENDCONTROL_H

--- a/source/beamline/BioXAS/BioXASMainM2MirrorBendControl.cpp
+++ b/source/beamline/BioXAS/BioXASMainM2MirrorBendControl.cpp
@@ -19,24 +19,26 @@ BioXASMainM2MirrorBendControl::~BioXASMainM2MirrorBendControl()
 
 }
 
-double BioXASMainM2MirrorBendControl::calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const
+double BioXASMainM2MirrorBendControl::calculateUpstreamBendRadius(double upstreamForce) const
 {
-	double radius1 = 3638.76 - (179.413 / upstreamBenderValue) - 910.066 * log(upstreamBenderValue);
-	double radius2 = 4007.53 - (245.964 / downstreamBenderValue) - 1039 * log(downstreamBenderValue);
+	double result = 870.191 + 18502.5/upstreamForce - 264.828 * log(upstreamForce);
+	return result;
+}
 
-	double radius = (radius1 + radius2) / 2.0;
-
-	return radius;
+double BioXASMainM2MirrorBendControl::calculateDownstreamBendRadius(double downstreamForce) const
+{
+	double result = 474.389 + 20700.9/downstreamForce - 156.535 * log(downstreamForce);
+	return result;
 }
 
 double BioXASMainM2MirrorBendControl::calculateUpstreamBenderValue(double bendRadius) const
 {
-	double result = 14.9095 + 19090.8/bendRadius - 2.40315 * log(bendRadius);
+	double result = 13.2496 + 17048.4/bendRadius - 1.47537 * log(bendRadius);
 	return result;
 }
 
 double BioXASMainM2MirrorBendControl::calculateDownstreamBenderValue(double bendRadius) const
 {
-	double result = 21.5529 + 17259.2/bendRadius - 3.11236 * log(bendRadius);
+	double result = 13.3754 + 17509.5/bendRadius - 1.4731 * log(bendRadius);
 	return result;
 }

--- a/source/beamline/BioXAS/BioXASMainM2MirrorBendControl.h
+++ b/source/beamline/BioXAS/BioXASMainM2MirrorBendControl.h
@@ -14,14 +14,15 @@ public:
 	virtual ~BioXASMainM2MirrorBendControl();
 
 protected:
-	/// Calculates and returns the mirror bend radius, for the given bender values.
-	virtual double calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const;
+	/// Calculates and returns the mirror bend radius for the upstream bender value.
+	virtual double calculateUpstreamBendRadius(double upstreamForce) const;
+	/// Calculates and returns the mirror bend radius for the downstream bender value.
+	virtual double calculateDownstreamBendRadius(double downstreamForce) const;
 
 	/// Calculates and returns the upstream bender value, for the given bend radius.
-	virtual double calculateUpstreamBenderValue(double bend) const;
+	virtual double calculateUpstreamBenderValue(double bendRadius) const;
 	/// Calculates and returns the downstream bender value, for the given bend radius.
-	virtual double calculateDownstreamBenderValue(double bend) const;
-
+	virtual double calculateDownstreamBenderValue(double bendRadius) const;
 };
 
 #endif // BIOXASMAINM2MIRRORBENDCONTROL_H

--- a/source/beamline/BioXAS/BioXASMirrorBendControl.cpp
+++ b/source/beamline/BioXAS/BioXASMirrorBendControl.cpp
@@ -91,3 +91,13 @@ AMAction3* BioXASMirrorBendControl::createMoveAction(double setpoint)
 	return result;
 }
 
+double BioXASMirrorBendControl::calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const
+{
+	double radius1 = calculateUpstreamBendRadius(upstreamBenderValue);
+	double radius2 = calculateDownstreamBendRadius(downstreamBenderValue);
+
+	double radius = (radius1 + radius2) / 2.0;
+
+	return radius;
+}
+

--- a/source/beamline/BioXAS/BioXASMirrorBendControl.h
+++ b/source/beamline/BioXAS/BioXASMirrorBendControl.h
@@ -33,7 +33,12 @@ protected:
 	virtual AMAction3* createMoveAction(double setpoint);
 
 	/// Calculates and returns the mirror bend radius, for the given bender values.
-	virtual double calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const = 0;
+	virtual double calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const;
+
+	/// Calculates and returns the mirror bend radius for the upstream bender value.
+	virtual double calculateUpstreamBendRadius(double upstreamForce) const = 0;
+	/// Calculates and returns the mirror bend radius for the downstream bender value.
+	virtual double calculateDownstreamBendRadius(double downstreamForce) const = 0;
 
 	/// Calculates and returns the upstream bender value, for the given bend radius.
 	virtual double calculateUpstreamBenderValue(double bendRadius) const = 0;

--- a/source/beamline/BioXAS/BioXASSideM1MirrorBendControl.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1MirrorBendControl.cpp
@@ -19,16 +19,6 @@ BioXASSideM1MirrorBendControl::~BioXASSideM1MirrorBendControl()
 
 }
 
-double BioXASSideM1MirrorBendControl::calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const
-{
-	double radius1 = calculateUpstreamBendRadius(upstreamBenderValue);
-	double radius2 = calculateDownstreamBendRadius(downstreamBenderValue);
-
-	double radius = (radius1 + radius2) / 2.0;
-
-	return radius;
-}
-
 double BioXASSideM1MirrorBendControl::calculateUpstreamBendRadius(double upstreamForce) const
 {
 	double result = -5060.53 + 65308.6/upstreamForce + 1809.02 * log(upstreamForce);

--- a/source/beamline/BioXAS/BioXASSideM1MirrorBendControl.h
+++ b/source/beamline/BioXAS/BioXASSideM1MirrorBendControl.h
@@ -14,9 +14,6 @@ public:
 	virtual ~BioXASSideM1MirrorBendControl();
 
 protected:
-	/// Calculates and returns the mirror bend radius, for the given bender values.
-	virtual double calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const;
-
 	/// Calculates and returns the mirror bend radius for the upstream bender value.
 	virtual double calculateUpstreamBendRadius(double upstreamForce) const;
 	/// Calculates and returns the mirror bend radius for the downstream bender value.

--- a/source/beamline/BioXAS/BioXASSideM2MirrorBendControl.cpp
+++ b/source/beamline/BioXAS/BioXASSideM2MirrorBendControl.cpp
@@ -19,16 +19,6 @@ BioXASSideM2MirrorBendControl::~BioXASSideM2MirrorBendControl()
 
 }
 
-double BioXASSideM2MirrorBendControl::calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const
-{
-	double radius1 = calculateUpstreamBendRadius(upstreamBenderValue);
-	double radius2 = calculateDownstreamBendRadius(downstreamBenderValue);
-
-	double radius = (radius1 + radius2) / 2.0;
-
-	return radius;
-}
-
 double BioXASSideM2MirrorBendControl::calculateUpstreamBendRadius(double upstreamForce) const
 {
 	double result = 893.733 + 21620.4/upstreamForce - 268.868 * log(upstreamForce);

--- a/source/beamline/BioXAS/BioXASSideM2MirrorBendControl.h
+++ b/source/beamline/BioXAS/BioXASSideM2MirrorBendControl.h
@@ -14,9 +14,6 @@ public:
 	virtual ~BioXASSideM2MirrorBendControl();
 
 protected:
-	/// Calculates and returns the mirror bend radius, for the given bender values.
-	virtual double calculateBendRadius(double upstreamBenderValue, double downstreamBenderValue) const;
-
 	/// Calculates and returns the mirror bend radius for the upstream bender value.
 	virtual double calculateUpstreamBendRadius(double upstreamForce) const;
 	/// Calculates and returns the mirror bend radius for the downstream bender value.


### PR DESCRIPTION
Updated the old equations with new values. Because all mirrors on Side and Main calculate the bend radius by averaging the upstream and the downstream radii, I moved this part of the calculation up to BioXASMirrorBendControl, the ancestor of all mirror bend controls on BioXAS.