### PR TITLE
Pull Request for Issue1930: code refactor - move the slot implementation function to the non-slot functions

### DIFF
--- a/source/ui/beamline/AMCurrentAmplifierCompositeView.h
+++ b/source/ui/beamline/AMCurrentAmplifierCompositeView.h
@@ -30,17 +30,17 @@ public slots:
 protected slots:
     /// Updates the value_ widget selection to reflect the amplifier's new selection.
     void onAmplifierValueChanged();
-    /// Handles passing changes in the value_ combobox to the amplifier.
-    virtual void onValueComboBoxChangedImplementation(const QString &newText);
-    /// Calls AMCurrentAmplifier::decreaseValue() for both amplifiers.
-    virtual void onMinusClickedImplementation();
-    /// Calls AMCurrentAmplifier::increaseValue() for both amplifiers.
-    virtual void onPlusClickedImplementation();
-    /// Clears and repopulations value_ widget.
-	virtual void refreshViewImplementation();
 
 protected:
-    /// Clears and repopulates value_ widget with information from amplifier1_.
+	/// Handles passing changes in the value_ combobox to the amplifier.
+	virtual void onValueComboBoxChangedImplementation(const QString &newText);
+	/// Calls AMCurrentAmplifier::decreaseValue() for both amplifiers.
+	virtual void onMinusClickedImplementation();
+	/// Calls AMCurrentAmplifier::increaseValue() for both amplifiers.
+	virtual void onPlusClickedImplementation();
+	/// Clears and repopulations value_ widget.
+	virtual void refreshViewImplementation();
+	/// Clears and repopulates value_ widget with information from amplifier1_.
     void refreshValues();
     /// Sets whether buttons should be en/disabled according to the min/max value state of amplifier1_.
     void refreshButtons();

--- a/source/ui/beamline/AMCurrentAmplifierSingleView.cpp
+++ b/source/ui/beamline/AMCurrentAmplifierSingleView.cpp
@@ -50,6 +50,16 @@ void AMCurrentAmplifierSingleView::onAmplifierValueChanged()
 	}
 }
 
+void AMCurrentAmplifierSingleView::onGainViewActionTriggered()
+{
+	amplifier_->setAmplifierMode(AMCurrentAmplifier::Gain);
+}
+
+void AMCurrentAmplifierSingleView::onSensitivityViewActionTriggered()
+{
+	amplifier_->setAmplifierMode(AMCurrentAmplifier::Sensitivity);
+}
+
 void AMCurrentAmplifierSingleView::onValueComboBoxChangedImplementation(const QString &newText)
 {
 	amplifier_->setValue(newText);
@@ -78,16 +88,6 @@ void AMCurrentAmplifierSingleView::onCustomContextMenuActionImplementation(QMenu
 		contextMenu->addAction(gainViewAction_);
 		contextMenu->addAction(sensitivityViewAction_);
 	}
-}
-
-void AMCurrentAmplifierSingleView::onGainViewActionTriggered()
-{
-	amplifier_->setAmplifierMode(AMCurrentAmplifier::Gain);
-}
-
-void AMCurrentAmplifierSingleView::onSensitivityViewActionTriggered()
-{
-	amplifier_->setAmplifierMode(AMCurrentAmplifier::Sensitivity);
 }
 
 void AMCurrentAmplifierSingleView::refreshValues()

--- a/source/ui/beamline/AMCurrentAmplifierSingleView.h
+++ b/source/ui/beamline/AMCurrentAmplifierSingleView.h
@@ -34,23 +34,23 @@ public slots:
 protected slots:
     /// Updates the value_ widget selection to reflect amplifier's new selection.
     void onAmplifierValueChanged();
-    /// Handles passing changes in the value combo box to the amplifier.
-    virtual void onValueComboBoxChangedImplementation(const QString &newText);
-    /// Calls either AMCurrentAmplifier::decreaseGain/decreaseSensitivity depending on the amplifier mode.
-    virtual void onMinusClickedImplementation();
-    /// Calls either AMCurrentAmplifier::increaseGain/increaseSensitivity depending on the amplifier mode.
-    virtual void onPlusClickedImplementation();
-    /// Clears and resets view widgets.
-    virtual void refreshViewImplementation();
-    /// If multiple modes are supported by the amplifier, context menu allows user to select gain/sensitivity preference.
-	virtual void onCustomContextMenuActionImplementation(QMenu *contextMenu);
 	/// slot to set gain preference
 	void onGainViewActionTriggered();
 	/// slot to set sensitivity preference
 	void onSensitivityViewActionTriggered();
 
 protected:
