### PR TITLE
Pull Request for Issue1974: Release changes made during SGM Deploy 2016-02-08

### DIFF
--- a/SGMAcquaman_internal.pro
+++ b/SGMAcquaman_internal.pro
@@ -25,7 +25,8 @@ HEADERS += \
     source/dataman/SGM/SGMUserConfiguration.h \
 	source/application/SGM/SGM.h \
     source/ui/SGM/SGMBeamOnControlWidget.h \
-    source/acquaman/SGM/SGMContinuousScanController.h
+    source/acquaman/SGM/SGMContinuousScanController.h \
+    source/acquaman/SGM/SGMContinuousScanControllerAssembler.h
 
 SOURCES += \
     source/application/SGM/SGMMain.cpp \
@@ -47,7 +48,10 @@ SOURCES += \
     source/ui/SGM/SGMMapScanConfigurationView.cpp \
 	source/dataman/SGM/SGMUserConfiguration.cpp \
     source/ui/SGM/SGMBeamOnControlWidget.cpp \
-    source/acquaman/SGM/SGMContinuousScanController.cpp
+    source/acquaman/SGM/SGMContinuousScanController.cpp \
+    source/acquaman/SGM/SGMContinuousScanControllerAssembler.cpp
+
+
 
 
 

--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -26,6 +26,7 @@ include ( $$PATH_TO_AM/compositeCommon/QJSON.pri )
 
 include ( $$PATH_TO_AM/compositeCommon/AMBeamline.pri )
 include ( $$PATH_TO_AM/compositeCommon/AMPVControl.pri )
+include( $$PATH_TO_AM/compositeCommon/AMAcquamanDataServer.pri )
 
 # Source Files (Acquaman Framework Common)
 #######################

--- a/acquaman_suite.pro
+++ b/acquaman_suite.pro
@@ -29,7 +29,7 @@ SUBDIRS += \
 	SXRMBAddOnsCoordinator.pro \
 	VESPERSAcquaman.pro \
 	VESPERSBendingMirrors.pro \
-	VESPERSDatabaseDuplicateEntryPatch.pro \
+#	VESPERSDatabaseDuplicateEntryPatch.pro \
 	VESPERSAddOnsCoordinator.pro \
 	BareBonesAcquaman.pro \
 	acquamanTest.pro \

--- a/clsCommon.pri
+++ b/clsCommon.pri
@@ -2,7 +2,6 @@
 DESTDIR = build
 
 include ( $$PATH_TO_AM/acquamanCommon.pri )
-include( $$PATH_TO_AM/compositeCommon/AMAcquamanDataServer.pri )
 
 HEADERS *=\
 	source/actions3/actions/CLSSIS3820ScalerDarkCurrentMeasurementAction.h \

--- a/compositeCommon/AMAcquamanDataServer.pri
+++ b/compositeCommon/AMAcquamanDataServer.pri
@@ -14,6 +14,7 @@ CONFIG(jenkins_build) {
 #	PATH_TO_AMDS = $$PATH_TO_AM/../AcquamanDataServer
 }
 
+QT += network
 
 DEPENDPATH *= $$PATH_TO_AMDS $$PATH_TO_AMDS/source
 INCLUDEPATH *= $$PATH_TO_AMDS $$PATH_TO_AMDS/source

--- a/compositeCommon/AMDetector.pri
+++ b/compositeCommon/AMDetector.pri
@@ -2,6 +2,7 @@ include( AMAction.pri )
 include( AMControlSet.pri )
 include( QJSON.pri )
 include( AMDetectorInfo.pri )
+include( $$PATH_TO_AM/compositeCommon/AMAcquamanDataServer.pri )
 
 DESTDIR = build
 

--- a/source/acquaman/AMContinuousScanActionControllerAMDSClientDataRequestFileWriter.cpp
+++ b/source/acquaman/AMContinuousScanActionControllerAMDSClientDataRequestFileWriter.cpp
@@ -5,6 +5,7 @@
 #include <QTimer>
 
 #include "source/ClientRequest/AMDSClientDataRequest.h"
+#include "source/ClientRequest/AMDSClientRequest.h"
 
 AMContinuousScanActionControllerAMDSClientDataRequestFileWriter::AMContinuousScanActionControllerAMDSClientDataRequestFileWriter(const QString &filePath, QObject *parent) :
 	QObject(parent)

--- a/source/acquaman/AMGenericScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMGenericScanActionControllerAssembler.cpp
@@ -30,12 +30,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/actions/AMDetectorTriggerAction.h"
 #include "beamline/AMDetectorTriggerSource.h"
 
