### PR TITLE
Pull Request for Issue1896: Add Be window motor to BioXAS Side

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -241,12 +241,13 @@ void BioXASAppController::setupUserInterface()
 	addComponentView(BioXASBeamline::bioXAS()->m1Mirror(), "M1 Mirror");
 	addComponentView(BioXASBeamline::bioXAS()->mono(), "Monochromator");
 	addComponentView(BioXASBeamline::bioXAS()->m2Mirror(), "M2 Mirror");
+	addComponentView(BioXASBeamline::bioXAS()->beWindow(), "Be Window");
+	addComponentView(BioXASBeamline::bioXAS()->endstationTable(), "Endstation Table");
+	addComponentView(BioXASBeamline::bioXAS()->dbhrMirrors(), "DBHR Mirrors");
 	addComponentView(BioXASBeamline::bioXAS()->jjSlits(), "JJ Slits");
 	addComponentView(BioXASBeamline::bioXAS()->xiaFilters(), "XIA Filters");
-	addComponentView(BioXASBeamline::bioXAS()->dbhrMirrors(), "DBHR Mirrors");
 	addComponentView(BioXASBeamline::bioXAS()->standardsWheel(), "Standards Wheel");
 	addComponentView(BioXASBeamline::bioXAS()->cryostatStage(), "Cryostat Stage");
-	addComponentView(BioXASBeamline::bioXAS()->endstationTable(), "Endstation Table");
 	addComponentView(BioXASBeamline::bioXAS()->filterFlipper(), "Filter Flipper");
 	addComponentView(BioXASBeamline::bioXAS()->zebra(), "Zebra");
 
@@ -534,6 +535,12 @@ QWidget* BioXASAppController::createComponentView(QObject *component)
 		BioXASFilterFlipper *filterFlipper = qobject_cast<BioXASFilterFlipper*>(component);
 		if (!componentFound && filterFlipper) {
 			componentView = new BioXASFilterFlipperView(filterFlipper);
+			componentFound = true;
+		}
+
+		CLSMAXvMotor *motor = qobject_cast<CLSMAXvMotor*>(component);
+		if (!componentFound && motor) {
+			componentView = new BioXASControlEditor(motor);
 			componentFound = true;
 		}
 	}

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -86,6 +86,8 @@ public:
 	/// Returns the beam status.
 	virtual BioXASBeamStatus* beamStatus() const { return 0; }
 
+	/// Returns the Be window motor.
+	virtual CLSMAXvMotor* beWindow() const { return 0; }
 	/// Returns the JJ slits.
 	virtual CLSJJSlits* jjSlits() const { return 0; }
 	/// Returns the XIA filters.

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -229,6 +229,11 @@ void BioXASSideBeamline::setupComponents()
 	beamStatus_->setMirrorMaskState(m1Mirror_->mask()->state());
 	beamStatus_->setMonoMaskState(mono_->mask()->state());
 
+	// Be window.
+
+	beWindow_ = new CLSMAXvMotor("SMTR1607-6-I22-01", "SMTR1607-6-I22-01", "SMTR1607-6-I22-01", true, 0.01, 2.0, this);
+	connect( beWindow_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
 	// JJ slits.
 
 	jjSlits_ = new CLSJJSlits("JJSlits", "SMTR1607-6-I22-10", "SMTR1607-6-I22-09", "SMTR1607-6-I22-11", "SMTR1607-6-I22-12", this);

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -80,6 +80,8 @@ public:
 	/// Returns the beam status.
 	virtual BioXASBeamStatus* beamStatus() const { return beamStatus_; }
 
+	/// Returns the Be window motor.
+	virtual CLSMAXvMotor* beWindow() const { return beWindow_; }
 	/// Returns the JJ slits.
 	virtual CLSJJSlits* jjSlits() const { return jjSlits_; }
 	/// Returns the XIA filters.
@@ -172,6 +174,8 @@ protected:
 	/// The beam status.
 	BioXASBeamStatus *beamStatus_;
 
+	/// The Be window motor.
+	CLSMAXvMotor *beWindow_;
 	/// The JJ slits
 	CLSJJSlits *jjSlits_;
 	/// The XIA filters


### PR DESCRIPTION
- Added instance of CLSMAXvMotor to BioXASSideBeamline.
- Added virtual getter to BioXASBeamline, as Main will have one added as well.
- Added view entry to BioXASAppController that shows a BioXASControlEditor for any control if the control can't be identified as belonging to any other specific class.

Beamline testing involved checking that the control connected and the motor moved as expected with small movements about its nominal position of -0.25mm.