### PR TITLE
Pull Request for Issue2101: removing fast shutter from Zebra trigger chain

### DIFF
--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -139,6 +139,19 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 		if (standardsWheelInitialization)
 			initializationAction->addSubAction(standardsWheelInitialization);
 
+		// Initialize the fast shutter.
+
+		AMListAction3 *fastShutterInitialization = 0;
+		BioXASFastShutter *fastShutter = BioXASBeamline::bioXAS()->fastShutter();
+
+		if (fastShutter) {
+			fastShutterInitialization = new AMListAction3(new AMListActionInfo3("BioXAS fast shutter initialization", "BioXAS fast shutter initialization"));
+			fastShutterInitialization->addSubAction(AMActionSupport::buildControlMoveAction(fastShutter, BioXASFastShutter::Open));
+		}
+
+		if (fastShutterInitialization)
+			initializationAction->addSubAction(fastShutterInitialization);
+
 		// Complete action.
 
 		result = initializationAction;

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -166,6 +166,19 @@ AMAction3* BioXASBeamline::createScanCleanupAction(AMGenericStepScanConfiguratio
 
 	AMListAction3 *result = new AMListAction3(new AMListActionInfo3("BioXAS scan cleanup actions", "BioXAS scan cleanup actions"), AMListAction3::Parallel);
 
+	// Create fast shutter cleanup actions.
+
+	AMListAction3 *fastShutterCleanup = 0;
+	BioXASFastShutter *fastShutter = BioXASBeamline::bioXAS()->fastShutter();
+
+	if (fastShutter) {
+		fastShutterCleanup = new AMListAction3(new AMListActionInfo3("BioXAS fast shutter initialization", "BioXAS fast shutter initialization"));
+		fastShutterCleanup->addSubAction(AMActionSupport::buildControlMoveAction(fastShutter, BioXASFastShutter::Closed));
+	}
+
+	if (fastShutterCleanup)
+		result->addSubAction(fastShutterCleanup);
+
 	// Create scaler cleanup actions.
 
 	AMListAction3 *scalerCleanup = 0;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -133,6 +133,9 @@ public:
 	/// Returns the detector stage control.
 	virtual AMControlSet* detectorStageLateralMotors() const { return detectorStageLateralMotors_; }
 
+	/// Returns the fast shutter.
+	virtual BioXASFastShutter* fastShutter() const { return 0; }
+
 	/// Returns the Zebra.
 	virtual BioXASZebra* zebra() const { return 0; }
 	/// Returns the Zebra trigger source.

--- a/source/beamline/BioXAS/BioXASFastShutter.cpp
+++ b/source/beamline/BioXAS/BioXASFastShutter.cpp
@@ -18,6 +18,26 @@ BioXASFastShutter::~BioXASFastShutter()
 
 }
 