-#include "beamline/CLS/CLSAMDSScalerChannelDetector.h"
-#include "beamline/SGM/SGMBeamline.h"
-#include "beamline/SGM/energy/SGMEnergyControlSet.h"
-#include "beamline/SGM/energy/SGMGratingSupport.h"
-#include "beamline/SGM/energy/SGMExitSlitSupport.h"
-
 #include <QDebug>
 
 AMGenericScanActionControllerAssembler::AMGenericScanActionControllerAssembler(bool automaticDirectionAssessment, AMScanConfiguration::Direction direction, QObject *parent)
@@ -277,17 +271,7 @@ AMAction3* AMGenericScanActionControllerAssembler::generateActionTreeForContinuo
 		// END OF ACTION GENERATION: Coordinated Movement and Wait to Finish
 
 		// ACTION GENERATION: Detectors
-		QList<AMDetector*> detectorsToConfigure;
-		bool foundOneScaler = false;
-		for(int x = 0, size = detectors_->count(); x < size; x++){
-			CLSAMDSScalerChannelDetector *asScalerChannelDetector = qobject_cast<CLSAMDSScalerChannelDetector*>(detectors_->at(x));
-			if(asScalerChannelDetector && !foundOneScaler){
-				foundOneScaler = true;
-				detectorsToConfigure.append(detectors_->at(x));
-			}
-			else if(!asScalerChannelDetector)
-				detectorsToConfigure.append(detectors_->at(x));
-		}
+		QList<AMDetector*> detectorsToConfigure = generateListOfDetectorsToConfigure();
 
 		// Generate two lists - one parallel for triggering the other parallel for reading
 		AMListAction3 *continuousDetectorTriggerList = new AMParallelListAction3(new AMParallelListActionInfo3(QString("Triggering Continuous Detectors"), QString("Triggering Continuous Detectors")));
@@ -393,4 +377,9 @@ QList<AMAction3*> AMGenericScanActionControllerAssembler::findInsertionPoints(AM
 		}
 	}
 	return retVal;
+}
+
+QList<AMDetector *> AMGenericScanActionControllerAssembler::generateListOfDetectorsToConfigure() const
+{
+	return detectors_->toList();
 }

--- a/source/acquaman/AMGenericScanActionControllerAssembler.cpp
+++ b/source/acquaman/AMGenericScanActionControllerAssembler.cpp
@@ -30,8 +30,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/actions/AMDetectorTriggerAction.h"
 #include "beamline/AMDetectorTriggerSource.h"
 
-#include <QDebug>
-
 AMGenericScanActionControllerAssembler::AMGenericScanActionControllerAssembler(bool automaticDirectionAssessment, AMScanConfiguration::Direction direction, QObject *parent)
 	: AMScanActionControllerScanAssembler(parent)
 {

--- a/source/acquaman/AMGenericScanActionControllerAssembler.h
+++ b/source/acquaman/AMGenericScanActionControllerAssembler.h
@@ -67,6 +67,8 @@ protected:
 	AMAction3* generateActionListForDetectorCleanup();
 	/// Method that finds all the placeholder actions that are used to build the action tree effectively.
 	QList<AMAction3*> findInsertionPoints(AMAction3 *action);
+	/// Method which generates a list of all the detectors to be configured for acquisition.
+	virtual QList<AMDetector*> generateListOfDetectorsToConfigure() const;
 
 protected:
 	/// Flag that holds whether a scan can scan in any direction (allows the scan assembler to figure it out).

--- a/source/acquaman/SGM/SGMContinuousScanController.cpp
+++ b/source/acquaman/SGM/SGMContinuousScanController.cpp
@@ -1,5 +1,6 @@
 #include "SGMContinuousScanController.h"
 
+#include "acquaman/SGM/SGMContinuousScanControllerAssembler.h"
 #include "beamline/CLS/CLSAMDSScalerChannelDetector.h"
 #include "beamline/CLS/CLSAmptekSDD123DetectorNew.h"
 #include "source/DataHolder/AMDSGenericFlatArrayDataHolder.h"
@@ -511,4 +512,11 @@ bool SGMContinuousScanController::placeInterpolatedDataInDataStore()
 	}
 
 	return true;
+}
+
+void SGMContinuousScanController::createScanAssembler()
+{
+	scanAssembler_ = new SGMContinuousScanControllerAssembler(continuousConfiguration_->automaticDirectionAssessment(),
+								  continuousConfiguration_->direction(),
+								  this);
 }

--- a/source/acquaman/SGM/SGMContinuousScanController.cpp
+++ b/source/acquaman/SGM/SGMContinuousScanController.cpp
@@ -70,14 +70,14 @@ bool SGMContinuousScanController::findStartMotionIndices()
 
 		QList<QVector<qint32> > amptekBaseData;
 		amptekBaseData << generalPurposeCounters.value(highestAverageAmptekDetector).generalPurposeCounterVector();
