### PR TITLE
Pull Request for Issue1993: Adding XAS detectors to BioXAS scan configuration by default

### DIFF
--- a/source/acquaman/AMGenericStepScanConfiguration.cpp
+++ b/source/acquaman/AMGenericStepScanConfiguration.cpp
@@ -232,9 +232,9 @@ void AMGenericStepScanConfiguration::addDetector(AMDetectorInfo newInfo)
 	}
 
 	if (!containsDetector){
-
 		detectorConfigurations_.append(newInfo, newInfo.name());
 		setModified(true);
+		emit detectorConfigurationsChanged();
 	}
 }
 
@@ -249,8 +249,16 @@ void AMGenericStepScanConfiguration::removeDetector(AMDetectorInfo info)
 			detectorRemoved = true;
 			detectorConfigurations_.remove(i);
 			setModified(true);
+			emit detectorConfigurationsChanged();
 		}
 	}
+}
+
+void AMGenericStepScanConfiguration::clearDetectors()
+{
+	detectorConfigurations_.clear();
+	setModified(true);
+	emit detectorConfigurationsChanged();
 }
 
 void AMGenericStepScanConfiguration::addRegionOfInterest(AMRegionOfInterest *region)

--- a/source/acquaman/AMGenericStepScanConfiguration.h
+++ b/source/acquaman/AMGenericStepScanConfiguration.h
@@ -70,6 +70,8 @@ public slots:
 	void addDetector(AMDetectorInfo newInfo);
 	/// Removes the detector from the detector info list.
 	void removeDetector(AMDetectorInfo info);
+	/// Clears all detectors from the detector info list.
+	void clearDetectors();
 	/// Adds a region of interest to the list.
 	void addRegionOfInterest(AMRegionOfInterest *region);
 	/// Removes a region of interest from the list.

--- a/source/acquaman/AMScanConfiguration.cpp
+++ b/source/acquaman/AMScanConfiguration.cpp
@@ -126,6 +126,8 @@ void AMScanConfiguration::setExpectedDuration(double duration)
 
 void AMScanConfiguration::setDetectorConfigurations(const AMDetectorInfoSet &detectorConfigurations){
 	if(detectorConfigurations_ != detectorConfigurations){
+
+
 		detectorConfigurations_ = detectorConfigurations;
 		setModified(true);
 		emit detectorConfigurationsChanged();

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -194,7 +194,7 @@ void BioXASAppController::onCurrentScanActionFinishedImplementation(AMScanAction
 	}
 }
 
-void BioXASAppController::onXASDetectorsConnectedChanged()
+void BioXASAppController::onXASDetectorsChanged()
 {
 	// Clear the configuration detectors.
 
@@ -735,8 +735,11 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 
 		// Set scan detectors.
 
-		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(connected(bool)), this, SLOT(onXASDetectorsConnectedChanged()) );
-		onXASDetectorsConnectedChanged();
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(connected(bool)), this, SLOT(onXASDetectorsChanged()) );
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(detectorAdded(int)), this, SLOT(onXASDetectorsChanged()) );
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(detectorRemoved(int)), this, SLOT(onXASDetectorsChanged()) );
+
+		onXASDetectorsChanged();
 	}
 }
 

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -194,7 +194,7 @@ void BioXASAppController::onCurrentScanActionFinishedImplementation(AMScanAction
 	}
 }
 
-void BioXASAppController::onXASDetectorsChanged()
+void BioXASAppController::updateXASScanConfigurationDetectors()
 {
 	// Clear the configuration detectors.
 
@@ -735,11 +735,11 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 
 		// Set scan detectors.
 
-		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(connected(bool)), this, SLOT(onXASDetectorsChanged()) );
-		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(detectorAdded(int)), this, SLOT(onXASDetectorsChanged()) );
-		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(detectorRemoved(int)), this, SLOT(onXASDetectorsChanged()) );
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(connected(bool)), this, SLOT(updateXASScanConfigurationDetectors()) );
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(detectorAdded(int)), this, SLOT(updateXASScanConfigurationDetectors()) );
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(detectorRemoved(int)), this, SLOT(updateXASScanConfigurationDetectors()) );
 
