### PR TITLE
Pull Request for Issue2099: Creating tabbed configuration detectors view

### DIFF
--- a/source/acquaman/AMGenericStepScanConfiguration.cpp
+++ b/source/acquaman/AMGenericStepScanConfiguration.cpp
@@ -220,7 +220,7 @@ void AMGenericStepScanConfiguration::removeControl(int axisId)
 		setModified(true);
 	}
 }
-
+#include <QDebug>
 void AMGenericStepScanConfiguration::addDetector(AMDetectorInfo newInfo)
 {
 	bool containsDetector = false;
@@ -232,9 +232,11 @@ void AMGenericStepScanConfiguration::addDetector(AMDetectorInfo newInfo)
 	}
 
 	if (!containsDetector){
-
+		qDebug() << "Adding detector" << newInfo.name() << "to configuration.";
 		detectorConfigurations_.append(newInfo, newInfo.name());
 		setModified(true);
+
+		emit detectorsChanged();
 	}
 }
 
@@ -245,10 +247,12 @@ void AMGenericStepScanConfiguration::removeDetector(AMDetectorInfo info)
 	for (int i = 0, size = detectorConfigurations_.count(); i < size && !detectorRemoved; i++){
 
 		if (info.name() == detectorConfigurations_.at(i).name()){
-
+			qDebug() << "Removing detector" << info.name() << "from configuration.";
 			detectorRemoved = true;
 			detectorConfigurations_.remove(i);
 			setModified(true);
+
+			emit detectorsChanged();
 		}
 	}
 }

--- a/source/acquaman/AMGenericStepScanConfiguration.cpp
+++ b/source/acquaman/AMGenericStepScanConfiguration.cpp
@@ -220,7 +220,7 @@ void AMGenericStepScanConfiguration::removeControl(int axisId)
 		setModified(true);
 	}
 }