-		amptekRangeData = highestAverageAmptekDetector->retrieveContinuousMotionRangeData(amptekBaseData, expectedDurationScaledToBaseTimeScale_, 20);
+		amptekRangeData = highestAverageAmptekDetector->retrieveContinuousMotionRangeData(amptekBaseData, expectedDurationScaledToBaseTimeScale_, 5);
 	}
 
 
 	int scalerInitiateMovementIndex = 0;
 	QList<QVector<qint32> > scalerBaseData;
 	scalerBaseData << scalerChannelRebaseVectors_.value("EncoderUp") << scalerChannelRebaseVectors_.value("EncoderDown");
-	AMDetectorContinuousMotionRangeData scalerRangeData = scalerChannelDetectors_.first()->retrieveContinuousMotionRangeData(scalerBaseData, expectedDurationScaledToBaseTimeScale_, 20);
+	AMDetectorContinuousMotionRangeData scalerRangeData = scalerChannelDetectors_.first()->retrieveContinuousMotionRangeData(scalerBaseData, expectedDurationScaledToBaseTimeScale_, 5);
 	if(scalerRangeData.isValid()){
 		scalerInitiateMovementIndex = scalerRangeData.motionStartIndex();
 	}

--- a/source/acquaman/SGM/SGMContinuousScanController.h
+++ b/source/acquaman/SGM/SGMContinuousScanController.h
@@ -45,6 +45,9 @@ protected:
 	/// Helper function to place the interpolated data in the data store
 	virtual bool placeInterpolatedDataInDataStore();
 
+	/// Creates the scan assembler used for this scan
+	virtual void createScanAssembler();
+
 	/// Map of other meta data collected at run time by request
 	QMap<QString, double> metaDataMap_;
 	/// The maximum value in the previous list, for quick lookup

--- a/source/acquaman/SGM/SGMContinuousScanControllerAssembler.cpp
+++ b/source/acquaman/SGM/SGMContinuousScanControllerAssembler.cpp
@@ -1,0 +1,26 @@
+#include "SGMContinuousScanControllerAssembler.h"
+#include "beamline/CLS/CLSAMDSScalerChannelDetector.h"
+
+SGMContinuousScanControllerAssembler::SGMContinuousScanControllerAssembler(bool automaticDirectionAssessment, AMScanConfiguration::Direction direction, QObject *parent) :
+    AMGenericScanActionControllerAssembler(automaticDirectionAssessment, direction, parent)
+{
+}
+
+QList<AMDetector *> SGMContinuousScanControllerAssembler::generateListOfDetectorsToConfigure() const
+{
+	QList<AMDetector*> detectorsToConfigure;
+
+	bool foundOneScaler = false;
+	for(int x = 0, size = detectors_->count(); x < size; x++){
+		CLSAMDSScalerChannelDetector *asScalerChannelDetector = qobject_cast<CLSAMDSScalerChannelDetector*>(detectors_->at(x));
+		if(asScalerChannelDetector && !foundOneScaler){
+			foundOneScaler = true;
+			detectorsToConfigure.append(detectors_->at(x));
+		}
+		else if(!asScalerChannelDetector) {
+			detectorsToConfigure.append(detectors_->at(x));
+		}
+	}
+
+	return detectorsToConfigure;
+}

--- a/source/acquaman/SGM/SGMContinuousScanControllerAssembler.h
+++ b/source/acquaman/SGM/SGMContinuousScanControllerAssembler.h
@@ -1,0 +1,24 @@
+#ifndef SGMCONTINUOUSSCANCONTROLLERASSEMBLER_H
+#define SGMCONTINUOUSSCANCONTROLLERASSEMBLER_H
+
+#include "acquaman/AMGenericScanActionControllerAssembler.h"
+
+class SGMContinuousScanControllerAssembler : public AMGenericScanActionControllerAssembler
+{
+    Q_OBJECT
+public:
+	explicit SGMContinuousScanControllerAssembler(bool automaticDirectionAssessment, AMScanConfiguration::Direction direction, QObject *parent = 0);
+
+	virtual ~SGMContinuousScanControllerAssembler() {}
+
+
+signals:
+
+public slots:
+protected:
+	/// Adds all the non-scaler detectors, plus one instance of a scaler detector.
+	virtual QList<AMDetector*> generateListOfDetectorsToConfigure() const;
+
+};
+
+#endif // SGMCONTINUOUSSCANCONTROLLERASSEMBLER_H

