### PR TITLE
Pull Request for Issue1992: BioXASBeamlineComponent to inherit from AMConnectedControl.

### DIFF
--- a/source/beamline/AMConnectedControl.cpp
+++ b/source/beamline/AMConnectedControl.cpp
@@ -11,28 +11,6 @@ AMConnectedControl::~AMConnectedControl()
 
 }
 
-bool AMConnectedControl::isConnected() const
-{
-	bool result = false;
-
-	if (!children_.isEmpty()) {
-		bool connected = true;
-
-		for (int childIndex = 0, childCount = children_.count(); childIndex < childCount && connected; childIndex++) {
-			AMControl *child = children_.at(childIndex);
-
-			if (child && child->isConnected())
-				connected = true;
-			else
-				connected = false;
-		}
-
-		result = connected;
-	}
-
-	return result;
-}
-
 void AMConnectedControl::setConnected(bool isConnected)
 {
 	if (connected_ != isConnected) {
@@ -43,7 +21,7 @@ void AMConnectedControl::setConnected(bool isConnected)
 
 void AMConnectedControl::updateConnected()
 {
-	setConnected( isConnected() );
+	setConnected( childrenConnected() );
 }
 
 void AMConnectedControl::addChildControl(AMControl *control)
@@ -65,4 +43,26 @@ void AMConnectedControl::removeChildControl(AMControl *control)
 
 		updateConnected();
 	}
+}
+
+bool AMConnectedControl::childrenConnected() const
+{
+	bool result = false;
+
+	if (!children_.isEmpty()) {
+		bool connected = true;
+
+		for (int childIndex = 0, childCount = children_.count(); childIndex < childCount && connected; childIndex++) {
+			AMControl *child = children_.at(childIndex);
+
+			if (child && child->isConnected())
+				connected = true;
+			else
+				connected = false;
+		}
+
+		result = connected;
+	}
+
+	return result;
 }

--- a/source/beamline/AMConnectedControl.h
+++ b/source/beamline/AMConnectedControl.h
@@ -14,7 +14,7 @@ public:
 	virtual ~AMConnectedControl();
 
 	/// Returns the current connected state, considers the connected state of each child.
-	virtual bool isConnected() const;
+	virtual bool isConnected() const { return connected_; }
 
 protected slots:
 	/// Sets the connected state.
@@ -26,6 +26,10 @@ protected slots:
 	virtual void addChildControl(AMControl *control);
 	/// Removes a child control: disconnects from all signals from the child.
 	virtual void removeChildControl(AMControl *control);
+
+protected:
+	/// Returns true if the child controls are connected.
+	virtual bool childrenConnected() const;
 
 protected:
 	/// The current connected state.

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -387,11 +387,6 @@ void AMPseudoMotorControl::updateStates()
 	updateTolerance();
 }
 
-void AMPseudoMotorControl::updateConnected()
-{
-	setConnected( childrenConnected() );
-}
-
 void AMPseudoMotorControl::onMoveStarted(QObject *action)
 {
 	Q_UNUSED(action)
@@ -462,28 +457,6 @@ AMAction3* AMPseudoMotorControl::createCalibrateAction(double oldValue, double n
 	Q_UNUSED(newValue)
 
 	return 0;
-}
-
-bool AMPseudoMotorControl::childrenConnected() const
-{
-	bool result = false;
-
-	int childCount = childControls().count();
-
-	if (childCount > 0) {
-		bool connected = true;
-
-		for (int i = 0; i < childCount && connected; i++) {
-			AMControl *child = childControlAt(i);
-
-			if ( !(child && child->isConnected()) )
-				connected = false;
-		}
-
-		result = connected;
-	}
-
-	return result;
 }
 
 void AMPseudoMotorControl::moveActionCleanup(QObject *action)

--- a/source/beamline/AMPseudoMotorControl.h
+++ b/source/beamline/AMPseudoMotorControl.h
@@ -94,8 +94,6 @@ protected slots:
 
 	/// Updates states.
 	virtual void updateStates();
-	/// Updates the connected state.
-    virtual void updateConnected();
 	/// Updates the current value.
 	virtual void updateValue() = 0;
 	/// Updates the moving state.
@@ -136,9 +134,6 @@ protected:
 
 	/// Creates and returns a calibration action. Subclasses can optionally reimplement.
 	virtual AMAction3* createCalibrateAction(double oldValue, double newValue);
-
-	/// Returns true if all children are connected, false otherwise.
-	bool childrenConnected() const;
 
 	/// Handles disconnecting from a move action and removing the signal mappings when the action is complete.
 	void moveActionCleanup(QObject *action);

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
@@ -76,20 +76,3 @@ bool BioXASBeamlineComponent::stop()
 
 	return result;
 }