-		onXASDetectorsChanged();
+		updateXASScanConfigurationDetectors();
 	}
 }
 

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -196,9 +196,11 @@ void BioXASAppController::onCurrentScanActionFinishedImplementation(AMScanAction
 
 void BioXASAppController::updateXASScanConfigurationDetectors()
 {
+	qDebug() << "Updating XAS scan configuration detectors.";
+
 	// Clear the configuration detectors.
 
-	xasConfiguration_->detectorConfigurations().clear();
+	xasConfiguration_->clearDetectors();
 
 	// Add all valid, connected detectors in the set.
 

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -194,6 +194,23 @@ void BioXASAppController::onCurrentScanActionFinishedImplementation(AMScanAction
 	}
 }
 
+void BioXASAppController::onXASDetectorsConnectedChanged()
+{
+	// Clear the configuration detectors.
+
+	xasConfiguration_->detectorConfigurations().clear();
+
+	// Add all valid, connected detectors in the set.
+
+	AMDetectorSet *detectors = BioXASBeamline::bioXAS()->xasDetectors();
+
+	for (int i = 0, count = detectors->count(); i < count; i++) {
+		AMDetector *detector = detectors->at(i);
+		if (detector && detector->isConnected())
+			xasConfiguration_->addDetector(detector->toInfo());
+	}
+}
+
 void BioXASAppController::registerClasses()
 {
 	AMDbObjectSupport::s()->registerClass<CLSSIS3820ScalerDarkCurrentMeasurementActionInfo>();
@@ -718,32 +735,8 @@ void BioXASAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *
 
 		// Set scan detectors.
 
-		AMDetector *i0Detector = BioXASBeamline::bioXAS()->i0Detector();
-		if (i0Detector && i0Detector->isConnected())
-			configuration->addDetector(i0Detector->toInfo());
-
-		AMDetector *i1Detector = BioXASBeamline::bioXAS()->i1Detector();
-		if (i1Detector && i1Detector->isConnected())
-			configuration->addDetector(i1Detector->toInfo());
-
-		AMDetector *i2Detector = BioXASBeamline::bioXAS()->i2Detector();
-		if (i2Detector && i2Detector->isConnected())
-			configuration->addDetector(i2Detector->toInfo());
-
-		AMDetector *scalerDwellTimeDetector = BioXASBeamline::bioXAS()->scalerDwellTimeDetector();
-		if (scalerDwellTimeDetector && scalerDwellTimeDetector->isConnected())
-			configuration->addDetector(scalerDwellTimeDetector->toInfo());
-
-		AMDetector *vortexDetector = BioXASBeamline::bioXAS()->fourElementVortexDetector();
-		if (vortexDetector && vortexDetector->isConnected())
-			configuration->addDetector(vortexDetector->toInfo());
-
-		AMDetectorSet *ge32Detectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();
-		for (int i = 0; i < ge32Detectors->count(); i++) {
-			AMDetector *detector = ge32Detectors->at(i);
-			if (detector && detector->isConnected())
-				configuration->addDetector(detector->toInfo());
-		}
+		connect( BioXASBeamline::bioXAS()->xasDetectors(), SIGNAL(connected(bool)), this, SLOT(onXASDetectorsConnectedChanged()) );
+		onXASDetectorsConnectedChanged();
 	}
 }
 

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -114,7 +114,7 @@ protected slots:
 	virtual void onCurrentScanActionFinishedImplementation(AMScanAction *action);
 
 	/// Clears all detectors from the XAS scan configuration, and adds each valid, connected detector from the default XAS detector set.
-	void onXASDetectorsConnectedChanged();
+	void onXASDetectorsChanged();
 
 protected:
 	/// Registers all of the necessary classes that are BioXAS-specific.

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -113,6 +113,9 @@ protected slots:
 	/// Implementation method that individual applications can flesh out if extra cleanup is required when a scan action finishes.  This is not pure virtual because there is no requirement to do anything to scan actions.
 	virtual void onCurrentScanActionFinishedImplementation(AMScanAction *action);
 
