### PR TITLE
Pull Request for Issue2080: Implement scientific detectors for BioXAS

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -584,7 +584,7 @@ AMScanConfigurationView* BioXASAppController::createScanConfigurationView(AMScan
 
 		AMGenericStepScanConfiguration *commissioningConfiguration = qobject_cast<AMGenericStepScanConfiguration*>(configuration);
 		if (!configurationFound && commissioningConfiguration) {
-			configurationView = new AMGenericStepScanConfigurationView(commissioningConfiguration, BioXASBeamline::bioXAS()->exposedControls(), BioXASBeamline::bioXAS()->exposedDetectors());
+			configurationView = new AMGenericStepScanConfigurationView(commissioningConfiguration, BioXASBeamline::bioXAS()->exposedControls(), BioXASBeamline::bioXAS()->exposedScientificDetectors());
 			configurationFound = true;
 		}
 	}

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -347,6 +347,7 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 	bool result = true;
 
 	if (ge32Detectors_->addDetector(newDetector)) {
+		addExposedScientificDetector(newDetector);
 		result = true;
 		emit ge32DetectorsChanged();
 	}
@@ -359,7 +360,9 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 	bool result = false;
 
 	if (ge32Detectors_->removeDetector(detector)) {
+		removeExposedScientificDetector(detector);
 		result = true;
+
 		emit ge32DetectorsChanged();
 	}
 
@@ -368,8 +371,13 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 
 bool BioXASBeamline::clearGe32Detectors()
 {
+	for (int i = 0, count = ge32Detectors_->count(); i < count; i++)
+		removeExposedScientificDetector(ge32Detectors_->at(i));
+
 	ge32Detectors_->clear();
+
 	emit ge32DetectorsChanged();
+
 	return true;
 }
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -44,12 +44,14 @@ bool BioXASMainBeamline::isConnected() const
 				endstationTable_ && endstationTable_->isConnected() &&
 				cryostatStage_ && cryostatStage_->isConnected() &&
 
-				scaler_ && scaler_->isConnected() &&
 				i0Keithley_ && i0Keithley_->isConnected() &&
-				i0Detector_ && i0Detector_->isConnected() &&
 				i1Keithley_ && i1Keithley_->isConnected() &&
-				i1Detector_ && i1Detector_->isConnected() &&
 				i2Keithley_ && i2Keithley_->isConnected() &&
+
+				scaler_ && scaler_->isConnected() &&
+
+				i0Detector_ && i0Detector_->isConnected() &&
+				i1Detector_ && i1Detector_->isConnected() &&
 				i2Detector_ && i2Detector_->isConnected()
 				);
 
