### PR TITLE
Pull Request for Issue1927: Scaler scan initialization and cleanup

### DIFF
--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -73,13 +73,21 @@ AMAction3* BioXASXASScanActionController::createInitializationActions()
 	CLSSIS3820Scaler *scaler = CLSBeamline::clsBeamline()->scaler();
 
 	if (scaler) {
-//		double regionTime = double(bioXASConfiguration_->scanAxisAt(0)->regionAt(0)->regionTime());
 
-//		scalerInitialization = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Scaler Initialization Actions", "BioXAS Scaler Initialization Actions"));
-//		scalerInitialization->addSubAction(scaler->createContinuousEnableAction3(false));
-//		scalerInitialization->addSubAction(scaler->createDwellTimeAction3(regionTime));
-//		scalerInitialization->addSubAction(scaler->createStartAction3(true));
-//		scalerInitialization->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
+		scalerInitialization = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Scaler Initialization Actions", "BioXAS Scaler Initialization Actions"));
+
+		// Check that the scaler is in single shot mode and is not acquiring.
+
+		scalerInitialization->addSubAction(scaler->createContinuousEnableAction3(false));
+		scalerInitialization->addSubAction(scaler->createStartAction3(false));
+
+		// Perform one acquisition to make sure the scaler is cleared of any previous data.
+
+		double regionTime = double(bioXASConfiguration_->scanAxisAt(0)->regionAt(0)->regionTime());
+
+		scalerInitialization->addSubAction(scaler->createDwellTimeAction3(regionTime));
+		scalerInitialization->addSubAction(scaler->createStartAction3(true));
+		scalerInitialization->addSubAction(scaler->createWaitForDwellFinishedAction(regionTime + 5.0));
 	}
 
 	// Initialize Ge 32-el detector, if using.
@@ -185,14 +193,15 @@ AMAction3* BioXASXASScanActionController::createCleanupActions()
 	// Create scaler cleanup actions.
 
 	AMSequentialListAction3 *scalerCleanup = 0;
-//	CLSSIS3820Scaler *scaler = CLSBeamline::clsBeamline()->scaler();
+	CLSSIS3820Scaler *scaler = CLSBeamline::clsBeamline()->scaler();
 
-	/*
 	if (scaler) {
 		scalerCleanup = new AMSequentialListAction3(new AMSequentialListActionInfo3("BioXAS Scaler Cleanup", "BioXAS Scaler Cleanup"));
+
+		// Put the scaler in Continuous mode.
+
 		scalerCleanup->addSubAction(scaler->createContinuousEnableAction3(true));
 	}
-	*/
 
 	// Create mono cleanup actions.
 


### PR DESCRIPTION
Modified the scan initialization and cleanup actions in the BioXAS XAS scan action controller. The scaler should now take an extra acquisition in initialization, and return to Continuous mode in cleanup.