+	/// Clears all detectors from the XAS scan configuration, and adds each valid, connected detector from the default XAS detector set.
+	void onXASDetectorsConnectedChanged();
+
 protected:
 	/// Registers all of the necessary classes that are BioXAS-specific.
 	virtual void registerClasses();

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -114,7 +114,7 @@ protected slots:
 	virtual void onCurrentScanActionFinishedImplementation(AMScanAction *action);
 
 	/// Clears all detectors from the XAS scan configuration, and adds each valid, connected detector from the default XAS detector set.
-	void onXASDetectorsChanged();
+	void updateXASScanConfigurationDetectors();
 
 protected:
 	/// Registers all of the necessary classes that are BioXAS-specific.

--- a/source/application/BioXAS/BioXASMainAppController.cpp
+++ b/source/application/BioXAS/BioXASMainAppController.cpp
@@ -74,39 +74,3 @@ bool BioXASMainAppController::setupDataFolder()
 {
 	return AMChooseDataFolderDialog::getDataFolder("/AcquamanLocalData/bioxas-m/AcquamanMainData", "/home/bioxas-m/AcquamanMainData", "users", QStringList());
 }
-
-void BioXASMainAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *configuration)
-{
-	// Start with default XAS settings.
-
-	BioXASAppController::setupXASScanConfiguration(configuration);
-
-	if (configuration) {
-
-		// Set the configuration detectors.
-
-		AMDetector *energySetpoint = BioXASMainBeamline::bioXAS()->energySetpointDetector();
-		if (energySetpoint)
-			configuration->addDetector(energySetpoint->toInfo());
-
-		AMDetector *encoderEnergyFeedback = BioXASMainBeamline::bioXAS()->encoderEnergyFeedbackDetector();
-		if (encoderEnergyFeedback && encoderEnergyFeedback->isConnected())
-			configuration->addDetector(encoderEnergyFeedback->toInfo());
-
-		AMDetector *stepEnergyFeedback = BioXASMainBeamline::bioXAS()->stepEnergyFeedbackDetector();
-		if (stepEnergyFeedback && stepEnergyFeedback->isConnected())
-			configuration->addDetector(stepEnergyFeedback->toInfo());
-
-		AMDetector *goniometerAngle = BioXASMainBeamline::bioXAS()->braggDetector();
-		if (goniometerAngle && goniometerAngle->isConnected())
-			configuration->addDetector(goniometerAngle->toInfo());
-
-		AMDetector *goniometerStepSetpoint = BioXASMainBeamline::bioXAS()->braggStepSetpointDetector();
-		if (goniometerStepSetpoint && goniometerStepSetpoint->isConnected())
-			configuration->addDetector(goniometerStepSetpoint->toInfo());
-
-		AMDetector *goniometerEncoderStepFeedback = BioXASMainBeamline::bioXAS()->braggEncoderStepDegFeedbackDetector();
-		if (goniometerEncoderStepFeedback && goniometerEncoderStepFeedback->isConnected())
-			configuration->addDetector(goniometerEncoderStepFeedback->toInfo());
-	}
-}

--- a/source/application/BioXAS/BioXASMainAppController.h
+++ b/source/application/BioXAS/BioXASMainAppController.h
@@ -44,9 +44,6 @@ protected:
 	virtual void setupUserInterface();
 	/// Sets up local and remote data paths.
 	virtual bool setupDataFolder();
-
-	/// Sets up an XAS scan configuration.
-	virtual void setupXASScanConfiguration(BioXASXASScanConfiguration *configuration);
 };
 
 #endif // BIOXASMAINAPPCONTROLLER_H

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -85,31 +85,3 @@ bool BioXASSideAppController::setupDataFolder()
 {
 	return AMChooseDataFolderDialog::getDataFolder("/AcquamanLocalData/bioxas-s/AcquamanSideData", "/home/bioxas-s/AcquamanSideData", "users", QStringList());
 }
