### PR TITLE
Pull Request for Issue1920: Resolving 'Top' window duplicate filter

### DIFF
--- a/source/beamline/AMEnumeratedControl.cpp
+++ b/source/beamline/AMEnumeratedControl.cpp
@@ -11,10 +11,6 @@ AMEnumeratedControl::AMEnumeratedControl(const QString &name, const QString &uni
 	setpoint_ = -1;
 	minimumValue_ = 0;
 	maximumValue_ = 0;
-
-	// Initialize class variables.
-
-	allowsDuplicateOptions_ = false;
 }
 
 AMEnumeratedControl::~AMEnumeratedControl()
@@ -86,14 +82,6 @@ bool AMEnumeratedControl::indexIsMoveIndex(int index) const
 	return result;
 }
 
-void AMEnumeratedControl::setAllowsDuplicateOptions(bool newStatus)
-{
-	if (allowsDuplicateOptions_ != newStatus) {
-		allowsDuplicateOptions_ = newStatus;
-		emit allowsDuplicationOptionsChanged(allowsDuplicateOptions_);
-	}
-}
-
 void AMEnumeratedControl::updateStates()
 {
 	updateConnected();
@@ -155,33 +143,16 @@ void AMEnumeratedControl::updateValue()
 
 bool AMEnumeratedControl::addOption(int index, const QString &optionString, bool readOnly)
 {
-	bool result = false;
-	bool proceed = false;
+	if (!indices_.contains(index))
+		indices_.append(index);
 
-	// First check whether we are in a situation where duplicate value options
-	// may be an issue.
+	indexStringMap_.insert(index, optionString);
 
-	if (!hasIndexNamed(optionString))
-		proceed = true;
-	else if (hasIndexNamed(optionString) && allowsDuplicateOptions_)
-		proceed = true;
+	indexReadOnlyStatusMap_.insert(index, readOnly);
 
-	// Proceed with adding the option if duplication isn't an issue.
+	updateEnumStates();
 
-	if (proceed) {
-		if (!indices_.contains(index))
-			indices_.append(index);
-
-		indexStringMap_.insert(index, optionString);
-
-		indexReadOnlyStatusMap_.insert(index, readOnly);
-
-		updateEnumStates();
-
-		result = true;
-	}
-
-	return result;
+	return true;
 }
 
 bool AMEnumeratedControl::removeOption(int index)

--- a/source/beamline/AMEnumeratedControl.cpp
+++ b/source/beamline/AMEnumeratedControl.cpp
@@ -82,6 +82,34 @@ bool AMEnumeratedControl::indexIsMoveIndex(int index) const
 	return result;
 }
 