-#include <QDebug>
+
 void AMGenericStepScanConfiguration::addDetector(AMDetectorInfo newInfo)
 {
 	bool containsDetector = false;
@@ -232,7 +232,6 @@ void AMGenericStepScanConfiguration::addDetector(AMDetectorInfo newInfo)
 	}
 
 	if (!containsDetector){
-		qDebug() << "Adding detector" << newInfo.name() << "to configuration.";
 		detectorConfigurations_.append(newInfo, newInfo.name());
 		setModified(true);
 
@@ -247,7 +246,6 @@ void AMGenericStepScanConfiguration::removeDetector(AMDetectorInfo info)
 	for (int i = 0, size = detectorConfigurations_.count(); i < size && !detectorRemoved; i++){
 
 		if (info.name() == detectorConfigurations_.at(i).name()){
-			qDebug() << "Removing detector" << info.name() << "from configuration.";
 			detectorRemoved = true;
 			detectorConfigurations_.remove(i);
 			setModified(true);

--- a/source/acquaman/AMGenericStepScanConfiguration.h
+++ b/source/acquaman/AMGenericStepScanConfiguration.h
@@ -60,6 +60,8 @@ public:
 signals:
 	/// Notifier that the total time estimate has changed.
 	void totalTimeChanged(double);
+	/// Notifier that the detectors have changed.
+	void detectorsChanged();
 
 public slots:
 	/// Sets a controlInfo to an axis.  If the axis has no control associated with it yet, then it will add it to the list, otherwise it will replace it.

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -348,6 +348,7 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 
 	if (ge32Detectors_->addDetector(newDetector)) {
 		addExposedScientificDetector(newDetector);
+		addExposedDetector(newDetector);
 		result = true;
 		emit ge32DetectorsChanged();
 	}
@@ -361,6 +362,7 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 
 	if (ge32Detectors_->removeDetector(detector)) {
 		removeExposedScientificDetector(detector);
+		removeExposedDetector(detector);
 		result = true;
 
 		emit ge32DetectorsChanged();
@@ -371,8 +373,10 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 
 bool BioXASBeamline::clearGe32Detectors()
 {
-	for (int i = 0, count = ge32Detectors_->count(); i < count; i++)
+	for (int i = 0, count = ge32Detectors_->count(); i < count; i++) {
 		removeExposedScientificDetector(ge32Detectors_->at(i));
+		removeExposedDetector(ge32Detectors_->at(i));
+	}
 
 	ge32Detectors_->clear();
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -266,6 +266,7 @@ void BioXASMainBeamline::setupComponents()
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i0Detector_);
 	addExposedScientificDetector(i0Detector_);
 
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
@@ -282,6 +283,7 @@ void BioXASMainBeamline::setupComponents()
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i1Detector_);
 	addExposedScientificDetector(i1Detector_);
 
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
@@ -298,6 +300,7 @@ void BioXASMainBeamline::setupComponents()
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i2Detector_);
 	addExposedScientificDetector(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
@@ -428,12 +431,6 @@ void BioXASMainBeamline::setupExposedControls()
 
 void BioXASMainBeamline::setupExposedDetectors()
 {
-	// Add detectors.
-
-	addExposedDetector(i0Detector_);
-	addExposedDetector(i1Detector_);
-	addExposedDetector(i2Detector_);
-
 	// Add controls as detectors.
 
 	foreach (AMDetector *detector, controlDetectorMap_.values())

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -229,6 +229,7 @@ bool BioXASSideBeamline::addDiodeDetector()
 		scaler_->channelAt(19)->setCustomChannelName("Diode");
 		scaler_->channelAt(19)->setDetector(diodeDetector_);
 
+		addExposedDetector(diodeDetector_);
 		addExposedScientificDetector(diodeDetector_);
 
 		hasDiodeDetector_ = true;
@@ -249,6 +250,7 @@ bool BioXASSideBeamline::removeDiodeDetector()
 		scaler_->channelAt(19)->setCustomChannelName("");
 		scaler_->channelAt(19)->setDetector(0);
 
+		removeExposedDetector(diodeDetector_);
 		removeExposedScientificDetector(diodeDetector_);
 
 		hasDiodeDetector_ = false;
@@ -276,6 +278,7 @@ bool BioXASSideBeamline::addPIPSDetector()
 		scaler_->channelAt(19)->setCustomChannelName("PIPS");
 		scaler_->channelAt(19)->setDetector(pipsDetector_);
 
+		addExposedDetector(pipsDetector_);
 		addExposedScientificDetector(pipsDetector_);
 
 		hasPIPSDetector_ = true;
@@ -296,6 +299,7 @@ bool BioXASSideBeamline::removePIPSDetector()
 		scaler_->channelAt(19)->setCustomChannelName("");
 		scaler_->channelAt(19)->setDetector(0);
 
+		removeExposedDetector(pipsDetector_);
 		removeExposedScientificDetector(pipsDetector_);
 
 		hasPIPSDetector_ = false;
@@ -323,6 +327,7 @@ bool BioXASSideBeamline::addLytleDetector()
 		scaler_->channelAt(19)->setCustomChannelName("Lytle");
 		scaler_->channelAt(19)->setDetector(lytleDetector_);
 
+		addExposedDetector(lytleDetector_);
 		addExposedScientificDetector(lytleDetector_);
 
 		hasLytleDetector_ = true;
@@ -343,6 +348,7 @@ bool BioXASSideBeamline::removeLytleDetector()
 		scaler_->channelAt(19)->setCustomChannelName("");
 		scaler_->channelAt(19)->setDetector(0);
 
+		removeExposedDetector(lytleDetector_);
 		removeExposedScientificDetector(lytleDetector_);
 
 		hasLytleDetector_ = false;
@@ -528,6 +534,7 @@ void BioXASSideBeamline::setupComponents()
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i0Detector_);
 	addExposedScientificDetector(i0Detector_);
 
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
@@ -544,6 +551,7 @@ void BioXASSideBeamline::setupComponents()
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i1Detector_);
 	addExposedScientificDetector(i1Detector_);
 
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
@@ -560,6 +568,7 @@ void BioXASSideBeamline::setupComponents()
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i2Detector_);
 	addExposedScientificDetector(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
@@ -730,13 +739,6 @@ void BioXASSideBeamline::setupExposedControls()
 
 void BioXASSideBeamline::setupExposedDetectors()
 {
-	// Add detectors.
-
-	addExposedDetector(i0Detector_);
-	addExposedDetector(i1Detector_);
-	addExposedDetector(i2Detector_);
-	addExposedDetector(ge32ElementDetector_);
-
 	// Add controls as detectors.
 
 	foreach (AMDetector *detector, controlDetectorMap_.values())

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
@@ -11,11 +11,13 @@
 BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScanConfiguration *configuration, QWidget *parent) :
 	BioXASXASScanConfigurationView(parent)
 {
-	// Create UI elements.
+	// Create scan name editor.
 
 	QLabel *namePrompt = new QLabel("Name: ");
 
 	nameLineEdit_ = new QLineEdit();
+
+	// Create scan energy editor.
 
 	QLabel *energyPrompt = new QLabel("Energy: ");
 
@@ -26,15 +28,33 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	edgeEditor_ = new BioXASXASScanConfigurationEdgeEditor(0);
 
+	// Create scan regions editor.
+
 	regionsEditor_ = new BioXASXASScanConfigurationRegionsEditor(0);
 
-	QTabWidget *detectorsViews = new QTabWidget();
+	// Create scan detectors editor.
 
 	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedScientificDetectors());
-	detectorsViews->addTab(scientificDetectorsView_, "Scientific detectors");
+
+	QVBoxLayout *scientificDetectorsWidgetLayout = new QVBoxLayout();
+	scientificDetectorsWidgetLayout->addWidget(scientificDetectorsView_);
+	scientificDetectorsWidgetLayout->addStretch();
+
+	QWidget *scientificDetectorsWidget = new QWidget();
+	scientificDetectorsWidget->setLayout(scientificDetectorsWidgetLayout);
 
 	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedDetectors());
-	detectorsViews->addTab(allDetectorsView_, "All detectors");
+
+	QVBoxLayout *allDetectorsWidgetLayout = new QVBoxLayout();
+	allDetectorsWidgetLayout->addWidget(allDetectorsView_);
+	allDetectorsWidgetLayout->addStretch();
+
+	QWidget *allDetectorsWidget = new QWidget();
+	allDetectorsWidget->setLayout(allDetectorsWidgetLayout);
+
+	QTabWidget *detectorsViews = new QTabWidget();
+	detectorsViews->addTab(scientificDetectorsWidget, "Scientific");
+	detectorsViews->addTab(allDetectorsWidget, "All");
 
 	// Create and set main layouts
 

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
@@ -28,8 +28,13 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	regionsEditor_ = new BioXASXASScanConfigurationRegionsEditor(0);
 
-	detectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedScientificDetectors());
-	detectorsView_->setMinimumWidth(150);
+	QTabWidget *detectorsViews = new QTabWidget();
+
+	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedScientificDetectors());
+	detectorsViews->addTab(scientificDetectorsView_, "Scientific detectors");
+
+	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedDetectors());
+	detectorsViews->addTab(allDetectorsView_, "All detectors");
 
 	// Create and set main layouts
 
