### PR TITLE
Pull Request for Issue1958: Main scaler errors when moving between 'Continuous' and 'SingleShot'

### DIFF
--- a/source/beamline/CLS/CLSSIS3820ScalerAcquisitionMode.cpp
+++ b/source/beamline/CLS/CLSSIS3820ScalerAcquisitionMode.cpp
@@ -17,9 +17,6 @@ CLSSIS3820ScalerAcquisitionMode::CLSSIS3820ScalerAcquisitionMode(const QString &
 	numberOfScansPerBufferControl_ = 0;
 	startScanControl_ = 0;
 
-	singleShotScanCountValue_ = 1;
-	singleShotNumberOfScansPerBufferValue_ = 1;
-
 	// Setup value options.
 
 	addOption(CLSSIS3820Scaler::SingleShot, "Single shot");
@@ -124,16 +121,10 @@ void CLSSIS3820ScalerAcquisitionMode::setStartScanControl(AMControl *newControl)
 	}
 }
 
-void CLSSIS3820ScalerAcquisitionMode::setSingleShotScanCountValue(double newValue)
+void CLSSIS3820ScalerAcquisitionMode::updateValue()
 {
-	if (singleShotScanCountValue_ != newValue)
-		singleShotScanCountValue_ = newValue;
-}
-
-void CLSSIS3820ScalerAcquisitionMode::setSingleShotNumberOfScansPerBufferValue(double newValue)
-{
-	if (singleShotNumberOfScansPerBufferValue_ != newValue)
-		singleShotNumberOfScansPerBufferValue_ = newValue;
+	if (!moveInProgress())
+		AMEnumeratedControl::updateValue();
 }
 
 int CLSSIS3820ScalerAcquisitionMode::currentIndex() const
@@ -154,8 +145,6 @@ AMAction3* CLSSIS3820ScalerAcquisitionMode::createMoveAction(double setpoint)
 
 	switch(int(setpoint)) {
 	case CLSSIS3820Scaler::Continuous:
-		setSingleShotScanCountValue(scanCountControl_->value());
-		setSingleShotNumberOfScansPerBufferValue(numberOfScansPerBufferControl_->value());
 		result = createMoveToContinuousModeAction();
 		break;
 
@@ -185,8 +174,8 @@ AMAction3* CLSSIS3820ScalerAcquisitionMode::createMoveToSingleShotModeAction()
 {
 	AMListAction3 *result = new AMListAction3(new AMListActionInfo3("ModeChange", "SIS3820 Scaler Mode Change"), AMListAction3::Sequential);
 	result->addSubAction(AMActionSupport::buildControlMoveAction(startScanControl_, CLSSIS3820Scaler::NotScanning));
-	result->addSubAction(AMActionSupport::buildControlMoveAction(scanCountControl_, singleShotScanCountValue_));
-	result->addSubAction(AMActionSupport::buildControlMoveAction(numberOfScansPerBufferControl_, singleShotNumberOfScansPerBufferValue_));
+	result->addSubAction(AMActionSupport::buildControlMoveAction(scanCountControl_, 1));
+	result->addSubAction(AMActionSupport::buildControlMoveAction(numberOfScansPerBufferControl_, 1));
 
 	return result;
 }

--- a/source/beamline/CLS/CLSSIS3820ScalerAcquisitionMode.h
+++ b/source/beamline/CLS/CLSSIS3820ScalerAcquisitionMode.h
@@ -54,10 +54,8 @@ public slots:
 	void setStartScanControl(AMControl *newControl);
 
 protected slots:
-	/// Sets the single shot scan count value.
-	void setSingleShotScanCountValue(double newValue);
-	/// Sets the single shot number of scans per buffer value.
-	void setSingleShotNumberOfScansPerBufferValue(double newValue);
+	/// Updates the current value. Reimplemented to only update the value when a move isn't in progress.
+	virtual void updateValue();
 
 protected:
 	/// Returns the current index. Subclasses must reimplement for their specific behavior/interaction.
@@ -77,11 +75,6 @@ protected:
 	AMControl *numberOfScansPerBufferControl_;
 	/// The start scan control.
 	AMControl *startScanControl_;
-
-	/// The value the scan count control should be set to when entering Single Shot mode.
-	double singleShotScanCountValue_;
-	/// The value the number of scans control should be set to when entering Single Shot mode.
-	double singleShotNumberOfScansPerBufferValue_;
 };
 
 #endif // CLSSIS3820SCALERACQUISITIONMODE_H


### PR DESCRIPTION
- Removed the class variables for the scans per buffer and the total scans from the AcquisitionControl, they are not used and could be the potential source of some problems.
- Reimplemented updateValue() so that the control's value is only updated when a move is not in progress.