### PR TITLE
Pull Request for Issue2091: Duplicate regions of interest

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -7,8 +7,6 @@
 
 #include "dataman/BioXAS/BioXASDbUpgrade1Pt1.h"
 
-#include <QDebug>
-
 BioXASAppController::BioXASAppController(QObject *parent) :
 	AMAppController(parent)
 {
@@ -108,10 +106,10 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 			if (geDetector) {
 
 				foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
-					qDebug() << "BioXASAppController: Loading ROI from user configuration.";
-					AMRegionOfInterest *newRegion = region->createCopy();
-					geDetector->addRegionOfInterest(newRegion);
-					onRegionOfInterestAdded(region);
+					if (!containsRegionOfInterest(geDetector->regionsOfInterest(), region)) {
+						geDetector->addRegionOfInterest(region->createCopy());
+						onRegionOfInterestAdded(region);
+					}
 				}
 
 				connect(geDetector, SIGNAL(addedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestAdded(AMRegionOfInterest*)));
@@ -124,14 +122,17 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 
 void BioXASAppController::onRegionOfInterestAdded(AMRegionOfInterest *region)
 {
-	if (userConfiguration_ && !userConfiguration_->regionsOfInterest().contains(region)) {
-		qDebug() << "BioXASAppController: Adding ROI to user configuration.";
-		userConfiguration_->addRegionOfInterest(region);
-	}
+	if (region) {
 
-	if (xasConfiguration_) {
-		qDebug() << "BioXASAppController: Adding ROI to XAS configuration.";
-		xasConfiguration_->addRegionOfInterest(region);
+		// Add the region of interest to the user configuration, if it doesn't have it already.
+
+		if (userConfiguration_ && !containsRegionOfInterest(userConfiguration_->regionsOfInterest(), region))
+			userConfiguration_->addRegionOfInterest(region);
+
+		// Add the region of interest to the XAS scan configuration, if it doesn't have it already.
+
+		if (xasConfiguration_ && !containsRegionOfInterest(xasConfiguration_->regionsOfInterest(), region))
+			xasConfiguration_->addRegionOfInterest(region);
 	}
 }
 
@@ -766,4 +767,20 @@ void BioXASAppController::setupGenericStepScanConfiguration(AMGenericStepScanCon
 		if (i0Detector)
 			configuration->addDetector(i0Detector->toInfo());
 	}
+}
+
+bool BioXASAppController::containsRegionOfInterest(QList<AMRegionOfInterest *> regionOfInterestList, AMRegionOfInterest *toFind) const
+{
+	bool regionOfInterestFound = false;
+
+	if (!regionOfInterestList.isEmpty() && toFind) {
+		for (int i = 0, count = regionOfInterestList.count(); i < count && !regionOfInterestFound; i++) {
+			AMRegionOfInterest *regionOfInterest = regionOfInterestList.at(i);
+
+			if (regionOfInterest && regionOfInterest->name() == toFind->name())
+				regionOfInterestFound = true;
+		}
+	}
+
+	return regionOfInterestFound;
 }

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -7,6 +7,8 @@
 
 #include "dataman/BioXAS/BioXASDbUpgrade1Pt1.h"
 
+#include <QDebug>
+
 BioXASAppController::BioXASAppController(QObject *parent) :
 	AMAppController(parent)
 {
@@ -106,6 +108,7 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 			if (geDetector) {
 
 				foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
+					qDebug() << "BioXASAppController: Loading ROI from user configuration.";
 					AMRegionOfInterest *newRegion = region->createCopy();
 					geDetector->addRegionOfInterest(newRegion);
 					onRegionOfInterestAdded(region);
@@ -121,11 +124,15 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 
 void BioXASAppController::onRegionOfInterestAdded(AMRegionOfInterest *region)
 {
-	if (userConfiguration_ && !userConfiguration_->regionsOfInterest().contains(region))
+	if (userConfiguration_ && !userConfiguration_->regionsOfInterest().contains(region)) {
+		qDebug() << "BioXASAppController: Adding ROI to user configuration.";
 		userConfiguration_->addRegionOfInterest(region);
+	}
 
-	if (xasConfiguration_)
+	if (xasConfiguration_) {
+		qDebug() << "BioXASAppController: Adding ROI to XAS configuration.";
 		xasConfiguration_->addRegionOfInterest(region);
+	}
 }
 
 void BioXASAppController::onRegionOfInterestRemoved(AMRegionOfInterest *region)

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -184,6 +184,9 @@ protected:
 	/// Sets up a generic step scan configuration.
 	virtual void setupGenericStepScanConfiguration(AMGenericStepScanConfiguration *configuration);
 
+	/// Returns true if the list of regions of interest contains the given ROI.
+	bool containsRegionOfInterest(QList<AMRegionOfInterest*> roiList, AMRegionOfInterest *regionOfInterest) const;
+
 protected:
 	/// Holds the user configuration used for automatically setting up some simple aspects of the user interface.
 	BioXASUserConfiguration *userConfiguration_;

--- a/source/beamline/AMXRFDetector.cpp
+++ b/source/beamline/AMXRFDetector.cpp
@@ -322,10 +322,9 @@ void AMXRFDetector::addRegionOfInterest(const AMEmissionLine &emissionLine)
 
 	addRegionOfInterest(region);
 }
-#include <QDebug>
+
 void AMXRFDetector::addRegionOfInterest(AMRegionOfInterest *newRegionOfInterest)
 {
-	qDebug() << "AMXRFDetector: adding ROI to detector.";
 	connect(newRegionOfInterest, SIGNAL(boundingRangeChanged(AMRange)), regionOfInterestSignalMapper_, SLOT(map()));
 	regionOfInterestSignalMapper_->setMapping(newRegionOfInterest, newRegionOfInterest);
 	regionsOfInterest_.append(newRegionOfInterest);

--- a/source/beamline/AMXRFDetector.cpp
+++ b/source/beamline/AMXRFDetector.cpp
@@ -322,9 +322,10 @@ void AMXRFDetector::addRegionOfInterest(const AMEmissionLine &emissionLine)
 
 	addRegionOfInterest(region);
 }
-
+#include <QDebug>
 void AMXRFDetector::addRegionOfInterest(AMRegionOfInterest *newRegionOfInterest)
 {
+	qDebug() << "AMXRFDetector: adding ROI to detector.";
 	connect(newRegionOfInterest, SIGNAL(boundingRangeChanged(AMRange)), regionOfInterestSignalMapper_, SLOT(map()));
 	regionOfInterestSignalMapper_->setMapping(newRegionOfInterest, newRegionOfInterest);
 	regionsOfInterest_.append(newRegionOfInterest);


### PR DESCRIPTION
Added a new method containsRegionOfInterest() to BioXASBeamline. Successfully used this method when a user configuration is loaded to prevent a ton of duplicate ROIs from being added to the detector and scan configuration.