--- a/source/beamline/SGM/SGMHexapodTransformedAxis.cpp
+++ b/source/beamline/SGM/SGMHexapodTransformedAxis.cpp
@@ -5,25 +5,26 @@
 #include "beamline/AMBeamline.h"
 
 SGMHexapodTransformedAxis::SGMHexapodTransformedAxis(AxisDesignation axis,
-													 AMControl* globalXAxisSetpoint,
-													 AMControl* globalXAxisFeedback,
-													 AMControl* globalXAxisStatus,
-													 AMControl* globalYAxisSetpoint,
-													 AMControl* globalYAxisFeedback,
-													 AMControl* globalYAxisStatus,
-													 AMControl* globalZAxisSetpoint,
-													 AMControl* globalZAxisFeedback,
-													 AMControl* globalZAxisStatus,
-													 AMControl* trajectoryStartControl,
-                                                     AMControl* systemVelocityControl,
-                                                     AMControl* dataRecorderRateControl,
-				                                     AMControl* dataRecorderStatusControl,
-													 const QString &name,
-													 const QString &units,
-													 QObject *parent,
-													 const QString &description)
+						     AMControl* globalXAxisSetpoint,
+						     AMControl* globalXAxisFeedback,
+						     AMControl* globalXAxisStatus,
+						     AMControl* globalYAxisSetpoint,
+						     AMControl* globalYAxisFeedback,
+						     AMControl* globalYAxisStatus,
+						     AMControl* globalZAxisSetpoint,
+						     AMControl* globalZAxisFeedback,
+						     AMControl* globalZAxisStatus,
+						     AMControl* trajectoryStartControl,
+						     AMControl* systemVelocityControl,
+						     AMControl* dataRecorderRateControl,
+						     AMControl* dataRecorderStatusControl,
+						     const QString &name,
+						     const QString &units,
+						     QObject *parent,
+						     const QString &description)
 	: AM3DRotatedSystemControl(axis, globalXAxisSetpoint, globalYAxisSetpoint, globalZAxisSetpoint, name, units, parent, description )
 {
+	setAttemptMoveWhenWithinTolerance(false);
 	trajectoryStartControl_ = trajectoryStartControl;
 	globalXAxisFeedback_ = globalXAxisFeedback;
 	globalYAxisFeedback_ = globalYAxisFeedback;

--- a/source/beamline/SGM/SGMHexapodTransformedAxis.h
+++ b/source/beamline/SGM/SGMHexapodTransformedAxis.h
@@ -38,23 +38,23 @@ public:
 	  * \param description ~ A human readable description of this motor.
 	  */
 	explicit SGMHexapodTransformedAxis(AxisDesignation axis,
-									   AMControl* globalXAxisSetpoint,
-									   AMControl* globalXAxisFeedback,
-									   AMControl* globalXAxisStatus,
-									   AMControl* globalYAxisSetpoint,
-									   AMControl* globalYAxisFeedback,
-									   AMControl* globalYAxisStatus,
-									   AMControl* globalZAxisSetpoint,
-									   AMControl* globalZAxisFeedback,
-									   AMControl* globalZAxisStatus,
-									   AMControl* trajectoryStartControl,
-	                                   AMControl* systemVelocityControl,
-	                                   AMControl* dataRecorderRateControl,
-	                                   AMControl* dataRecorderStatusControl,
-									   const QString &name,
-									   const QString &units,
-									   QObject *parent = 0,
-									   const QString &description = "");
+					   AMControl* globalXAxisSetpoint,
+					   AMControl* globalXAxisFeedback,
+					   AMControl* globalXAxisStatus,
+					   AMControl* globalYAxisSetpoint,
+					   AMControl* globalYAxisFeedback,
+					   AMControl* globalYAxisStatus,
+					   AMControl* globalZAxisSetpoint,
+					   AMControl* globalZAxisFeedback,
+					   AMControl* globalZAxisStatus,
+					   AMControl* trajectoryStartControl,
+					   AMControl* systemVelocityControl,
+					   AMControl* dataRecorderRateControl,
+					   AMControl* dataRecorderStatusControl,
+					   const QString &name,
+					   const QString &units,
+					   QObject *parent = 0,
+					   const QString &description = "");
 
 	/// Whether the hexapod axis is designed to perform coordinated movements
 	bool shouldPerformCoordinatedMovement() const;


### PR DESCRIPTION
- Removed dependency on CLSAMDSScalerChannelDetector from AMGenericScanActionControllerAssembler.
  - Created a virtual function generateListOfDetectorsToConfigure() in AMGenericScanActionControllerAssembler which creates the list of detectors which need to be configured. The base implementation returns a list of all detectors.
  - Created a SGMContinuousScanControllerAssembler which overrides generateListOfDetectorsToConfigure() to ensure that only one instance of the CLSAMDSScalerChannelDetectors is added.
- Added include of AMDS to AMDetector.pri
- Added QT += network to AMDS.pri
- Removed VESPERSDatabaseDuplicateEntryPatch from acquaman_suite.pro
- Remade scaler/amptek tolerance changes which had been torched when moving old code from the generic scan action controller to the SGM continuous scan controller.

**NOTE:** This will be merged into SGMUpgrade_mergedMaster, before that is merged into SGMUpgrade. SGMUpgrade will then be merged into master.