### PR TITLE
Pull Request for Issue1494alt: Adding second coordinate to the data position tool view.

### DIFF
--- a/source/ui/dataman/AMScanViewPlotToolView.cpp
+++ b/source/ui/dataman/AMScanViewPlotToolView.cpp
@@ -371,17 +371,22 @@ void AMDataPositionCursorToolView::updateVisibility()
 
 QString AMDataPositionCursorToolView::positionToString(double value, const QString &units) const
 {
-	return QString("%1%2").arg(value).arg(units.isEmpty() ? QString("") : QString(" %1").arg(units));
+	QString result = QString("%1").arg(value);
+
+	if (!units.isEmpty() && units != " ")
+		result.append(QString(" %1").arg(units));
+
+	return result;
 }
 
 QString AMDataPositionCursorToolView::positionToString(const QPointF &values, const QStringList &units) const
 {
-	QString text;
+	QString result;
 
 	QString xString = positionToString(values.x(), units.size() > 0 ? units.at(0) : "");
 	QString yString = positionToString(values.y(), units.size() > 1 ? units.at(1) : "");
 
-	text = "(" + xString + ", " + yString + ")";
+	result = QString("(%1, %2)").arg(xString).arg(yString);
 
-	return text;
+	return result;
 }

--- a/source/ui/dataman/AMScanViewPlotToolView.cpp
+++ b/source/ui/dataman/AMScanViewPlotToolView.cpp
@@ -293,21 +293,10 @@ void AMDataPositionCursorToolView::onVisibilityChanged()
 
 void AMDataPositionCursorToolView::updatePositionLabel()
 {
-	QString toDisplay;
+	QString toDisplay = QString("");
 
-	if (tool_) {
-		QPointF value;
-		QString units;
-		QStringList unitsList;
-
-		value = tool_->cursorPosition();
-		unitsList = tool_->units();
-
-		if (!unitsList.isEmpty())
-			units = unitsList.first();
-
-		toDisplay = positionToString(value.x(), units);
-	}
+	if (tool_)
+		toDisplay = positionToString(tool_->cursorPosition(), tool_->units());
 
 	positionLabel_->setText(toDisplay);
 }
@@ -380,28 +369,19 @@ void AMDataPositionCursorToolView::updateVisibility()
 	}
 }
 
-QString AMDataPositionCursorToolView::positionToString(double value, const QString &units)
+QString AMDataPositionCursorToolView::positionToString(double value, const QString &units) const
 {
-	QString text = QString::number(value, 'f', 2);
-	if (!units.isEmpty())
-		text += " " + units;
-
-	return text;
+	return QString("%1%2").arg(value).arg(units.isEmpty() ? QString("") : QString(" %1").arg(units));
 }
 
-QString AMDataPositionCursorToolView::positionToString(const QPointF &values, const QStringList &units)
+QString AMDataPositionCursorToolView::positionToString(const QPointF &values, const QStringList &units) const
 {
 	QString text;
 
-	QString x = QString::number(values.x(), 'f', 2);
-	if (units.size() > 0)
-		x += " " + units.at(0);
+	QString xString = positionToString(values.x(), units.size() > 0 ? units.at(0) : "");
+	QString yString = positionToString(values.y(), units.size() > 1 ? units.at(1) : "");
 
-	QString y = QString::number(values.y(), 'f', 2);
-	if (units.size() > 1)
-		y += " " + units.at(1);
-
-	text = "(" + x + ", " + y + ")";
+	text = "(" + xString + ", " + yString + ")";
 
 	return text;
 }

--- a/source/ui/dataman/AMScanViewPlotToolView.h
+++ b/source/ui/dataman/AMScanViewPlotToolView.h
@@ -116,9 +116,9 @@ protected slots:
 
 protected:
 	/// Returns a string representation of the given 1D position.
-	static QString positionToString(double value, const QString &units);
+	QString positionToString(double value, const QString &units) const;
 	/// Returns a string representation of the given 2D position.
-	static QString positionToString(const QPointF &values, const QStringList &units);
+	QString positionToString(const QPointF &values, const QStringList &units) const;
 
 protected:
 	/// The tool being viewed.

--- a/source/ui/dataman/AMScanViewPlotToolView.h
+++ b/source/ui/dataman/AMScanViewPlotToolView.h
@@ -56,8 +56,6 @@ protected:
 	QLabel *valuePrompt_;
 	/// The label containing the current value.
 	QLabel *value_;
-	/// The box containing all value-related UI elements.
-	QWidget *valueBox_;
 };
 
 
@@ -108,7 +106,7 @@ protected slots:
 	/// Handles updating the view to match the tool's value and units.
 	void updatePositionLabel();
 	/// Handles updating the view to match the tool's value and units.
-	void updatePositionSpinBox();
+	void updatePositionBoxes();
 	/// Handles updating the view to match the tool's marker.
 	void updateMarkerComboBox();
 	/// Handles updating the view to match the tool's color.
@@ -128,8 +126,10 @@ protected:
 
 	/// The position label.
 	QLabel *positionLabel_;
-	/// The double spinbox that displays the cursor position.
-	QDoubleSpinBox *positionSpinBox_;
+	/// The spinbox displaying the cursor x position.
+	QDoubleSpinBox *xPositionBox_;
+	/// The spinbox displaying the cursor y position.
+	QDoubleSpinBox *yPositionBox_;
 	/// The plot marker combo box.
 	AMPlotMarkerComboBox *markerComboBox_;
 	/// The button that displays and selects the cursor color.


### PR DESCRIPTION
- Added a second QDoubleSpinBox to the data position tool view. Now there is a spin box for the x coordinate and the y coordinate.
- Modified the data position tool view string generator, to include both the x and y coordinate.