### PR TITLE
Pull Request for Issue1839: SGM Undulator Calculation Wrong For High Energies on the First Harmonic

### DIFF
--- a/source/beamline/SGM/energy/SGMUndulatorSupport.h
+++ b/source/beamline/SGM/energy/SGMUndulatorSupport.h
@@ -4,6 +4,13 @@
 #define UNDULATOR_STEP_TO_POSITION_SLOPE 8.467394369e-5
 #define UNDULATOR_MIN_POSITION 12.51
 #define UNDULATOR_MAX_POSITION 270.0
+
+// The optimized undulator position function uses the following 3 parametric fit
+// values:
+#define UNDULATOR_PARAMETRIC_FIT_1 0.14295709668
+#define UNDULATOR_PARAMETRIC_FIT_2 36.00511212946
+#define UNDULATOR_PARAMETRIC_FIT_3 1737.41045746644
+
 #include "SGMGratingSupport.h"
 /*!
   * Namespace containing enumerators and functions related to the undulator on the
@@ -97,9 +104,9 @@ inline static double optimizedUndulatorPosition(double energy,
                                                 SGMUndulatorSupport::UndulatorHarmonic undulatorHarmonic,
                                                 double undulatorOffset)
 {
-	double rawUndulatorPosition = (-1/0.14295709668) * log( (1/36.00511212946)*((1737.41045746644/(energy/int(undulatorHarmonic))) -1)) + undulatorOffset;
+	double rawUndulatorPosition = (-1/UNDULATOR_PARAMETRIC_FIT_1) * log( (1/UNDULATOR_PARAMETRIC_FIT_2)*((UNDULATOR_PARAMETRIC_FIT_3/(energy/int(undulatorHarmonic))) -1)) + undulatorOffset;
 
-	if(energy > 1737.41045746644 && undulatorHarmonic == SGMUndulatorSupport::FirstHarmonic) {
+	if(energy > UNDULATOR_PARAMETRIC_FIT_3 && undulatorHarmonic == SGMUndulatorSupport::FirstHarmonic) {
 		 rawUndulatorPosition = UNDULATOR_MAX_POSITION + undulatorOffset;
 	}
 	return qBound(UNDULATOR_MIN_POSITION, rawUndulatorPosition, UNDULATOR_MAX_POSITION);

--- a/source/beamline/SGM/energy/SGMUndulatorSupport.h
+++ b/source/beamline/SGM/energy/SGMUndulatorSupport.h
@@ -94,10 +94,14 @@ inline static bool validEnergy(UndulatorHarmonic undulatorHarmonic, double energ
   * position.
   */
 inline static double optimizedUndulatorPosition(double energy,
-				  SGMUndulatorSupport::UndulatorHarmonic undulatorHarmonic,
-				  double undulatorOffset)
+                                                SGMUndulatorSupport::UndulatorHarmonic undulatorHarmonic,
+                                                double undulatorOffset)
 {
 	double rawUndulatorPosition = (-1/0.14295709668) * log( (1/36.00511212946)*((1737.41045746644/(energy/int(undulatorHarmonic))) -1)) + undulatorOffset;
+
+	if(energy > 1737.41045746644 && undulatorHarmonic == SGMUndulatorSupport::FirstHarmonic) {
+		 rawUndulatorPosition = UNDULATOR_MAX_POSITION + undulatorOffset;
+	}
 	return qBound(UNDULATOR_MIN_POSITION, rawUndulatorPosition, UNDULATOR_MAX_POSITION);
 }
 

--- a/source/beamline/SGM/energy/SGMUndulatorSupport.h
+++ b/source/beamline/SGM/energy/SGMUndulatorSupport.h
@@ -3,7 +3,7 @@
 
 #define UNDULATOR_STEP_TO_POSITION_SLOPE 8.467394369e-5
 #define UNDULATOR_MIN_POSITION 12.51
