### PR TITLE
Pull Request for Issue2035: Created general way to access component multiples

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -8,8 +8,8 @@
 #include "dataman/BioXAS/BioXASDbUpgrade1Pt1.h"
 
 BioXASAppController::BioXASAppController(QObject *parent) :
-    AMAppController(parent)
-{	
+	AMAppController(parent)
+{
 	// Initialize controller settings.
 
 	userConfiguration_ = new BioXASUserConfiguration(this);
@@ -251,7 +251,6 @@ void BioXASAppController::setupUserInterface()
 	addComponentView(BioXASBeamline::bioXAS()->standardsWheel(), "Standards Wheel");
 	addComponentView(BioXASBeamline::bioXAS()->cryostatStage(), "Cryostat Stage");
 	addComponentView(BioXASBeamline::bioXAS()->filterFlipper(), "Filter Flipper");
-	addComponentView(BioXASBeamline::bioXAS()->detectorStageLateral(), "Ge 32-el Stage");
 	addComponentView(BioXASBeamline::bioXAS()->zebra(), "Zebra");
 
 	addDetectorView(BioXASBeamline::bioXAS()->scaler(), "Scaler");

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -97,19 +97,24 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 {
 	if (userConfiguration_) {
 
-		BioXAS32ElementGeDetector *geDetector = BioXASBeamline::bioXAS()->ge32ElementDetector();
+		AMDetectorSet *geDetectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();
 
-		if (geDetector) {
+		for (int i = 0; i < geDetectors->count(); i++) {
 
-			foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
-				AMRegionOfInterest *newRegion = region->createCopy();
-				geDetector->addRegionOfInterest(newRegion);
-				onRegionOfInterestAdded(region);
+			AMXRFDetector *geDetector = qobject_cast<AMXRFDetector*>(geDetectors->at(i));
+
+			if (geDetector) {
+
+				foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
+					AMRegionOfInterest *newRegion = region->createCopy();
+					geDetector->addRegionOfInterest(newRegion);
+					onRegionOfInterestAdded(region);
+				}
+
+				connect(geDetector, SIGNAL(addedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestAdded(AMRegionOfInterest*)));
+				connect(geDetector, SIGNAL(removedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestRemoved(AMRegionOfInterest*)));
+				connect(geDetector, SIGNAL(regionOfInterestBoundingRangeChanged(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestBoundingRangeChanged(AMRegionOfInterest*)));
 			}
-
-			connect(geDetector, SIGNAL(addedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestAdded(AMRegionOfInterest*)));
-			connect(geDetector, SIGNAL(removedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestRemoved(AMRegionOfInterest*)));
-			connect(geDetector, SIGNAL(regionOfInterestBoundingRangeChanged(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestBoundingRangeChanged(AMRegionOfInterest*)));
 		}
 	}
 }
@@ -254,7 +259,7 @@ void BioXASAppController::setupUserInterface()
 	addComponentView(BioXASBeamline::bioXAS()->zebra(), "Zebra");
 
 	addDetectorView(BioXASBeamline::bioXAS()->scaler(), "Scaler");
-	addDetectorView(BioXASBeamline::bioXAS()->ge32ElementDetector(), "Ge 32-el");
+//	addDetectorView(BioXASBeamline::bioXAS()->ge32ElementDetector(), "Ge 32-el");
 	addDetectorView(BioXASBeamline::bioXAS()->fourElementVortexDetector(), "Four element");
 
 	// Create scan views:
@@ -719,9 +724,16 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 		if (vortexDetector && vortexDetector->isConnected())
 			configuration->addDetector(vortexDetector->toInfo());
 
-		AMDetector *ge32Detector = BioXASBeamline::bioXAS()->ge32ElementDetector();
-		if (ge32Detector && ge32Detector->isConnected())
-			configuration->addDetector(ge32Detector->toInfo());
+//		AMDetector *ge32Detector = BioXASBeamline::bioXAS()->ge32ElementDetector();
+//		if (ge32Detector && ge32Detector->isConnected())
+//			configuration->addDetector(ge32Detector->toInfo());
+
+		AMDetectorSet *ge32Detectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();
+		for (int i = 0; i < ge32Detectors->count(); i++) {
+			AMDetector *detector = ge32Detectors->at(i);
+			if (detector && detector->isConnected())
+				configuration->addDetector(detector->toInfo());
+		}
 	}
 }
 

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -68,11 +68,13 @@ void BioXASSideAppController::setupUserInterface()
 
 	BioXASAppController::setupUserInterface();
 
+	// Side specific setup.
+
 	mw_->setWindowTitle("Acquaman - BioXAS Side");
 
-	// Add Side specific component views.
-
 	addComponentView(BioXASSideBeamline::bioXAS()->detectorStageLateralMotor(), "Ge 32-el Stage");
+
+	addDetectorView(BioXASSideBeamline::bioXAS()->ge32ElementDetector(), "Ge 32-el");
 
 	// Add persistent view.
 

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -64,9 +64,17 @@ void BioXASSideAppController::initializeBeamline()
 
 void BioXASSideAppController::setupUserInterface()
 {
+	// General BioXAS interface setup.
+
 	BioXASAppController::setupUserInterface();
 
 	mw_->setWindowTitle("Acquaman - BioXAS Side");
+
+	// Add Side specific component views.
+
+	addComponentView(BioXASSideBeamline::bioXAS()->detectorStageLateralMotor(), "Ge 32-el Stage");
+
+	// Add persistent view.
 
 	addPersistentView(new BioXASSidePersistentView());
 }

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -15,7 +15,8 @@ bool BioXASBeamline::isConnected() const
 	bool connected = (
 				beamStatus_ && beamStatus_->isConnected() &&
 				utilities_ && utilities_->isConnected() &&
-				detectorStageLateralMotors_ && detectorStageLateralMotors_->isConnected()
+				detectorStageLateralMotors_ && detectorStageLateralMotors_->isConnected() &&
+				ge32Detectors_ && ge32Detectors_->isConnnected()
 				);
 
 	return connected;
@@ -134,6 +135,37 @@ bool BioXASBeamline::clearDetectorStageLateralMotors()
 {
 	detectorStageLateralMotors_->clear();
 	emit detectorStageLateralMotorsChanged();
+	return true;
+}
+
+bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
+{
+	bool result = true;
+
+	if (ge32Detectors_->addDetector(newDetector)) {
+		result = true;
+		emit ge32DetectorsChanged();
+	}
+
+	return result;
+}
+
+bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
+{
+	bool result = false;
+
+	if (ge32Detectors_->removeDetector(detector)) {
+		result = true;
+		emit ge32DetectorsChanged();
+	}
+
+	return result;
+}
+
+bool BioXASBeamline::clearGe32Detectors()
+{
+	ge32Detectors_->clear();
+	emit ge32DetectorsChanged();
 	return true;
 }
 
@@ -513,6 +545,11 @@ void BioXASBeamline::setupComponents()
 
 	detectorStageLateralMotors_ = new AMControlSet(this);
 	connect( detectorStageLateralMotors_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	// 32Ge detectors.
+
+	ge32Detectors_ = new AMDetectorSet(this);
+	connect( ge32Detectors_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 }
 
 AMBasicControlDetectorEmulator* BioXASBeamline::createDetectorEmulator(const QString &name, const QString &description, AMControl *control, bool hiddenFromUsers, bool isVisible)

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -4,6 +4,7 @@
 #include "beamline/AMDetector.h"
 #include "beamline/AMBasicControlDetectorEmulator.h"
 #include "beamline/AMMotorGroup.h"
+#include "beamline/AMDetectorSet.h"
 
 #include "beamline/CLS/CLSBeamline.h"
 #include "beamline/CLS/CLSExclusiveStatesControl.h"
@@ -136,7 +137,7 @@ public:
 	/// Returns the I2 scaler channel detector.
 	virtual AMDetector* i2Detector() const { return 0; }
 	/// Returns the 32-element Germanium detector.
-	virtual BioXAS32ElementGeDetector* ge32ElementDetector() const { return 0; }
+	virtual AMDetectorSet* ge32ElementDetectors() const { return ge32Detectors_; }
 	/// Returns the four-element Vortex detector.
 	virtual BioXASFourElementVortexDetector* fourElementVortexDetector() const { return 0; }
 	/// Returns the scaler dwell time detector.
@@ -150,6 +151,8 @@ signals:
 	void connectedChanged(bool isConnected);
 	/// Notifier that the detector stage lateral motors list has changed.
 	void detectorStageLateralMotorsChanged();
+	/// Notifier that the 32Ge detectors have changed.
+	void ge32DetectorsChanged();
 
 public slots:
 	/// Adds a detector stage lateral motor.
@@ -158,6 +161,13 @@ public slots:
 	bool removeDetectorStageLateralMotor(CLSMAXvMotor *motor);
 	/// Clears the detector stage lateral motors.
 	bool clearDetectorStageLateralMotors();
+
+	/// Adds a 32Ge detector. Returns true if successful, false otherwise.
+	bool addGe32Detector(BioXAS32ElementGeDetector *newDetector);
+	/// Removes a 32Ge detector. Returns true if successful, false otherwise.
+	bool removeGe32Detector(BioXAS32ElementGeDetector *detector);
+	/// Clears the 32Ge detectors. Returns true if successful, false otherwise.
+	bool clearGe32Detectors();
 
 protected slots:
 	/// Sets the cached connected state.
@@ -241,9 +251,10 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
-
 	/// The set of detector stage motors.
 	AMControlSet *detectorStageLateralMotors_;
+	/// The 32Ge detectors.
+	AMDetectorSet *ge32Detectors_;
 
 	/// The control/detector map. Assumes a 1-1 correlation between controls and detector emulators.
 	QMap<AMControl*, AMBasicControlDetectorEmulator*> controlDetectorMap_;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -119,7 +119,7 @@ public:
 	/// Returns the filter flipper.
 	virtual BioXASFilterFlipper* filterFlipper() const { return 0; }
 	/// Returns the detector stage control.
-	virtual CLSMAXvMotor* detectorStageLateral() const { return 0; }
+	virtual AMControlSet* detectorStageLateralMotors() const { return detectorStageLateralMotors_; }
 
 	/// Returns the Zebra.
 	virtual BioXASZebra* zebra() const { return 0; }
@@ -148,6 +148,16 @@ public:
 signals:
 	/// Notifier that the current connected state has changed.
 	void connectedChanged(bool isConnected);
+	/// Notifier that the detector stage lateral motors list has changed.
+	void detectorStageLateralMotorsChanged();
+
+public slots:
+	/// Adds a detector stage lateral motor.
+	bool addDetectorStageLateralMotor(CLSMAXvMotor *newMotor);
+	/// Removes a detector stage lateral motor.
+	bool removeDetectorStageLateralMotor(CLSMAXvMotor *motor);
+	/// Clears the detector stage lateral motors.
+	bool clearDetectorStageLateralMotors();
 
 protected slots:
 	/// Sets the cached connected state.
@@ -231,6 +241,9 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
+
+	/// The set of detector stage motors.
+	AMControlSet *detectorStageLateralMotors_;
 
 	/// The control/detector map. Assumes a 1-1 correlation between controls and detector emulators.
 	QMap<AMControl*, AMBasicControlDetectorEmulator*> controlDetectorMap_;

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -61,8 +61,6 @@ bool BioXASSideBeamline::isConnected() const
 				i2Keithley_ && i2Keithley_->isConnected() &&
 				i2Detector_ && i2Detector_->isConnected() &&
 
-				detectorStageLateral_ && detectorStageLateral_->isConnected() &&
-
 				zebra_ && zebra_->isConnected() &&
 
 				fastShutter_ && fastShutter_->isConnected() &&
@@ -268,7 +266,7 @@ void BioXASSideBeamline::setupComponents()
 	// Detector stage.
 
 	detectorStageLateral_ = new CLSMAXvMotor("SMTR1607-6-I22-16", "SMTR1607-6-I22-16", "SMTR1607-6-I22-16", true, 0.05, 2.0, this, ":mm");
-	connect( detectorStageLateral_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+	addDetectorStageLateralMotor(detectorStageLateral_);
 
 	// Cryostat stage.
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -94,7 +94,7 @@ public:
 	CLSKeithley428* i2Keithley() const { return i2Keithley_; }
 
 	/// Returns the lateral detector stage motor.
-	virtual CLSMAXvMotor* detectorStageLateral() const { return detectorStageLateral_; }
+	virtual CLSMAXvMotor* detectorStageLateralMotor() const { return detectorStageLateral_; }
 
 	/// Return the set of BioXAS Motors by given motor category
 	QList<AMControl *> getMotorsByType(BioXASBeamlineDef::BioXASMotorType category) const;


### PR DESCRIPTION
- Added new AMControlSet class variable to BioXASBeamline. This set holds the detector stage motors. Added new methods addDetectorStageMotor(...), removeDetectorStageMotor(...), clearDetectorStageMotors() to BioXASBeamline. Subclasses can call these methods to add as many motor controls as needed.
- Similarly, added new AMDetectorSet class variable to BioXASBeamline and methods for manipulating its members. This set is for the 32Ge detectors.