### PR TITLE
Pull Request for Issue1996: Removing clockSource_

### DIFF
--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
@@ -18,9 +18,6 @@ BioXASSIS3820Scaler::BioXASSIS3820Scaler(const QString &baseName, BioXASZebraSof
 	triggerSourceMode_ = new AMSinglePVControl("TriggerSource", baseName+":triggerSource", this);
 	allControls_->addControl(triggerSourceMode_);
 
-	clockSourceMode_ = new AMSinglePVControl("ClockSource", baseName+":source", this);
-	allControls_->addControl(clockSourceMode_);
-
 	softInput_ = softInput;
 	allControls_->addControl(softInput_);
 
@@ -39,7 +36,6 @@ bool BioXASSIS3820Scaler::isConnected() const
 	bool connected = (CLSSIS3820Scaler::isConnected() &&
 			  inputsMode_ && inputsMode_->isConnected() &&
 			  triggerSourceMode_ && triggerSourceMode_->isConnected() &&
-			  clockSourceMode_ && clockSourceMode_->isConnected() &&
 			  softInput_ && softInput_->isConnected());
 
 	return connected;

--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.h
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.h
@@ -35,8 +35,6 @@ public:
 	AMControl* inputsModeControl() const { return inputsMode_; }
 	/// Returns the trigger source control.
 	AMControl* triggerSourceModeControl() const { return triggerSourceMode_; }
-	/// Returns the clock source mode control.
-	AMControl* clockSourceModeControl() const { return clockSourceMode_; }
 
 	/// The BioXAS scaler requires arming
 	virtual bool requiresArming() const { return true; }
@@ -94,8 +92,6 @@ protected:
 	AMControl *inputsMode_;
 	/// Controls the trigger source mode.
 	AMControl *triggerSourceMode_;
-	/// Controls the clock source mode.
-	AMControl *clockSourceMode_;
 	/// The control for the soft input control of the zebra.  This is the actual trigger now.
 	BioXASZebraSoftInputControl *softInput_;
 

--- a/source/ui/BioXAS/BioXASSIS3820ScalerModesView.cpp
+++ b/source/ui/BioXAS/BioXASSIS3820ScalerModesView.cpp
@@ -21,18 +21,12 @@ BioXASSIS3820ScalerModesView::BioXASSIS3820ScalerModesView(BioXASSIS3820Scaler *
 	triggerSourceModeEditor_->setNoUnitsBox(true);
 	triggerSourceModeEditor_->setMinimumWidth(150);
 
-	clockSourceModeEditor_ = new AMExtendedControlEditor(0);
-	clockSourceModeEditor_->setTitle("Clock source");
-	clockSourceModeEditor_->setNoUnitsBox(true);
-	clockSourceModeEditor_->setMinimumWidth(150);
-
 	// Create and set layouts.
 
 	QHBoxLayout *layout = new QHBoxLayout();
 	layout->setMargin(0);
 	layout->addWidget(inputsModeEditor_);
 	layout->addWidget(triggerSourceModeEditor_);
-	layout->addWidget(clockSourceModeEditor_);
 
 	setLayout(layout);
 
@@ -52,14 +46,12 @@ void BioXASSIS3820ScalerModesView::refresh()
 
 	inputsModeEditor_->setControl(0);
 	triggerSourceModeEditor_->setControl(0);
-	clockSourceModeEditor_->setControl(0);
 
 	// Update view elements.
 
 	if (scaler_) {
 		inputsModeEditor_->setControl(scaler_->inputsModeControl());
 		triggerSourceModeEditor_->setControl(scaler_->triggerSourceModeControl());
-		clockSourceModeEditor_->setControl(scaler_->clockSourceModeControl());
 	}
 }
 

--- a/source/ui/BioXAS/BioXASSIS3820ScalerModesView.h
+++ b/source/ui/BioXAS/BioXASSIS3820ScalerModesView.h
@@ -38,8 +38,6 @@ protected:
 	AMExtendedControlEditor *inputsModeEditor_;
 	/// The trigger source mode editor.
 	AMExtendedControlEditor *triggerSourceModeEditor_;
-	/// The clock source mode editor.
-	AMExtendedControlEditor *clockSourceModeEditor_;
 };
 
 #endif // BIOXASSIS3820SCALERMODESVIEW_H


### PR DESCRIPTION
Removed the clockSource_ control from BioXASSIS3820Scaler, as it didn't end up being a component of moving the scaler from software triggered to hardware triggered (Zebra). Removed it's editor view from BioXASSIS3820ScalerView.