-#define UNDULATOR_MAX_POSITION 400.0
+#define UNDULATOR_MAX_POSITION 270.0
 #include "SGMGratingSupport.h"
 /*!
   * Namespace containing enumerators and functions related to the undulator on the

--- a/source/tests/SGM/SGMEnergyTrajectoryTestView.cpp
+++ b/source/tests/SGM/SGMEnergyTrajectoryTestView.cpp
@@ -116,8 +116,14 @@ void SGMEnergyTrajectoryTestView::setupUi()
 	controlsLayout->addWidget(undulatorHarmonicComboBox_, 5, 0);
 
 
+	QLabel* undulatorOffsetLabel = new QLabel("Undulator Offset");
+	undulatorOffsetSpinBox_ = new QDoubleSpinBox();
+	undulatorOffsetSpinBox_->setRange(-500, 500);
+	controlsLayout->addWidget(undulatorOffsetLabel, 6, 0);
+	controlsLayout->addWidget(undulatorOffsetSpinBox_, 6, 1);
+
 	calculateButton_ = new QPushButton("Calculate");
-	controlsLayout->addWidget(calculateButton_, 6, 0);
+	controlsLayout->addWidget(calculateButton_, 7, 0);
 	controlSpacingLayout->addStretch();
 	// Setup plot widgets
 
@@ -270,6 +276,7 @@ void SGMEnergyTrajectoryTestView::setTheoreticalPlotData(SGMGratingSupport::Grat
 		SGMEnergyPosition energyPosition(200, gratingTranslation);
 		energyPosition.setAutoDetectUndulatorHarmonic(false);
 		energyPosition.setUndulatorHarmonic(undulatorHarmonic);
+		energyPosition.setUndulatorOffset(undulatorOffsetSpinBox_->value());
 
 		QVector<qreal> xValues = QVector<qreal>(numberOfItems);
 		QVector<qreal> gratingAngleYValues = QVector<qreal>(numberOfItems);
@@ -405,5 +412,6 @@ void SGMEnergyTrajectoryTestView::setupConnections()
 	connect(gratingTranslationComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(recalculate()));
 	connect(undulatorHarmonicComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(recalculate()));
 	connect(calculateButton_, SIGNAL(clicked(bool)), this, SLOT(recalculate()));
+	connect(undulatorOffsetSpinBox_, SIGNAL(valueChanged(double)), this, SLOT(recalculate()));
 }
 

--- a/source/tests/SGM/SGMEnergyTrajectoryTestView.cpp
+++ b/source/tests/SGM/SGMEnergyTrajectoryTestView.cpp
@@ -270,9 +270,9 @@ void SGMEnergyTrajectoryTestView::setTheoreticalPlotData(SGMGratingSupport::Grat
 		double startValue = 200;
 		double endValue = 3000;
 
-		double increment = 1;
+		double deltaEnergy = 1;
 
-		int numberOfItems = int((endValue - startValue) / increment);
+		int numberOfItems = int((endValue - startValue) / deltaEnergy);
 		SGMEnergyPosition energyPosition(200, gratingTranslation);
 		energyPosition.setAutoDetectUndulatorHarmonic(false);
 		energyPosition.setUndulatorHarmonic(undulatorHarmonic);
@@ -293,7 +293,7 @@ void SGMEnergyTrajectoryTestView::setTheoreticalPlotData(SGMGratingSupport::Grat
 			undulatorPositionYValues[iDataPoint] = energyPosition.undulatorPosition();
 			exitSlitPositionYValues[iDataPoint] = energyPosition.exitSlitPosition();
 
-			currentEnergy += increment;
+			currentEnergy += deltaEnergy;
 		}
 
 		gratingAngleTheoreticalData_->setValues(xValues, gratingAngleYValues);

--- a/source/tests/SGM/SGMEnergyTrajectoryTestView.h
+++ b/source/tests/SGM/SGMEnergyTrajectoryTestView.h
@@ -88,6 +88,7 @@ protected:
 	QDoubleSpinBox* startEnergySpinBox_;
 	QDoubleSpinBox* endEnergySpinBox_;
 	QDoubleSpinBox* timeSpinBox_;
+	QDoubleSpinBox* undulatorOffsetSpinBox_;
 	QComboBox* gratingTranslationComboBox_;
 	QComboBox* undulatorHarmonicComboBox_;
 	QPushButton* calculateButton_;

--- a/source/tests/SGM/SGMEnergyTrajectoryTestView.h
+++ b/source/tests/SGM/SGMEnergyTrajectoryTestView.h
@@ -9,6 +9,7 @@
 #include <QStackedWidget>
 
 #include "beamline/SGM/energy/SGMGratingSupport.h"
+#include "beamline/SGM/energy/SGMUndulatorSupport.h"
 
 class MPlotWidget;
 class MPlotVectorSeriesData;
@@ -33,12 +34,8 @@ protected slots:
 	 * Calculates the provided trajectory view (if valid) and dispalys the information
 	 * in the view's plots.
 	 */
-	void onCalculateButtonPushed();
+	void recalculate();
 
-	/*!
-	 * Updates the plots information to reflect data for the provided grating.
-	 */
-	void onGratingTranslationChanged(int);
 protected:
 	/*!
 	 * Helper function for initializing the ui
@@ -50,8 +47,11 @@ protected:
 	 * component positions vs. energy.
 	 * \param gratingTranslation ~ The grating translation used to produce the
 	 * energy.
+	 * \param undulatorHarmonic ~ The undulator harmonic used to produce the undulator
+	 * gap value
 	 */
-	void setTheoreticalPlotData(SGMGratingSupport::GratingTranslation gratingTranslation);
+	void setTheoreticalPlotData(SGMGratingSupport::GratingTranslation gratingTranslation,
+	                            SGMUndulatorSupport::UndulatorHarmonic undulatorHarmonic);
 
 	/*!
 	 * Helper function for updating the plot data of the energy produced by the
@@ -89,6 +89,7 @@ protected:
 	QDoubleSpinBox* endEnergySpinBox_;
 	QDoubleSpinBox* timeSpinBox_;
 	QComboBox* gratingTranslationComboBox_;
+	QComboBox* undulatorHarmonicComboBox_;
 	QPushButton* calculateButton_;
 	QStackedWidget* plotStackWidget_;
 


### PR DESCRIPTION
- Updated the energy trajectory test view in order to show the whole range of energy values
- Added a check to the undulator position calculation so that it is capped if the result would tend to infinity
- Set the undulator max position to 270.00mm