### PR TITLE
PullRequest for Issue1919: Incorrect way to initialize the combox of the detector for scan configuration

### DIFF
--- a/source/ui/SXRMB/SXRMBScanConfigurationView.cpp
+++ b/source/ui/SXRMB/SXRMBScanConfigurationView.cpp
@@ -60,8 +60,7 @@ QGroupBox *SXRMBScanConfigurationView::createAndLayoutDetectorSettings(SXRMBScan
 	connect(fluorescenceDetectorComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onFluorescenceDetectorChanged(int)));
 	connect(configuration->dbObject(), SIGNAL(fluorescenceDetectorChanged(SXRMB::FluorescenceDetectors)), this, SLOT(updateFluorescenceDetectorComboBox(SXRMB::FluorescenceDetectors)));
 
-	// default using bruker
-	updateFluorescenceDetectorComboBox(SXRMB::BrukerDetector);
+	updateFluorescenceDetectorComboBox(configuration->fluorescenceDetector());
 
 	return detectorSettingGroupBox;
 }


### PR DESCRIPTION
When initializing the scan configuration view, we didn't set the combox with the current configured value

#1919 