@@ -239,33 +241,53 @@ void BioXASMainBeamline::setupComponents()
 	cryostatStage_ = new BioXASMainCryostatStage("BioXASMainCryostatStage", this);
 	connect( cryostatStage_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	// Scaler
+	// Scaler.
+
 	scaler_ = new CLSSIS3820Scaler("MCS1607-701:mcs", this);
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
-	// Scaler channel detectors.
-	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0 Detector", scaler_, 16, this);
-	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1 Detector", scaler_, 17, this);
-	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2 Detector", scaler_, 18, this);
+	// I0 channel.
 
-	// I0 channel amplifier
-	i0Keithley_ = new CLSKeithley428("I0 Channel", "AMP1607-701", this);
+	i0Keithley_ = new CLSKeithley428("AMP1607-701", "AMP1607-701", this);
+	connect( i0Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
+
+	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
+	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	addExposedScientificDetector(i0Detector_);
+
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
 	scaler_->channelAt(16)->setDetector(i0Detector_);
 	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
 	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
 
-	// I1 channel amplifier
-	i1Keithley_ = new CLSKeithley428("I1 Channel", "AMP1607-702", this);
+	// I1 channel.
+
+	i1Keithley_ = new CLSKeithley428("AMP1607-702", "AMP1607-702", this);
+	connect( i1Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
+
+	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
+	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	addExposedScientificDetector(i1Detector_);
+
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
 	scaler_->channelAt(17)->setDetector(i1Detector_);
 	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
 	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
 
-	// I2 channel amplifier
-	i2Keithley_ = new CLSKeithley428("I2 Channel", "AMP1607-703", this);
+	// I2 channel.
+
+	i2Keithley_ = new CLSKeithley428("AMP1607-703", "AMP1607-703", this);
+	connect( i2Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
+
+	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
+	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	addExposedScientificDetector(i2Detector_);
+
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
 	scaler_->channelAt(18)->setDetector(i2Detector_);

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -54,12 +54,19 @@ bool BioXASSideBeamline::isConnected() const
 				filterFlipper_ && filterFlipper_->isConnected() &&
 				sollerSlit_ && sollerSlit_->isConnected() &&
 
+				detectorStageLateral_ && detectorStageLateral_->isConnected() &&
+
+				zebra_ && zebra_->isConnected() &&
+
+				fastShutter_ && fastShutter_->isConnected() &&
+
 				i0Keithley_ && i0Keithley_->isConnected() &&
 				i1Keithley_ && i1Keithley_->isConnected() &&
 				i2Keithley_ && i2Keithley_->isConnected() &&
 				miscKeithley_ && miscKeithley_->isConnected() &&
 
 				scaler_ && scaler_->isConnected() &&
+
 				i0Detector_ && i0Detector_->isConnected() &&
 				i1Detector_ && i1Detector_->isConnected() &&
 				i2Detector_ && i2Detector_->isConnected() &&
@@ -67,12 +74,6 @@ bool BioXASSideBeamline::isConnected() const
 				diodeDetector_ && diodeDetector_->isConnected() &&
 				pipsDetector_ && pipsDetector_->isConnected() &&
 				lytleDetector_ && lytleDetector_->isConnected() &&
-
-				detectorStageLateral_ && detectorStageLateral_->isConnected() &&
-
-				zebra_ && zebra_->isConnected() &&
-
-				fastShutter_ && fastShutter_->isConnected() &&
 
 				ge32ElementDetector_ && ge32ElementDetector_->isConnected()
 				);
@@ -228,7 +229,7 @@ bool BioXASSideBeamline::addDiodeDetector()
 		scaler_->channelAt(19)->setCustomChannelName("Diode");
 		scaler_->channelAt(19)->setDetector(diodeDetector_);
 
-		addExposedDetector(diodeDetector_);
+		addExposedScientificDetector(diodeDetector_);
 
 		hasDiodeDetector_ = true;
 		result = true;
@@ -248,7 +249,7 @@ bool BioXASSideBeamline::removeDiodeDetector()
 		scaler_->channelAt(19)->setCustomChannelName("");
 		scaler_->channelAt(19)->setDetector(0);
 
-		removeExposedDetector(diodeDetector_);
+		removeExposedScientificDetector(diodeDetector_);
 
 		hasDiodeDetector_ = false;
 		result = true;
@@ -275,7 +276,7 @@ bool BioXASSideBeamline::addPIPSDetector()
 		scaler_->channelAt(19)->setCustomChannelName("PIPS");
 		scaler_->channelAt(19)->setDetector(pipsDetector_);
 
-		addExposedDetector(pipsDetector_);
+		addExposedScientificDetector(pipsDetector_);
 
 		hasPIPSDetector_ = true;
 		result = true;
@@ -295,7 +296,7 @@ bool BioXASSideBeamline::removePIPSDetector()
 		scaler_->channelAt(19)->setCustomChannelName("");
 		scaler_->channelAt(19)->setDetector(0);
 
-		removeExposedDetector(pipsDetector_);
+		removeExposedScientificDetector(pipsDetector_);
 
 		hasPIPSDetector_ = false;
 		result = true;
@@ -322,7 +323,7 @@ bool BioXASSideBeamline::addLytleDetector()
 		scaler_->channelAt(19)->setCustomChannelName("Lytle");
 		scaler_->channelAt(19)->setDetector(lytleDetector_);
 
-		addExposedDetector(lytleDetector_);
+		addExposedScientificDetector(lytleDetector_);
 
 		hasLytleDetector_ = true;
 		result = true;
@@ -342,7 +343,7 @@ bool BioXASSideBeamline::removeLytleDetector()
 		scaler_->channelAt(19)->setCustomChannelName("");
 		scaler_->channelAt(19)->setDetector(0);
 
-		removeExposedDetector(lytleDetector_);
+		removeExposedScientificDetector(lytleDetector_);
 
 		hasLytleDetector_ = false;
 		result = true;
@@ -517,6 +518,8 @@ void BioXASSideBeamline::setupComponents()
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedScientificDetector(i0Detector_);
+
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
 	scaler_->channelAt(16)->setDetector(i0Detector_);
@@ -531,6 +534,8 @@ void BioXASSideBeamline::setupComponents()
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedScientificDetector(i1Detector_);
+
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
 	scaler_->channelAt(17)->setDetector(i1Detector_);
@@ -544,6 +549,8 @@ void BioXASSideBeamline::setupComponents()
 
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	addExposedScientificDetector(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
@@ -572,7 +579,7 @@ void BioXASSideBeamline::setupComponents()
 	// The germanium detector.
 
 	ge32ElementDetector_ = new BioXAS32ElementGeDetector("Ge32Element",
-							     "Ge 32 Element",
+								 "Ge 32 Element",
 							     zebra_->softInputControlAt(0),
 							     zebra_->pulseControlAt(2),
 							     this);

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
@@ -28,7 +28,8 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	regionsEditor_ = new BioXASXASScanConfigurationRegionsEditor(0);
 
-	detectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedDetectors());
+	detectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedScientificDetectors());
+	detectorsView_->setMinimumWidth(150);
 
 	// Create and set main layouts
 
@@ -52,6 +53,7 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	QVBoxLayout *detectorBoxLayout = new QVBoxLayout();
 	detectorBoxLayout->addWidget(detectorsView_);
+	detectorBoxLayout->addStretch();
 
 	QGroupBox *detectorBox = new QGroupBox("Detectors");
 	detectorBox->setLayout(detectorBoxLayout);


### PR DESCRIPTION
- The I0, I1, I2 scaler channel detectors are added as scientific detectors by default.
- Ge 32 element detectors are added/removed as scientific detectors as they are added to/removed from BioXASBeamline.
- The diode/PIPS/Lytle detectors are added/removed as scientific detectors as they are added to/removed from BioXASBeamline.

Also did some minor housekeeping in BioXASMainBeamline so that it more closely resembled Side.