### PR TITLE
Pull Request for Issue1889: Some scans hang when running with ImmediateRead detectors

### DIFF
--- a/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
@@ -213,10 +213,12 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 			for(int x = 0; x < detectors_->count(); x++){
 
-				AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(variableIntegrationTimes.at(i));
+				if(detectors_->at(x)->supportsSynchronizedDwell()) {
+					AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(variableIntegrationTimes.at(i));
 
-				if(detectorSetDwellAction)
-					detectorSetDwellList->addSubAction(detectorSetDwellAction);
+					if(detectorSetDwellAction)
+						detectorSetDwellList->addSubAction(detectorSetDwellAction);
+				}
 			}
 
 			AMAction3 *controlMove = AMActionSupport::buildControlMoveAction(axisControl, energyPositions.at(i), false);

--- a/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
@@ -156,10 +156,12 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 		for(int x = 0; x < detectors_->count(); x++){
 
-			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(exafsRegion->regionTime());
+			if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
+				AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(exafsRegion->regionTime());
 
-			if(detectorSetDwellAction)
-				detectorSetDwellList->addSubAction(detectorSetDwellAction);
+				if(detectorSetDwellAction)
+					detectorSetDwellList->addSubAction(detectorSetDwellAction);
+			}
 		}
 
 		regionList->addSubAction(detectorSetDwellList);
@@ -213,7 +215,7 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 			for(int x = 0; x < detectors_->count(); x++){
 
-				if(detectors_->at(x)->supportsSynchronizedDwell()) {
+				if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
 					AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(variableIntegrationTimes.at(i));
 
 					if(detectorSetDwellAction)
@@ -239,10 +241,13 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 			for(int x = 0; x < detectors_->count(); x++){
 
-				AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(double(exafsRegion->maximumTime()));
+				if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
 
-				if(detectorSetDwellAction)
-					detectorSetDwellList->addSubAction(detectorSetDwellAction);
+					AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(double(exafsRegion->maximumTime()));
+
+					if(detectorSetDwellAction)
+						detectorSetDwellList->addSubAction(detectorSetDwellAction);
+				}
 			}
 
 			AMAction3 *controlMove = AMActionSupport::buildControlMoveAction(axisControl, double(kCalculator.energy(exafsRegion->regionEnd())), false);

--- a/source/acquaman/AMGenericScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMGenericScanActionControllerAssembler.cpp
@@ -163,10 +163,12 @@ AMAction3* AMGenericScanActionControllerAssembler::generateActionTreeForStepAxis
 
 	for(int x = 0; x < detectors_->count(); x++){
 
-		AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(stepScanAxisRegion->regionTime());
+		if(detectors_->at(x)->supportsSynchronizedDwell()) {
+			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(stepScanAxisRegion->regionTime());
 
-		if(detectorSetDwellAction)
-			detectorSetDwellList->addSubAction(detectorSetDwellAction);
+			if(detectorSetDwellAction)
+				detectorSetDwellList->addSubAction(detectorSetDwellAction);
+		}
 	}
 
 	regionList->addSubAction(detectorSetDwellList);

--- a/source/acquaman/AMGenericScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMGenericScanActionControllerAssembler.cpp
@@ -163,7 +163,7 @@ AMAction3* AMGenericScanActionControllerAssembler::generateActionTreeForStepAxis
 
 	for(int x = 0; x < detectors_->count(); x++){
 
-		if(detectors_->at(x)->supportsSynchronizedDwell()) {
+		if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
 			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(stepScanAxisRegion->regionTime());
 
 			if(detectorSetDwellAction)

--- a/source/acquaman/AMTimedScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMTimedScanActionControllerAssembler.cpp
@@ -36,7 +36,7 @@ bool AMTimedScanActionControllerAssembler::generateActionTreeImplmentation()
 
 	for(int x = 0; x < detectors_->count(); x++){
 
-		if(detectors_->at(x)->supportsSynchronizedDwell()) {
+		if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
 			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(acquisitionTime_);
 
 			if(detectorSetDwellAction)

--- a/source/acquaman/AMTimedScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMTimedScanActionControllerAssembler.cpp
@@ -36,10 +36,12 @@ bool AMTimedScanActionControllerAssembler::generateActionTreeImplmentation()
 
 	for(int x = 0; x < detectors_->count(); x++){
 
-		AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(acquisitionTime_);
+		if(detectors_->at(x)->supportsSynchronizedDwell()) {
+			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(acquisitionTime_);
 
-		if(detectorSetDwellAction)
-			detectorSetDwellList->addSubAction(detectorSetDwellAction);
+			if(detectorSetDwellAction)
+				detectorSetDwellList->addSubAction(detectorSetDwellAction);
+		}
 	}
 
 	AMListAction3 *scanActions = new AMSequentialListAction3(new AMSequentialListActionInfo3("Timed Scan Actions", "Timed Scan Actions"));


### PR DESCRIPTION
- Added a check in [AMEXAFS/AMGeneric/AMTimed]ScanActionControllerAssembler that a given detector supports synchronized dwell acquisition before attempting to create an action to set its dwell time.