-
-void BioXASSideAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *configuration)
-{
-	// Start with default XAS settings.
-
-	BioXASAppController::setupXASScanConfiguration(configuration);
-
-	if (configuration) {
-
-		// Set the configuration detectors.
-
-		AMDetector *encoderEnergyFeedback = BioXASSideBeamline::bioXAS()->encoderEnergyFeedbackDetector();
-		if (encoderEnergyFeedback && encoderEnergyFeedback->isConnected())
-			configuration->addDetector(encoderEnergyFeedback->toInfo());
-
-		AMDetector *stepEnergyFeedback = BioXASSideBeamline::bioXAS()->stepEnergyFeedbackDetector();
-		if (stepEnergyFeedback && stepEnergyFeedback->isConnected())
-			configuration->addDetector(stepEnergyFeedback->toInfo());
-
-		AMDetector *goniometerAngle = BioXASSideBeamline::bioXAS()->braggDetector();
-		if (goniometerAngle && goniometerAngle->isConnected())
-			configuration->addDetector(goniometerAngle->toInfo());
-
-		AMDetector *goniometerStepSetpoint = BioXASSideBeamline::bioXAS()->braggStepSetpointDetector();
-		if (goniometerStepSetpoint && goniometerStepSetpoint->isConnected())
-			configuration->addDetector(goniometerStepSetpoint->toInfo());
-	}
-}

--- a/source/application/BioXAS/BioXASSideAppController.h
+++ b/source/application/BioXAS/BioXASSideAppController.h
@@ -44,9 +44,6 @@ protected:
 	virtual void setupUserInterface();
 	/// Sets up local and remote data paths.
 	virtual bool setupDataFolder();
-
-	/// Sets up an XAS scan configuration.
-	virtual void setupXASScanConfiguration(BioXASXASScanConfiguration *configuration);
 };
 
 #endif // BIOXASSIDEAPPCONTROLLER_H

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -348,6 +348,7 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 
 	if (ge32Detectors_->addDetector(newDetector)) {
 		addExposedScientificDetector(newDetector);
+		addXASDetector(newDetector);
 		result = true;
 		emit ge32DetectorsChanged();
 	}