-    /// Clears and repopulates value_ widget with information from amplifier_.
+	/// Handles passing changes in the value combo box to the amplifier.
+	virtual void onValueComboBoxChangedImplementation(const QString &newText);
+	/// Calls either AMCurrentAmplifier::decreaseGain/decreaseSensitivity depending on the amplifier mode.
+	virtual void onMinusClickedImplementation();
+	/// Calls either AMCurrentAmplifier::increaseGain/increaseSensitivity depending on the amplifier mode.
+	virtual void onPlusClickedImplementation();
+	/// Clears and resets view widgets.
+	virtual void refreshViewImplementation();
+	/// If multiple modes are supported by the amplifier, context menu allows user to select gain/sensitivity preference.
+	virtual void onCustomContextMenuActionImplementation(QMenu *contextMenu);
+	/// Clears and repopulates value_ widget with information from amplifier_.
     void refreshValues();
     /// Sets whether buttons should be en/disabled according to whether amplifier_ is at a max/min gain/sensitivity state.
     void refreshButtons();

--- a/source/ui/beamline/AMCurrentAmplifierView.cpp
+++ b/source/ui/beamline/AMCurrentAmplifierView.cpp
@@ -227,6 +227,12 @@ void AMCurrentAmplifierView::onAdvancedViewActionTriggered()
 	setViewMode(Advanced);
 }
 
+void AMCurrentAmplifierView::onCustomContextMenuActionImplementation(QMenu *contextMenu)
+{
+	Q_UNUSED(contextMenu)
+	// this is the default implementation of onCustomContextMenuActionImplementation(), which does nothing actually
+}
+
 QString AMCurrentAmplifierView::toDisplay(double value, const QString &units) const
 {
 	return QString("%1 %2").arg(value, 0, format_, precision_).arg(units);

--- a/source/ui/beamline/AMCurrentAmplifierView.h
+++ b/source/ui/beamline/AMCurrentAmplifierView.h
@@ -88,27 +88,32 @@ protected slots:
     void setInitialized(bool isInitialized);
     /// Called when the selected value in value_ changes. Checks that the view is valid, then calls onValueComboBoxChangedImplementation.
     void onValueComboBoxChanged(const QString &newText);
-    virtual void onValueComboBoxChangedImplementation(const QString &newText) = 0;
     /// Called when minus_ button is clicked. Checks that the view is valid, then calls onMinusClickedImplementation.
     void onMinusClicked();
-    virtual void onMinusClickedImplementation() = 0;
     /// Called when plus_ button is clicked. Checks that the view is valid, then calls onPlusClickedImplementation.
     void onPlusClicked();
-    virtual void onPlusClickedImplementation() = 0;
     /// Children can call this method when its time to refresh the view. Checks that the view is valid, then calls refreshViewImplementation.
     void refreshView();
-    virtual void refreshViewImplementation() = 0;
 
 	/// Provides a custom context menu, used to switch between Basic and Advanced views.
 	void onCustomContextMenuRequested(QPoint position);
-	virtual void onCustomContextMenuActionImplementation(QMenu *contextMenu) { }
 	/// set the view to basic view
 	void onBasicViewActionTriggered();
 	/// set the view to advance view
 	void onAdvancedViewActionTriggered();
 
 protected:
-    /// Helper function that returns a string of the given amplifier value and units. Provides consistent formatting.
+	/// pure virtual function to handle the value changed signal for the combobox
+	virtual void onValueComboBoxChangedImplementation(const QString &newText) = 0;
+	/// pure virtual function to handle the minus button click signal
+	virtual void onMinusClickedImplementation() = 0;
+	/// pure virtual function to handle the plus button click signal
+	virtual void onPlusClickedImplementation() = 0;
+	/// pure virtual function to handle the refresh view signal
+	virtual void refreshViewImplementation() = 0;
+	/// the customized implementation for the Amplifier view context menu
+	virtual void onCustomContextMenuActionImplementation(QMenu *contextMenu);
+	/// Helper function that returns a string of the given amplifier value and units. Provides consistent formatting.
     QString toDisplay(double value, const QString &units) const;
 
 protected:


### PR DESCRIPTION
#1930 

- The customized functions for AMCurrentAmplifierView should be "protected" instead of "protected slot".
- Add Q_UNUSED() for the default implementation of the context menu function


