### PR TITLE
Pull Request for Issue 1906: Remove Detector Mode Check from Scan Action Assemblers

### DIFF
--- a/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMEXAFSScanActionControllerAssembler.cpp
@@ -156,12 +156,11 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 		for(int x = 0; x < detectors_->count(); x++){
 
-			if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
-				AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(exafsRegion->regionTime());
+			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(exafsRegion->regionTime());
 
-				if(detectorSetDwellAction)
-					detectorSetDwellList->addSubAction(detectorSetDwellAction);
-			}
+			if(detectorSetDwellAction)
+				detectorSetDwellList->addSubAction(detectorSetDwellAction);
+
 		}
 
 		regionList->addSubAction(detectorSetDwellList);
@@ -215,12 +214,11 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 			for(int x = 0; x < detectors_->count(); x++){
 
-				if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
-					AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(variableIntegrationTimes.at(i));
+				AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(variableIntegrationTimes.at(i));
 
-					if(detectorSetDwellAction)
-						detectorSetDwellList->addSubAction(detectorSetDwellAction);
-				}
+				if(detectorSetDwellAction)
+					detectorSetDwellList->addSubAction(detectorSetDwellAction);
+
 			}
 
 			AMAction3 *controlMove = AMActionSupport::buildControlMoveAction(axisControl, energyPositions.at(i), false);
@@ -241,13 +239,10 @@ AMAction3 *AMEXAFSScanActionControllerAssembler::generateActionTreeForEXAFSStepA
 
 			for(int x = 0; x < detectors_->count(); x++){
 
-				if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
+				AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(double(exafsRegion->maximumTime()));
 
-					AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(double(exafsRegion->maximumTime()));
-
-					if(detectorSetDwellAction)
-						detectorSetDwellList->addSubAction(detectorSetDwellAction);
-				}
+				if(detectorSetDwellAction)
+					detectorSetDwellList->addSubAction(detectorSetDwellAction);
 			}
 
 			AMAction3 *controlMove = AMActionSupport::buildControlMoveAction(axisControl, double(kCalculator.energy(exafsRegion->regionEnd())), false);

--- a/source/acquaman/AMGenericScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMGenericScanActionControllerAssembler.cpp
@@ -163,12 +163,11 @@ AMAction3* AMGenericScanActionControllerAssembler::generateActionTreeForStepAxis
 
 	for(int x = 0; x < detectors_->count(); x++){
 
-		if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
-			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(stepScanAxisRegion->regionTime());
+		AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(stepScanAxisRegion->regionTime());
 
-			if(detectorSetDwellAction)
-				detectorSetDwellList->addSubAction(detectorSetDwellAction);
-		}
+		if(detectorSetDwellAction)
+			detectorSetDwellList->addSubAction(detectorSetDwellAction);
+
 	}
 
 	regionList->addSubAction(detectorSetDwellList);

--- a/source/acquaman/AMTimedScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMTimedScanActionControllerAssembler.cpp
@@ -36,12 +36,11 @@ bool AMTimedScanActionControllerAssembler::generateActionTreeImplmentation()
 
 	for(int x = 0; x < detectors_->count(); x++){
 
-		if(detectors_->at(x)->readMode() == AMDetectorDefinitions::RequestRead) {
-			AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(acquisitionTime_);
+		AMAction3 *detectorSetDwellAction = detectors_->at(x)->createSetAcquisitionTimeAction(acquisitionTime_);
 
-			if(detectorSetDwellAction)
-				detectorSetDwellList->addSubAction(detectorSetDwellAction);
-		}
+		if(detectorSetDwellAction)
+			detectorSetDwellList->addSubAction(detectorSetDwellAction);
+
 	}
 
 	AMListAction3 *scanActions = new AMSequentialListAction3(new AMSequentialListActionInfo3("Timed Scan Actions", "Timed Scan Actions"));


### PR DESCRIPTION
Removed the check to ensure that the read mode was request read when adding detectors to the scan action assemblers, as it was interfering with XRF detectors.