### PR TITLE
Pull Request for Issue1945: Refactoring the scaler controls view

### DIFF
--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.cpp
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.cpp
@@ -151,16 +151,14 @@ void CLSSIS3820ScalerControlsView::setDwellTime()
 void CLSSIS3820ScalerControlsView::setScansPerBuffer()
 {
 	if (scaler_ && scaler_->isConnected()) {
-		int newValue = scansPerBufferBox_->value();
-		scaler_->setScansPerBuffer(newValue);
+		scaler_->setScansPerBuffer(scansPerBufferBox_->value());
 	}
 }
 
 void CLSSIS3820ScalerControlsView::setTotalScans()
 {
 	if (scaler_ && scaler_->isConnected()) {
-		int newValue = totalScansBox_->value();
-		scaler_->setTotalScans(newValue);
+		scaler_->setTotalScans(totalScansBox_->value());
 	}
 }
 

--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.h
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.h
@@ -10,8 +10,6 @@
 
 #include "beamline/CLS/CLSSIS3820Scaler.h"
 
-#define MILLISECONDS_PER_SECOND 1000
-
 class CLSSIS3820ScalerControlsView : public QWidget
 {
     Q_OBJECT
@@ -25,6 +23,8 @@ public:
 	CLSSIS3820Scaler* scaler() const { return scaler_; }
 
 signals:
+	/// Notifier that the scaler being viewed has changed.
+	void scalerChanged(CLSSIS3820Scaler *newScaler);
 
 public slots:
 	/// Refreshes the view.

--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.h
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.h
@@ -52,13 +52,12 @@ protected slots:
 	void updateStatusLabel();
 	/// Updates the acquisition mode box with the scaler's current mode.
 	void updateAcquisitionModeBox();
-	/// Handles updating the dwell time, in response to the scaler's change in time.
-	void onDwellTimeChanged();
+	/// Handles updating the dwell time box with the scaler's current dwell time.
+	void updateDwellTimeBox();
 	/// Handles updating the scans per buffer, in response to the scaler's change in scans per buffer.
-	void onScansPerBufferChanged();
+	void updateScansPerBufferBox();
 	/// Handles updating the total scans, in response to the scaler's change in total scans.
-	void onTotalScansChanged();
-
+	void updateTotalScansBox();
 
 protected:
 	/// The scaler being viewed.
@@ -75,10 +74,9 @@ protected:
 	/// Spin box holding the dwell time per point, in milliseconds.
 	QSpinBox *dwellTimeBox_;
 	/// Spin box holding the number of scans per buffer.
-	QSpinBox *scansPerBuffer_;
+	QSpinBox *scansPerBufferBox_;
 	/// Spin box holding the total number of scans.
-	QSpinBox *totalScans_;
-
+	QSpinBox *totalScansBox_;
 };
 
 #endif // CLSSIS3820SCALERCONTROLSVIEW_H

--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.h
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.h
@@ -46,8 +46,10 @@ protected slots:
 	/// Sets the scaler's total number of scans, using the view input.
 	void setTotalScans();
 
-	/// Updates the start and stop buttons.
-	void updateStartStopButtons();
+	/// Updates the start button.
+	void updateStartButton();
+	/// Updates the stop button.
+	void updateStopButton();
 	/// Updates the status label.
 	void updateStatusLabel();
 	/// Updates the acquisition mode box with the scaler's current mode.
@@ -59,6 +61,11 @@ protected slots:
 	/// Handles updating the total scans, in response to the scaler's change in total scans.
 	void updateTotalScansBox();
 
+	/// Handles updating the start and stop buttons and the status label when the scaler scanning state changes.
+	void onScalerScanningStateChanged();
+	/// Handles updating the acquisition mode box, the dwell time box, the scans per buffer box, and the total number of scans box when the scaler continuous state changes.
+	void onScalerContinuousStateChanged();
+
 protected:
 	/// The scaler being viewed.
 	CLSSIS3820Scaler *scaler_;
@@ -69,7 +76,7 @@ protected:
 	QPushButton *stopButton_;
 	/// Button that handles setting the mode of the scaler.
 	QComboBox *acquisitionModeBox_;
-	/// Label holding the overal scanning status of the scaler.  Matches the scanning button.
+	/// Label holding the overall scanning status of the scaler.  Matches the scanning button.
 	QLabel *statusLabel_;
 	/// Spin box holding the dwell time per point, in milliseconds.
 	QSpinBox *dwellTimeBox_;

--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.h
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.h
@@ -27,6 +27,8 @@ public:
 signals:
 
 public slots:
+	/// Refreshes the view.
+	void refresh();
 	/// Sets the scaler being viewed.
 	void setScaler(CLSSIS3820Scaler *newScaler);
 
@@ -44,16 +46,19 @@ protected slots:
 	/// Sets the scaler's total number of scans, using the view input.
 	void setTotalScans();
 
-	/// Handles updating the start and stop buttons' enabled state and the scanning status LED, in response to the scaler's scanning status changed.
-	void onScanningChanged();
-	/// Handles updating the mode choice, in response to the scaler's continous mode status changed.
-	void onContinuousChanged();
+	/// Updates the start and stop buttons.
+	void updateStartStopButtons();
+	/// Updates the status label.
+	void updateStatusLabel();
+	/// Updates the acquisition mode box with the scaler's current mode.
+	void updateAcquisitionModeBox();
 	/// Handles updating the dwell time, in response to the scaler's change in time.
 	void onDwellTimeChanged();
 	/// Handles updating the scans per buffer, in response to the scaler's change in scans per buffer.
 	void onScansPerBufferChanged();
 	/// Handles updating the total scans, in response to the scaler's change in total scans.
 	void onTotalScansChanged();
+
 
 protected:
 	/// The scaler being viewed.
@@ -64,11 +69,11 @@ protected:
 	/// Button that handles stopping the scanning mode of the scaler.
 	QPushButton *stopButton_;
 	/// Button that handles setting the mode of the scaler.
-	QComboBox *modeChoice_;
+	QComboBox *acquisitionModeBox_;
 	/// Label holding the overal scanning status of the scaler.  Matches the scanning button.
-	QLabel *status_;
-	/// Spin box holding the amount of time to per point.
-	QSpinBox *time_;
+	QLabel *statusLabel_;
+	/// Spin box holding the dwell time per point, in milliseconds.
+	QSpinBox *dwellTimeBox_;
 	/// Spin box holding the number of scans per buffer.
 	QSpinBox *scansPerBuffer_;
 	/// Spin box holding the total number of scans.


### PR DESCRIPTION
Changes:
- Added connect statement, so the view listens for and can respond to changes in the scaler's connectivity.
- Moved some of the initialization code for the individual UI elements from the constructor to the methods that update them. The UI elements will be cleared and not enabled by default; they will only be editable if there is a valid, connected scaler in the appropriate acquisition mode (a change from previous behavior).
- Renamed some variables and functions, hopefully to make their function clearer.

Testing on Side & Main:
- Pressing start causes scaler to start scanning for the specified dwell time, only enabled in SingleShot and when not scanning.
- Pressing stop causes scaler to stop scanning/disarm, only enabled in SingleShot when scanning.
- Changing the dwell time in AM causes scaler EDM screen to update with new time.
- Changing scaler EDM dwell time causes AM screen to update.
- Changing scans per buffer in AM causes scaler EDM screen to update with new value.
- Changing scaler EDM scans per buffer causes AM screen to update.
- Changing total scans in AM causes scaler EDM screen to update with new value.
- Changing scaler EDM total scans causes AM screen to update.