### PR TITLE
Pull Request for Issue2015: AMStorageInfo not releasing file handles

### DIFF
--- a/source/util/AMStorageInfo.cpp
+++ b/source/util/AMStorageInfo.cpp
@@ -198,6 +198,8 @@ void AMStorageInfo::refresh()
 					fileSystemType_ = fileSystemType;
 				}
 			}
+
+            ::endmntent(filePointer);
 		}
 	}
 
@@ -277,6 +279,8 @@ QList<AMStorageInfo> AMStorageInfo::mountedVolumes()
 			}
 
 		}
+
+        ::endmntent(filePointer);
 	}
 	return volumes;
 #endif


### PR DESCRIPTION
The file iterator element of AMStorageInfo was not properly releasing the file handles it acquired. Added two calls to free the file handles after iteration was complete.

Tested on BIOXAS Side. The file descriptors for /etc/mtab obtained by the StorageInfo class which appear in the bugged version no longer appeared.