+bool BioXASFastShutter::isOpen() const
+{
+	return (int(value()) == Open);
+}
+
+bool BioXASFastShutter::isClosed() const
+{
+	return (int(value()) == Closed);
+}
+
+AMControl::FailureExplanation BioXASFastShutter::open()
+{
+	return move(Open);
+}
+
+AMControl::FailureExplanation BioXASFastShutter::close()
+{
+	return move(Closed);
+}
+
 void BioXASFastShutter::setOperatorControl(AMControl *newOperator, double openStatusValue, double openTrigger, double closedStatusValue, double closeTrigger)
 {
 	if (operator_ != newOperator) {
@@ -28,8 +48,8 @@ void BioXASFastShutter::setOperatorControl(AMControl *newOperator, double openSt
 		operator_ = newOperator;
 
 		if (operator_) {
-			addState(openStatusValue, "Open", openStatusValue, operator_, openTrigger);
-			addState(closedStatusValue, "Closed", closedStatusValue, operator_, closeTrigger);
+			addState(Open, "Open", openStatusValue, operator_, openTrigger);
+			addState(Closed, "Closed", closedStatusValue, operator_, closeTrigger);
 		}
 
 		emit operatorChanged(operator_);

--- a/source/beamline/BioXAS/BioXASFastShutter.h
+++ b/source/beamline/BioXAS/BioXASFastShutter.h
@@ -8,16 +8,29 @@ class BioXASFastShutter : public AMExclusiveStatesEnumeratedControl
     Q_OBJECT
 
 public:
+	/// Enumeration of the possible values.
+	enum Value { Open = 0, Closed = 1 };
+
 	/// Constructor.
 	explicit BioXASFastShutter(const QString &name, QObject *parent = 0);
 	/// Destructor.
 	virtual ~BioXASFastShutter();
+
+	/// Returns true if the fast shutter is open.
+	virtual bool isOpen() const;
+	/// Returns true if the fast shutter is closed.
+	virtual bool isClosed() const;
 
 signals:
 	/// Notifier that the shutter operator control has changed.
 	void operatorChanged(AMControl *newOperator);
 
 public slots:
+	/// Opens the fast shutter.
+	AMControl::FailureExplanation open();
+	/// Closes the fast shutter.
+	AMControl::FailureExplanation close();
+
 	/// Sets the operator control, the control used to move shutter states.
 	void setOperatorControl(AMControl *newOperator, double openStatusValue, double openTrigger, double closedStatusValue, double closeTrigger);
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -28,6 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "util/AMPeriodicTable.h"
 
 #include "beamline/AMDetectorTriggerSource.h"
+#include "beamline/BioXAS/BioXASZebraLogicBlock.h"
 
 BioXASSideBeamline::~BioXASSideBeamline()
 {
@@ -507,6 +508,27 @@ void BioXASSideBeamline::setupComponents()
 	BioXASZebraSoftInputControl *softIn3 = zebra_->softInputControlAt(2);
 	if (softIn3)
 		softIn3->setTimeBeforeResetPreference(0.1);
+
+	BioXASZebraLogicBlock *fastShutterBlock = zebra_->andBlockAt(0);
+	if (fastShutterBlock) {
+		fastShutterBlock->setInputValuePreference(0, 61); // The fast shutter can be triggered using soft input 2 (#61).
+//		fastShutterBlock->setInputValuePreference(1, 52); // The fast shutter can be triggered using pulse 1 (#52).
+		fastShutterBlock->setInputValuePreference(1, 0); // The fast shutter is disconnected from pulse 1, until we want the fast shutter to be triggered with every acquisition point.
+	}
+
+	BioXASZebraLogicBlock *scalerBlock = zebra_->orBlockAt(1);
+	if (scalerBlock) {
+		scalerBlock->setInputValuePreference(0, 52); // The scaler can be triggered using pulse 1 (#52).
+		scalerBlock->setInputValuePreference(1, 62); // The scaler can be triggered using soft input 3 (#62).
+	}
+
+	BioXASZebraPulseControl *scanPulse = zebra_->pulseControlAt(0);
+	if (scanPulse)
+		scanPulse->setInputValuePreference(60); // The 'scan pulse' (pulse 1) can be triggered using soft input 1 (#60).
+
+	BioXASZebraPulseControl *xspress3Pulse = zebra_->pulseControlAt(2);
+	if (xspress3Pulse)
+		xspress3Pulse->setInputValuePreference(52); // The Xspress3 detector can be triggered using pulse 1 (#52).
 
 	// The Zebra trigger source.
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -503,11 +503,15 @@ void BioXASSideBeamline::setupComponents()
 
 	BioXASZebraSoftInputControl *softIn1 = zebra_->softInputControlAt(0);
 	if (softIn1)
-		softIn1->setTimeBeforeResetPreference(0.1);
+		softIn1->setTimeBeforeResetPreference(0.1); // The zebra has a good chance of missing triggers if this value is lower (definitely at 0.01).
+
+	BioXASZebraSoftInputControl *softIn2 = zebra_->softInputControlAt(1);
+	if (softIn2)
+		softIn2->setTimeBeforeResetPreference(0);  // The fast shutter control should toggle high or toggle low when triggered.
 
 	BioXASZebraSoftInputControl *softIn3 = zebra_->softInputControlAt(2);
 	if (softIn3)
-		softIn3->setTimeBeforeResetPreference(0.1);
+		softIn3->setTimeBeforeResetPreference(0.1); // The zebra has a good chance of missing triggers if this value is lower (definitely at 0.01).
 
 	BioXASZebraLogicBlock *fastShutterBlock = zebra_->andBlockAt(0);
 	if (fastShutterBlock) {

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -132,7 +132,7 @@ public:
 	virtual AMZebraDetectorTriggerSource* zebraTriggerSource() const { return zebraTriggerSource_; }
 
 	/// Returns the fast shutter.
-	BioXASFastShutter* fastShutter() const { return fastShutter_; }
+	virtual BioXASFastShutter* fastShutter() const { return fastShutter_; }
 
 	/// Returns the scaler dwell time detector.
 	virtual AMBasicControlDetectorEmulator* scalerDwellTimeDetector() const;

--- a/source/beamline/BioXAS/BioXASZebraInput.cpp
+++ b/source/beamline/BioXAS/BioXASZebraInput.cpp
@@ -7,6 +7,9 @@ BioXASZebraInput::BioXASZebraInput(const QString &name, const QString &baseName,
 {
 	connected_ = false;
 
+	valuePreferenceSet_ = false;
+	valuePreference_ = 0;
+
 	valueControl_ = new AMSinglePVControl(
 				QString("InputControlValue"),
 				QString("%1").arg(baseName),
@@ -25,6 +28,8 @@ BioXASZebraInput::BioXASZebraInput(const QString &name, const QString &baseName,
 	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged(bool)));
 	connect(valueControl_, SIGNAL(valueChanged(double)), this, SLOT(onInputValueChanged()));
 	connect(stateControl_, SIGNAL(valueChanged(double)), this, SLOT(onInputStateChanged()));
+
+	connect( valueControl_, SIGNAL(connected(bool)), this, SLOT(updateValueControl()) );
 }
 
 BioXASZebraInput::~BioXASZebraInput()
@@ -58,6 +63,17 @@ void BioXASZebraInput::setInputValue(int value)
 		valueControl_->move(double(value));
 }
 
+void BioXASZebraInput::setValuePreference(int preferredValue)
+{
+	if (valuePreference_ != preferredValue) {
+		valuePreferenceSet_ = true;
+		valuePreference_ = preferredValue;
+		updateValueControl();
+
+		emit valuePreferenceChanged(valuePreference_);
+	}
+}
+
 void BioXASZebraInput::onControlSetConnectedChanged(bool connected)
 {
 	if (connected_ != connected){
@@ -75,5 +91,11 @@ void BioXASZebraInput::onInputValueChanged()
 void BioXASZebraInput::onInputStateChanged()
 {
 	emit inputStateChanged(inputStateValue());
+}
+
+void BioXASZebraInput::updateValueControl()
+{
+	if (valuePreferenceSet_)
+		setInputValue(valuePreference_);
 }
 

--- a/source/beamline/BioXAS/BioXASZebraInput.h
+++ b/source/beamline/BioXAS/BioXASZebraInput.h
@@ -35,6 +35,11 @@ public:
 	/// Returns the state control.
 	AMReadOnlyPVControl* inputStateControl() const { return stateControl_; }
 
+	/// Returns true if the value preference has been set.
+	bool valuePreferenceSet() const { return valuePreferenceSet_; }
+	/// Returns the value preference.
+	int valuePreference() const { return valuePreference_; }
+
 signals:
 	/// Notifier that the connected state has changed.
 	void connectedChanged(bool);
@@ -45,9 +50,14 @@ signals:
 	/// Notifier that the input state has changed.
 	void inputStateChanged(double newState);
 
+	/// Notifier that the value preference has changed.
+	void valuePreferenceChanged(int newPreference);
+
 public slots:
 	/// Sets the input value.
 	void setInputValue(int value);
+	/// Sets the input value preference.
+	void setValuePreference(int preferredValue);
 
 protected slots:
 	/// On control set bool changed.
@@ -56,6 +66,9 @@ protected slots:
 	void onInputValueChanged();
 	/// Handles emitting the input state value changed signal.
 	void onInputStateChanged();
+
+	/// Updates the input value control with the value preference.
+	void updateValueControl();
 
 protected:
 	/// The connected state.
@@ -67,6 +80,11 @@ protected:
 	AMPVControl *valueControl_;
 	/// The state control.
 	AMReadOnlyPVControl *stateControl_;
+
+	/// Flag for whether the input control value preference has been set.
+	bool valuePreferenceSet_;
+	/// The value control value preference
+	int valuePreference_;
 };
 
 #endif // BIOXASZEBRAINPUT_H

--- a/source/beamline/BioXAS/BioXASZebraLogicBlock.cpp
+++ b/source/beamline/BioXAS/BioXASZebraLogicBlock.cpp
@@ -50,6 +50,24 @@ bool BioXASZebraLogicBlock::isOutputStateHigh() const
 	return (outputStateControl_->value() == High);
 }
 
+BioXASZebraLogicBlockInput* BioXASZebraLogicBlock::inputControlAt(int index) const
+{
+	BioXASZebraLogicBlockInput *result = 0;
+
+	if (index >= 0 && index < inputControls_.count())
+		result = inputControls_.at(index);
+
+	return result;
+}
+
+void BioXASZebraLogicBlock::setInputValuePreference(int index, int newPreference)
+{
+	BioXASZebraInput *input = inputControlAt(index);
+
+	if (input)
+		input->setValuePreference(newPreference);
+}
+
 void BioXASZebraLogicBlock::setConnected(bool isConnected)
 {
 	if (connected_ != isConnected) {

--- a/source/beamline/BioXAS/BioXASZebraLogicBlock.h
+++ b/source/beamline/BioXAS/BioXASZebraLogicBlock.h
@@ -30,6 +30,8 @@ public:
 	/// Returns true if the output state is high, false otherwise.
 	bool isOutputStateHigh() const;
 
+	/// Returns the input control at the given index.
+	BioXASZebraLogicBlockInput* inputControlAt(int index) const;
 	/// Returns the list of input controls.
 	QList<BioXASZebraLogicBlockInput*> inputControls() const { return inputControls_; }
 	/// Returns the output state control.
@@ -40,6 +42,10 @@ signals:
 	void outputStateChanged(double);
 	/// Notifier that the output state value has changed, true if the state is now high.
 	void outputStateHighChanged(bool);
+
+public slots:
+	/// Sets the value preference for the input control at the given index.
+	void setInputValuePreference(int index, int newPreference);
 
 protected slots:
 	/// Sets the connected state.

--- a/source/beamline/BioXAS/BioXASZebraPulseControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraPulseControl.cpp
@@ -55,7 +55,11 @@ BioXASZebraPulseControl::BioXASZebraPulseControl(const QString &baseName, int pu
 
 	connected_ = false;
 
+	edgeTriggerPreferenceSet_ = false;
 	edgeTriggerPreference_ = 0;
+
+	inputValuePreferenceSet_ = false;
+	inputValuePreference_ = 0;
 
 	allControls_ = new AMControlSet(this);
 	allControls_->addControl(inputControl_);
@@ -72,6 +76,7 @@ BioXASZebraPulseControl::BioXASZebraPulseControl(const QString &baseName, int pu
 
 	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged(bool)));
 	connect(inputControl_, SIGNAL(valueChanged(double)), this, SLOT(onInputValueChanged()));
+	connect(inputControl_, SIGNAL(connected(bool)), this, SLOT(updateInputControl()));
 	connect(inputStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onInputValueStatusChanged()));
 	connect(edgeTriggerControl_, SIGNAL(valueChanged(double)), this, SLOT(onEdgeTriggerValueChanged()));
 	connect(edgeTriggerControl_, SIGNAL(connected(bool)), this, SLOT(updateEdgeTriggerControl()) );
@@ -215,10 +220,22 @@ void BioXASZebraPulseControl::setPulseWidthValueSeconds(double pulseWidth)
 void BioXASZebraPulseControl::setEdgeTriggerPreference(int value)
 {
 	if (edgeTriggerPreference_ != value) {
+		edgeTriggerPreferenceSet_ = true;
 		edgeTriggerPreference_ = value;
 		updateEdgeTriggerControl();
 
 		emit edgeTriggerPreferenceChanged(edgeTriggerPreference_);
+	}
+}
+
+void BioXASZebraPulseControl::setInputValuePreference(int value)
+{
+	if (inputValuePreference_ != value) {
+		inputValuePreferenceSet_ = true;
+		inputValuePreference_ = value;
+		updateInputControl();
+
+		emit inputValuePreferenceChanged(inputValuePreference_);
 	}
 }
 
@@ -283,7 +300,14 @@ void BioXASZebraPulseControl::onPulseWidthValueSecondsChanged()
 
 void BioXASZebraPulseControl::updateEdgeTriggerControl()
 {
-	setEdgeTriggerValue(edgeTriggerPreference_);
+	if (edgeTriggerPreferenceSet_)
+		setEdgeTriggerValue(edgeTriggerPreference_);
+}
+
+void BioXASZebraPulseControl::updateInputControl()
+{
+	if (inputValuePreferenceSet_)
+		setInputValue(inputValuePreference_);
 }
 
 QString BioXASZebraPulseControl::letterFromPulseIndex(int index) const

--- a/source/beamline/BioXAS/BioXASZebraPulseControl.h
+++ b/source/beamline/BioXAS/BioXASZebraPulseControl.h
@@ -102,6 +102,8 @@ signals:
 
 	/// Notifier that the edge trigger value preference has changed.
 	void edgeTriggerPreferenceChanged(int);
+	/// Notifier that the input value preference has changed.
+	void inputValuePreferenceChanged(int);
 
 public slots:
 	/// Sets the input value.
@@ -121,6 +123,9 @@ public slots:
 
 	/// Sets the edge trigger value preference, to be applied once the edge trigger control connects.
 	void setEdgeTriggerPreference(int value);
+
+	/// Sets the input value preference, to be applied once the input control connects.
+	void setInputValuePreference(int value);
 
 protected slots:
 	/// On control set bool changed.
@@ -148,6 +153,8 @@ protected slots:
 
 	/// Updates the edge trigger control with the edge trigger value preference.
 	void updateEdgeTriggerControl();
+	/// Updates the input control with the input value preference.
+	void updateInputControl();
 
 protected:
 	/// Helper method that returns the appropriate "letter" for the pulse index.
@@ -181,8 +188,15 @@ protected:
 	/// The pulse width control, resolve the pulse width value and time units into value in seconds.
 	BioXASZebraTimeSeconds *pulseWidthSecondsControl_;
 
+	/// The flag for indicating whether an edge trigger preference has been set.
+	bool edgeTriggerPreferenceSet_;
 	/// The trigger edge control value preference, to be applied when the control connects.
 	int edgeTriggerPreference_;
+
+	/// The flag for indicating whether an input control value preference has been set.
+	bool inputValuePreferenceSet_;
+	/// The input control value preference.
+	int inputValuePreference_;
 };
 
 #endif // BIOXASZEBRAPULSECONTROL_H


### PR DESCRIPTION
- Added the ability to set a 'preferred' input value for Zebra logic blocks and pulse controls.
- Added some default 'preferred' input values for some Zebra controls in BioXASSideBeamline, including that the fast shutter should be disconnected from Pulse 1/scanning pulse.
- Added fast shutter getter to BioXASBeamline. This allows for the fast shutter to be accessible in scan initialization and cleanup actions.
- Added fast shutter initialization (opening shutter) and cleanup (closing shutter) to scan initialization and cleanup actions.