@@ -361,6 +362,7 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 
 	if (ge32Detectors_->removeDetector(detector)) {
 		removeExposedScientificDetector(detector);
+		removeXASDetector(detector);
 		result = true;
 
 		emit ge32DetectorsChanged();
@@ -371,8 +373,11 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 
 bool BioXASBeamline::clearGe32Detectors()
 {
-	for (int i = 0, count = ge32Detectors_->count(); i < count; i++)
-		removeExposedScientificDetector(ge32Detectors_->at(i));
+	for (int i = 0, count = ge32Detectors_->count(); i < count; i++) {
+		AMDetector *detector = ge32Detectors_->at(i);
+		removeExposedScientificDetector(detector);
+		removeXASDetector(detector);
+	}
 
 	ge32Detectors_->clear();
 
@@ -536,6 +541,24 @@ void BioXASBeamline::clearFlowTransducers()
 {
 	if (utilities_)
 		utilities_->clearFlowTransducers();
+}
+
+void BioXASBeamline::addXASDetector(AMDetector *detector)
+{
+	if (xasDetectors_)
+		xasDetectors_->addDetector(detector);
+}
+
+void BioXASBeamline::removeXASDetector(AMDetector *detector)
+{
+	if (xasDetectors_)
+		xasDetectors_->removeDetector(detector);
+}
+
+void BioXASBeamline::clearXASDetectors()
+{
+	if (xasDetectors_)
+		xasDetectors_->clear();
 }
 
 void BioXASBeamline::setupComponents()
@@ -747,6 +770,10 @@ void BioXASBeamline::setupComponents()
 
 	ge32Detectors_ = new AMDetectorSet(this);
 	connect( ge32Detectors_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	// Default XAS scan detectors.
+
+	xasDetectors_ = new AMDetectorSet(this);
 }
 
 AMBasicControlDetectorEmulator* BioXASBeamline::createDetectorEmulator(const QString &name, const QString &description, AMControl *control, bool hiddenFromUsers, bool isVisible)
@@ -767,6 +794,8 @@ void BioXASBeamline::addControlAsDetector(const QString &name, const QString &de
 	if (control && !controlDetectorMap_.contains(control)) {
 		AMBasicControlDetectorEmulator *detector = createDetectorEmulator(name, description, control, hiddenFromUsers, isVisible);
 		controlDetectorMap_.insert(control, detector);
+
+		addXASDetector(detector);
 	}
 }
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -795,6 +795,7 @@ void BioXASBeamline::addControlAsDetector(const QString &name, const QString &de
 		AMBasicControlDetectorEmulator *detector = createDetectorEmulator(name, description, control, hiddenFromUsers, isVisible);
 		controlDetectorMap_.insert(control, detector);
 
+		addExposedDetector(detector);
 		addXASDetector(detector);
 	}
 }

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -173,6 +173,9 @@ public:
 	/// Returns the detector for the given control, if one has been created and added to the control/detector map.
 	AMBasicControlDetectorEmulator* detectorForControl(AMControl *control) const;
 
+	/// Returns the list of default XAS scan detectors.
+	AMDetectorSet* xasDetectors() const { return xasDetectors_; }
+
 signals:
 	/// Notifier that the current connected state has changed.
 	void connectedChanged(bool isConnected);
@@ -195,13 +198,6 @@ public slots:
 	/// Clears the detector stage lateral motors.
 	bool clearDetectorStageLateralMotors();
 
-	/// Adds a 32Ge detector. Returns true if successful, false otherwise.
-	bool addGe32Detector(BioXAS32ElementGeDetector *newDetector);
-	/// Removes a 32Ge detector. Returns true if successful, false otherwise.
-	bool removeGe32Detector(BioXAS32ElementGeDetector *detector);
-	/// Clears the 32Ge detectors. Returns true if successful, false otherwise.
-	bool clearGe32Detectors();
-
 	/// Adds the diode detector. Returns true if successful, false otherwise.
 	virtual bool addDiodeDetector() { return false; }
 	/// Removes the diode detector. Returns true if successful, false otherwise.
@@ -216,6 +212,13 @@ public slots:
 	virtual bool addLytleDetector() { return false; }
 	/// Removes the Lytle detector. Returns true if successful, false otherwise.
 	virtual bool removeLytleDetector() { return false; }
+
+	/// Adds a 32Ge detector. Returns true if successful, false otherwise.
+	bool addGe32Detector(BioXAS32ElementGeDetector *newDetector);
+	/// Removes a 32Ge detector. Returns true if successful, false otherwise.
+	bool removeGe32Detector(BioXAS32ElementGeDetector *detector);
+	/// Clears the 32Ge detectors. Returns true if successful, false otherwise.
+	bool clearGe32Detectors();
 
 protected slots:
 	/// Sets the cached connected state.
@@ -279,6 +282,13 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
+	/// Adds a detector to the list of XAS-default detectors.
+	void addXASDetector(AMDetector *detector);
+	/// Removes a detector from the list of XAS-default detectors.
+	void removeXASDetector(AMDetector *detector);
+	/// Clears all XAS-default detectors.
+	void clearXASDetectors();
+
 protected:
 	/// Sets up controls for front end beamline components and/or components that are common to all three BioXAS beamlines.
 	virtual void setupComponents();
@@ -306,6 +316,9 @@ protected:
 
 	/// The control/detector map. Assumes a 1-1 correlation between controls and detector emulators.
 	QMap<AMControl*, AMBasicControlDetectorEmulator*> controlDetectorMap_;
+
+	/// The set of detectors to be added to XAS scans by default.
+	AMDetectorSet *xasDetectors_;
 };
 
 #endif // BIOXASBEAMLINE_H

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -431,11 +431,6 @@ void BioXASMainBeamline::setupExposedControls()
 
 void BioXASMainBeamline::setupExposedDetectors()
 {
-	// Add controls as detectors.
-
-	foreach (AMDetector *detector, controlDetectorMap_.values())
-		addExposedDetector(detector);
-
 	// Add any remaining detectors.
 
 	addExposedDetector(energySetpointDetector_);

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -267,6 +267,7 @@ void BioXASMainBeamline::setupComponents()
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	addExposedScientificDetector(i0Detector_);
+	addXASDetector(i0Detector_);
 
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
@@ -283,6 +284,7 @@ void BioXASMainBeamline::setupComponents()
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	addExposedScientificDetector(i1Detector_);
+	addXASDetector(i1Detector_);
 
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
@@ -299,6 +301,7 @@ void BioXASMainBeamline::setupComponents()
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	addExposedScientificDetector(i2Detector_);
+	addXASDetector(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
@@ -428,12 +431,6 @@ void BioXASMainBeamline::setupExposedControls()
 
 void BioXASMainBeamline::setupExposedDetectors()
 {
-	// Add detectors.
-
-	addExposedDetector(i0Detector_);
-	addExposedDetector(i1Detector_);
-	addExposedDetector(i2Detector_);
-
 	// Add controls as detectors.
 
 	foreach (AMDetector *detector, controlDetectorMap_.values())

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -230,6 +230,7 @@ bool BioXASSideBeamline::addDiodeDetector()
 		scaler_->channelAt(19)->setDetector(diodeDetector_);
 
 		addExposedScientificDetector(diodeDetector_);
+		addXASDetector(diodeDetector_);
 
 		hasDiodeDetector_ = true;
 		result = true;
@@ -250,6 +251,7 @@ bool BioXASSideBeamline::removeDiodeDetector()
 		scaler_->channelAt(19)->setDetector(0);
 
 		removeExposedScientificDetector(diodeDetector_);
+		removeXASDetector(diodeDetector_);
 
 		hasDiodeDetector_ = false;
 		result = true;
@@ -277,6 +279,7 @@ bool BioXASSideBeamline::addPIPSDetector()
 		scaler_->channelAt(19)->setDetector(pipsDetector_);
 
 		addExposedScientificDetector(pipsDetector_);
+		addXASDetector(pipsDetector_);
 
 		hasPIPSDetector_ = true;
 		result = true;
@@ -297,6 +300,7 @@ bool BioXASSideBeamline::removePIPSDetector()
 		scaler_->channelAt(19)->setDetector(0);
 
 		removeExposedScientificDetector(pipsDetector_);
+		removeXASDetector(pipsDetector_);
 
 		hasPIPSDetector_ = false;
 		result = true;
@@ -324,6 +328,7 @@ bool BioXASSideBeamline::addLytleDetector()
 		scaler_->channelAt(19)->setDetector(lytleDetector_);
 
 		addExposedScientificDetector(lytleDetector_);
+		addXASDetector(lytleDetector_);
 
 		hasLytleDetector_ = true;
 		result = true;
@@ -344,6 +349,7 @@ bool BioXASSideBeamline::removeLytleDetector()
 		scaler_->channelAt(19)->setDetector(0);
 
 		removeExposedScientificDetector(lytleDetector_);
+		removeXASDetector(lytleDetector_);
 
 		hasLytleDetector_ = false;
 		result = true;
@@ -529,6 +535,7 @@ void BioXASSideBeamline::setupComponents()
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	addExposedScientificDetector(i0Detector_);
+	addXASDetector(i0Detector_);
 
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
@@ -545,6 +552,7 @@ void BioXASSideBeamline::setupComponents()
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	addExposedScientificDetector(i1Detector_);
+	addXASDetector(i1Detector_);
 
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
@@ -561,6 +569,7 @@ void BioXASSideBeamline::setupComponents()
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	addExposedScientificDetector(i2Detector_);
+	addXASDetector(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
@@ -730,13 +739,6 @@ void BioXASSideBeamline::setupExposedControls()
 
 void BioXASSideBeamline::setupExposedDetectors()
 {
-	// Add detectors.
-
-	addExposedDetector(i0Detector_);
-	addExposedDetector(i1Detector_);
-	addExposedDetector(i2Detector_);
-	addExposedDetector(ge32ElementDetector_);
-
 	// Add controls as detectors.
 
 	foreach (AMDetector *detector, controlDetectorMap_.values())


### PR DESCRIPTION
Added new detector set to BioXASBeamline, xasDetectors. This set is for the list of detectors that we'd like to be added to XAS scans by default once the detector set connects and whenever there are changes to the set contents. Modified BioXASSideBeamline and BioXASMainBeamline to add I0, I1, I2, and any Ge detectors to the set, though this can probably be refactored/simplified later. Added connect statement to BioXASAppController that listens to the connected state of the beamline's XAS detectors. The slot clears the configuration detectors and adds all valid, connected detectors from the set every time the set reports a connected change. Awaiting testing.