### PR TITLE
Pull Request for Issue2020: SSRL mono region control to inherit from AMEnumeratedControl

### DIFF
--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.cpp
@@ -2,7 +2,7 @@
 #include "BioXASSSRLMonochromator.h"
 
 BioXASSSRLMonochromatorRegionControl::BioXASSSRLMonochromatorRegionControl(const QString &name, QObject *parent) :
-	AMPseudoMotorControl(name, "", parent)
+	AMEnumeratedControl(name, "", parent)
 {
 	// Initialize local variables.
 
@@ -23,13 +23,10 @@ BioXASSSRLMonochromatorRegionControl::BioXASSSRLMonochromatorRegionControl(const
 
 	// Initialize inherited variables.
 
-	value_ = BioXASSSRLMonochromator::Region::None;
-	setpoint_ = BioXASSSRLMonochromator::Region::None;
-	minimumValue_ = BioXASSSRLMonochromator::Region::A;
-	maximumValue_ = BioXASSSRLMonochromator::Region::None;
+	addOption(BioXASSSRLMonochromator::Region::A, "A");
+	addOption(BioXASSSRLMonochromator::Region::B, "B");
+	addOption(BioXASSSRLMonochromator::Region::None, "None", true);
 
-	setEnumStates(QStringList() << "A" << "B" << "None");
-	setMoveEnumStates(QStringList() << "A" << "B");
 	setAllowsMovesWhileMoving(false);
 	setContextKnownDescription("Region Control");
 
@@ -342,23 +339,6 @@ void BioXASSSRLMonochromatorRegionControl::updateConnected()
 				);
 
 	setConnected(isConnected);
-}
-
-void BioXASSSRLMonochromatorRegionControl::updateValue()
-{
-	if (isConnected()) {
-		int regionAVal = (int)regionAStatus_->value();
-		int regionBVal = (int)regionBStatus_->value();
-
-		BioXASSSRLMonochromator::Region::State newRegion = BioXASSSRLMonochromator::Region::None;
-
-		if (regionAVal == BioXASSSRLMonochromator::Region::NotIn && regionBVal == BioXASSSRLMonochromator::Region::In)
-			newRegion = BioXASSSRLMonochromator::Region::B;
-		else if (regionAVal == BioXASSSRLMonochromator::Region::In && regionBVal == BioXASSSRLMonochromator::Region::NotIn)
-			newRegion = BioXASSSRLMonochromator::Region::A;
-
-		setValue(newRegion);
-	}
 }
 
 void BioXASSSRLMonochromatorRegionControl::updateMoving()
@@ -791,6 +771,21 @@ AMAction3* BioXASSSRLMonochromatorRegionControl::createWaitForKeyDisabledAction(
 		AMErrorMon::error(this, BioXAS_MONO_REGION_KEY_DISABLED_WAIT_FAILED, "Failed to create action to wait for the mono key to be turned to 'Disabled.'");
 
 	return action;
+}
+
+int BioXASSSRLMonochromatorRegionControl::currentIndex() const
+{
+	int result = BioXASSSRLMonochromator::Region::None;
+
+	int regionAVal = (int)regionAStatus_->value();
+	int regionBVal = (int)regionBStatus_->value();
+
+	if (regionAVal == BioXASSSRLMonochromator::Region::NotIn && regionBVal == BioXASSSRLMonochromator::Region::In)
+		result = BioXASSSRLMonochromator::Region::B;
+	else if (regionAVal == BioXASSSRLMonochromator::Region::In && regionBVal == BioXASSSRLMonochromator::Region::NotIn)
+		result = BioXASSSRLMonochromator::Region::A;
+
+	return result;
 }
 
 QString BioXASSSRLMonochromatorRegionControl::regionStateToString(int region)

--- a/source/beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.h
@@ -5,7 +5,7 @@
 #include "actions3/actions/AMControlWaitAction.h"
 #include "actions3/actions/AMWaitAction.h"
 #include "actions3/AMListAction3.h"
-#include "beamline/AMPseudoMotorControl.h"
+#include "beamline/AMEnumeratedControl.h"
 #include "util/AMErrorMonitor.h"
 
 // {setpoint}_{motor}_{property} VALUE
@@ -51,7 +51,7 @@
 #define BioXAS_MONO_REGION_REGION_B_WAIT_FAILED 1407719
 #define BioXAS_MONO_REGION_KEY_DISABLED_WAIT_FAILED 1407720
 
-class BioXASSSRLMonochromatorRegionControl : public AMPseudoMotorControl
+class BioXASSSRLMonochromatorRegionControl : public AMEnumeratedControl
 {
 	Q_OBJECT
 
@@ -151,8 +151,6 @@ public slots:
 protected slots:
 	/// Updates the connected state.
 	virtual void updateConnected();
-	/// Updates the current value.
-	virtual void updateValue();
 	/// Updates the 'is moving' state.
 	virtual void updateMoving();
 
@@ -219,6 +217,9 @@ protected:
 
 	/// Returns a new action that waits for the mono region key to be turned CW to Disabled, 0 if not connected.
 	AMAction3* createWaitForKeyDisabledAction();
+
+	/// Returns the current index.
+	virtual int currentIndex() const;
 
 	/// Returns a string representation of the given region state.
 	static QString regionStateToString(int region);


### PR DESCRIPTION
Small modifications to the SSRL mono region control.
- Changed ancestor class from AMPseudoMotorControl to AMEnumeratedControl
- Removed reimplementation of updateValue(), as AMEnumeratedControl has its own implementation
- Added reimplementation of currentIndex.