+bool AMEnumeratedControl::setIndexString(int index, const QString &newString)
+{
+	bool result = false;
+
+	if (indices_.contains(index)) {
+		indexStringMap_.insert(index, newString);
+		updateEnumStates();
+
+		result = true;
+	}
+
+	return result;
+}
+
+bool AMEnumeratedControl::setIndexReadOnlyStatus(int index, bool readOnly)
+{
+	bool result = false;
+
+	if (indices_.contains(index)) {
+		indexReadOnlyStatusMap_.insert(index, readOnly);
+		updateEnumStates();
+
+		result = true;
+	}
+
+	return result;
+}
+
 void AMEnumeratedControl::updateStates()
 {
 	updateConnected();
@@ -147,9 +175,7 @@ bool AMEnumeratedControl::addOption(int index, const QString &optionString, bool
 		indices_.append(index);
 
 	indexStringMap_.insert(index, optionString);
-
 	indexReadOnlyStatusMap_.insert(index, readOnly);
-
 	updateEnumStates();
 
 	return true;

--- a/source/beamline/AMEnumeratedControl.h
+++ b/source/beamline/AMEnumeratedControl.h
@@ -46,6 +46,12 @@ public:
 	/// Returns true if the given option index is valid and is a move index (can be a move destination).
 	bool indexIsMoveIndex(int index) const;
 
+public slots:
+	/// Sets the given option's string representation.
+	bool setIndexString(int index, const QString &newString);
+	/// Sets the given option index as read-only.
+	bool setIndexReadOnlyStatus(int index, bool readOnly);
+
 protected slots:
 	/// Updates the states. Reimplemented to make sure the control min/max and the enumerated states are updated before the current value.
 	virtual void updateStates();

--- a/source/beamline/AMEnumeratedControl.h
+++ b/source/beamline/AMEnumeratedControl.h
@@ -31,9 +31,6 @@ public:
 	/// Returns true if the given value corresponds to a valid window setpoint, false otherwise.
 	virtual bool validSetpoint(double value) const;
 
-	/// Returns true if this control allows duplicate value option entries.
-	bool allowsDuplicateOptions() const { return allowsDuplicateOptions_; }
-
 	/// Returns a list of all indices.
 	QList<int> indices() const { return indices_; }
 	/// Returns a list of the read-only indices, values that can't be move destinations. A subset of all indices.
@@ -49,14 +46,7 @@ public:
 	/// Returns true if the given option index is valid and is a move index (can be a move destination).
 	bool indexIsMoveIndex(int index) const;
 
-signals:
-	/// Notifier that whether this control allows duplicate value option entries has changed.
-	void allowsDuplicationOptionsChanged(bool newStatus);
-
 protected slots:
-	/// Sets whether this control allows duplicate value option entries.
-	void setAllowsDuplicateOptions(bool newStatus);
-
 	/// Updates the states. Reimplemented to make sure the control min/max and the enumerated states are updated before the current value.
 	virtual void updateStates();
 	/// Updates the connected state.
@@ -89,9 +79,6 @@ protected:
 	virtual int currentIndex() const = 0;
 
 protected:
-	/// The flag indicating whether this control will allow value options with the same string representation.
-	bool allowsDuplicateOptions_;
-
 	/// The list of option indices.
 	QList<int> indices_;
 	/// The mapping between an option's index value and its string representation.

--- a/source/beamline/BioXAS/BioXASCarbonFilterFarmActuatorFilterControl.cpp
+++ b/source/beamline/BioXAS/BioXASCarbonFilterFarmActuatorFilterControl.cpp
@@ -76,7 +76,24 @@ void BioXASCarbonFilterFarmActuatorFilterControl::clearFilters()
 
 void BioXASCarbonFilterFarmActuatorFilterControl::setWindowPreference(double filter, int windowIndex)
 {
-	filterWindowPreferenceMap_.insert(filter, windowIndex);
+	if (indices_.contains(windowIndex)) {
+
+		// Identify any other window indices with the given filter value.
+		// Mark these windows as read-only.
+
+		QList<int> filterMatches = indexFilterMap_.keys(filter);
+
+		foreach (int index, filterMatches)
+			setIndexReadOnlyStatus(index, true);
+
+		// Insert preferred window to the map of filter preferences.
+
+		filterWindowPreferenceMap_.insert(filter, windowIndex);
+
+		// Mark the preferred window as a move filter.
+
+		setIndexReadOnlyStatus(windowIndex, false);
+	}
 }
 
 void BioXASCarbonFilterFarmActuatorFilterControl::removeWindowPreference(double filter)

--- a/source/beamline/BioXAS/BioXASCarbonFilterFarmFilterControl.cpp
+++ b/source/beamline/BioXAS/BioXASCarbonFilterFarmFilterControl.cpp
@@ -10,7 +10,6 @@ BioXASCarbonFilterFarmFilterControl::BioXASCarbonFilterFarmFilterControl(const Q
 	setUnits("mm");
 	setContextKnownDescription("Filter Control");
 	setAllowsMovesWhileMoving(false);
-	setAllowsDuplicateOptions(false);
 
 	// Initialize local variables.
 


### PR DESCRIPTION
- Removed the duplicate entries code in AMEnumeratedControl. It isn't used anywhere and is an unnecessary complication.
- Modified setWindowPreference for the actuator filter control, marks all entries that are not the preference to be read-only.