-
-void BioXASBeamlineComponent::addChildControl(AMControl *control)
-{
-	if (control && !children_.contains(control)) {
-		children_ << control;
-
-		connect( control, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
-	}
-}
-
-void BioXASBeamlineComponent::removeChildControl(AMControl *control)
-{
-	if (children_.contains(control)) {
-		disconnect( control, 0, this, 0 );
-		children_.removeOne(control);
-	}
-}

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.cpp
@@ -1,9 +1,9 @@
 #include "BioXASBeamlineComponent.h"
 
 BioXASBeamlineComponent::BioXASBeamlineComponent(const QString &name, QObject *parent) :
-	AMControl(name, "", parent)
+	AMConnectedControl(name, "", parent)
 {
-	connected_ = false;
+
 }
 
 BioXASBeamlineComponent::~BioXASBeamlineComponent()
@@ -92,17 +92,4 @@ void BioXASBeamlineComponent::removeChildControl(AMControl *control)
 		disconnect( control, 0, this, 0 );
 		children_.removeOne(control);
 	}
-}
-
-void BioXASBeamlineComponent::setConnected(bool isConnected)
-{
-	if (connected_ != isConnected) {
-		connected_ = isConnected;
-		emit connected(connected_);
-	}
-}
-
-void BioXASBeamlineComponent::updateConnected()
-{
-	setConnected( isConnected() );
 }

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.h
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.h
@@ -1,9 +1,9 @@
 #ifndef BIOXASBEAMLINECOMPONENT_H
 #define BIOXASBEAMLINECOMPONENT_H
 
-#include "beamline/AMControl.h"
+#include "beamline/AMConnectedControl.h"
 
-class BioXASBeamlineComponent : public AMControl
+class BioXASBeamlineComponent : public AMConnectedControl
 {
     Q_OBJECT
 
@@ -27,16 +27,6 @@ protected slots:
 	virtual void addChildControl(AMControl *control);
 	/// Removes a given control from the list of child controls.
 	virtual void removeChildControl(AMControl *control);
-
-	/// Sets the current connected state.
-	void setConnected(bool isConnected);
-
-	/// Updates the connected state.
-	virtual void updateConnected();
-
-protected:
-	/// The current connected state.
-	bool connected_;
 };
 
 #endif // BIOXASBEAMLINECOMPONENT_H

--- a/source/beamline/BioXAS/BioXASBeamlineComponent.h
+++ b/source/beamline/BioXAS/BioXASBeamlineComponent.h
@@ -21,12 +21,6 @@ public:
 public slots:
 	/// Stops all child controls that can be stopped.
 	virtual bool stop();
-
-protected slots:
-	/// Adds a given control to the list of child controls.
-	virtual void addChildControl(AMControl *control);
-	/// Removes a given control from the list of child controls.
-	virtual void removeChildControl(AMControl *control);
 };
 
 #endif // BIOXASBEAMLINECOMPONENT_H


### PR DESCRIPTION
Modified BioXASBeamlineComponent to inherit from AMConnectedControl, instead of AMControl. Removed the class content related to getting and tracking connected state information, as this is taken care of in the new ancestor.