### PR TITLE
Pull Request for Issue1946: CLSSIS3820Scaler view doesn't show scaler as scanning while performing a scan (BioXAS)

### DIFF
--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
@@ -120,6 +120,7 @@ void BioXASSIS3820Scaler::onTriggerSourceTriggered(AMDetectorDefinitions::ReadMo
 {
 	Q_UNUSED(readMode)
 	initializeTriggerSource();
+	setScanningState(true);
 }
 
 void BioXASSIS3820Scaler::triggerSourceSucceeded()


### PR DESCRIPTION
Added a setScanningState call to the onTriggerSourceTriggered method inside the BioXASSIS3820Scaler class because there are two distinct triggering mechanisms now that the scaler is controlled by the Zebra.