@@ -52,7 +57,7 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 	scanBox->setLayout(scanBoxLayout);
 
 	QVBoxLayout *detectorBoxLayout = new QVBoxLayout();
-	detectorBoxLayout->addWidget(detectorsView_);
+	detectorBoxLayout->addWidget(detectorsViews);
 	detectorBoxLayout->addStretch();
 
 	QGroupBox *detectorBox = new QGroupBox("Detectors");
@@ -107,7 +112,8 @@ void BioXASXASScanConfigurationEditor::clear()
 	energySpinBox_->clear();
 	edgeEditor_->clear();
 	regionsEditor_->clear();
-	detectorsView_->clear();
+	scientificDetectorsView_->clear();
+	allDetectorsView_->clear();
 }
 
 void BioXASXASScanConfigurationEditor::update()
@@ -116,7 +122,8 @@ void BioXASXASScanConfigurationEditor::update()
 	updateEnergySpinBox();
 	edgeEditor_->update();
 	regionsEditor_->update();
-	detectorsView_->update();
+	scientificDetectorsView_->update();
+	allDetectorsView_->update();
 }
 
 void BioXASXASScanConfigurationEditor::refresh()
@@ -129,7 +136,8 @@ void BioXASXASScanConfigurationEditor::refresh()
 
 	edgeEditor_->setConfiguration(configuration_);
 	regionsEditor_->setConfiguration(configuration_);
-	detectorsView_->setConfiguration(configuration_);
+	scientificDetectorsView_->setConfiguration(configuration_);
+	allDetectorsView_->setConfiguration(configuration_);
 
 	// Update the view.
 

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.h
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.h
@@ -4,6 +4,7 @@
 #include <QLineEdit>
 #include <QLabel>
 #include <QGroupBox>
+#include <QTabWidget>
 
 #include "acquaman/BioXAS/BioXASXASScanConfiguration.h"
 #include "ui/acquaman/AMScanConfigurationView.h"
@@ -53,8 +54,10 @@ protected:
 	BioXASXASScanConfigurationEdgeEditor *edgeEditor_;
 	/// Regions editor.
 	BioXASXASScanConfigurationRegionsEditor *regionsEditor_;
-	/// The detectors view.
-	AMGenericStepScanConfigurationDetectorsView *detectorsView_;
+	/// The 'scientific detectors' view.
+	AMGenericStepScanConfigurationDetectorsView *scientificDetectorsView_;
+	/// The 'all detectors' view.
+	AMGenericStepScanConfigurationDetectorsView *allDetectorsView_;
 };
 
 #endif // BIOXASXASSCANCONFIGURATIONEDITOR_H

--- a/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
@@ -51,6 +51,7 @@ void AMGenericStepScanConfigurationDetectorsView::setConfiguration(AMGenericStep
 
 		if (configuration_) {
 			connect( configuration_, SIGNAL(detectorConfigurationsChanged()), this, SLOT(refresh()) );
+			connect( configuration_, SIGNAL(detectorsChanged()), this, SLOT(refresh()) );
 		}
 
 		refresh();


### PR DESCRIPTION
- Added an extra configuration detectors view to the BioXASXASScanConfigurationEditor for all exposed beamline detectors.
- Added signal to AMGenericStepScanConfiguration to notify listeners to changes in the configuration's detectors.