### PR TITLE
Pull Request for Issue2110: IDEASBeamline shutters connect statements

### DIFF
--- a/source/actions3/actions/AMDetectorWaitForAcquisitionStateActionInfo.cpp
+++ b/source/actions3/actions/AMDetectorWaitForAcquisitionStateActionInfo.cpp
@@ -11,7 +11,8 @@ AMDetectorWaitForAcquisitionStateActionInfo::AMDetectorWaitForAcquisitionStateAc
 	setLongDescription(description);
 }
 
-AMDetectorWaitForAcquisitionStateActionInfo::AMDetectorWaitForAcquisitionStateActionInfo(const AMDetectorWaitForAcquisitionStateActionInfo &other)
+AMDetectorWaitForAcquisitionStateActionInfo::AMDetectorWaitForAcquisitionStateActionInfo(const AMDetectorWaitForAcquisitionStateActionInfo &other) :
+	AMActionInfo3(other)
 {
 	detectorInfo_.setValuesFrom(*(other.detectorInfo()));
 	acquisitionState_ = other.acquisitionState();

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -155,13 +155,13 @@ void IDEASBeamline::setupComponents()
 	jjSlitVGap_ = new AMPVwStatusControl("Sample Slit Height","SMTR1608-10-B20-03:mm:sp","SMTR1608-10-B20-03:mm","SMTR1608-10-B20-03:status","SMTR1608-10-B20-03:stop",this,0.1);
 	jjSlitVCenter_ = new AMPVwStatusControl("Vertical Center","SMTR1608-10-B20-04:mm:sp","SMTR1608-10-B20-04:mm","SMTR1608-10-B20-04:status","SMTR1608-10-B20-04:stop",this,0.1);
 
-	connect(safetyShutter_, SIGNAL(valueChanged(double)), this, SLOT(onShutterStatusChanged()));
-	connect(safetyShutter2_, SIGNAL(valueChanged(double)), this, SLOT(onShutterStatusChanged()));
-	connect(photonShutter2_, SIGNAL(valueCHanged(double)), this, SLOT(onShutterStatusChanged()));
-	onShutterStatusChanged();
-	connect(safetyShutter_, SIGNAL(connected(bool)), this, SLOT(onShutterStatusChanged()));
-	connect(safetyShutter2_, SIGNAL(connected(bool)), this, SLOT(onShutterStatusChanged()));
-	connect(photonShutter2_, SIGNAL(connected(bool)), this, SLOT(onShutterStatusChanged()));
+	connect(safetyShutter_, SIGNAL(valueChanged(double)), this, SLOT(onShutterValueChanged()));
+	connect(safetyShutter2_, SIGNAL(valueChanged(double)), this, SLOT(onShutterValueChanged()));
+	connect(photonShutter2_, SIGNAL(valueChanged(double)), this, SLOT(onShutterValueChanged()));
+	onShutterValueChanged();
+	connect(safetyShutter_, SIGNAL(connected(bool)), this, SLOT(onShutterValueChanged()));
+	connect(safetyShutter2_, SIGNAL(connected(bool)), this, SLOT(onShutterValueChanged()));
+	connect(photonShutter2_, SIGNAL(connected(bool)), this, SLOT(onShutterValueChanged()));
 
 	scaler_ = new CLSSIS3820Scaler("BL08B2-1:mcs", this);
 
@@ -270,7 +270,7 @@ bool IDEASBeamline::shuttersOpen() const
 	return safetyShutter_->isOpen() && photonShutter2_->isOpen() && safetyShutter2_->isOpen();
 }
 
-void IDEASBeamline::onShutterStatusChanged()
+void IDEASBeamline::onShutterValueChanged()
 {
 	emit overallShutterStatus(safetyShutter_->isOpen() && photonShutter2_->isOpen() && safetyShutter2_->isOpen());
 }

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -155,9 +155,9 @@ void IDEASBeamline::setupComponents()
 	jjSlitVGap_ = new AMPVwStatusControl("Sample Slit Height","SMTR1608-10-B20-03:mm:sp","SMTR1608-10-B20-03:mm","SMTR1608-10-B20-03:status","SMTR1608-10-B20-03:stop",this,0.1);
 	jjSlitVCenter_ = new AMPVwStatusControl("Vertical Center","SMTR1608-10-B20-04:mm:sp","SMTR1608-10-B20-04:mm","SMTR1608-10-B20-04:status","SMTR1608-10-B20-04:stop",this,0.1);
 
-	connect(safetyShutter_, SIGNAL(stateChanged(int)), this, SLOT(onShutterStatusChanged()));
-	connect(safetyShutter2_, SIGNAL(stateChanged(int)), this, SLOT(onShutterStatusChanged()));
-	connect(photonShutter2_, SIGNAL(stateChanged(int)), this, SLOT(onShutterStatusChanged()));
+	connect(safetyShutter_, SIGNAL(valueChanged(double)), this, SLOT(onShutterStatusChanged()));
+	connect(safetyShutter2_, SIGNAL(valueChanged(double)), this, SLOT(onShutterStatusChanged()));
+	connect(photonShutter2_, SIGNAL(valueCHanged(double)), this, SLOT(onShutterStatusChanged()));
 
 	scaler_ = new CLSSIS3820Scaler("BL08B2-1:mcs", this);
 

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -158,6 +158,10 @@ void IDEASBeamline::setupComponents()
 	connect(safetyShutter_, SIGNAL(valueChanged(double)), this, SLOT(onShutterStatusChanged()));
 	connect(safetyShutter2_, SIGNAL(valueChanged(double)), this, SLOT(onShutterStatusChanged()));
 	connect(photonShutter2_, SIGNAL(valueCHanged(double)), this, SLOT(onShutterStatusChanged()));
+	onShutterStatusChanged();
+	connect(safetyShutter_, SIGNAL(connected(bool)), this, SLOT(onShutterStatusChanged()));
+	connect(safetyShutter2_, SIGNAL(connected(bool)), this, SLOT(onShutterStatusChanged()));
+	connect(photonShutter2_, SIGNAL(connected(bool)), this, SLOT(onShutterStatusChanged()));
 
 	scaler_ = new CLSSIS3820Scaler("BL08B2-1:mcs", this);
 

--- a/source/beamline/IDEAS/IDEASBeamline.h
+++ b/source/beamline/IDEAS/IDEASBeamline.h
@@ -163,7 +163,7 @@ public slots:
 
 protected slots:
 	/// Helper slot that handles emitting the overall shutter status.
-	void onShutterStatusChanged();
+	void onShutterValueChanged();
 
 protected:
 	/// Sets up the readings such as pressure, flow switches, temperature, etc.

--- a/source/beamline/REIXS/REIXSBeamline.cpp
+++ b/source/beamline/REIXS/REIXSBeamline.cpp
@@ -291,9 +291,9 @@ REIXSValvesAndShutters::REIXSValvesAndShutters(QObject *parent) : AMCompositeCon
 	connect(ssh1_, SIGNAL(connected(bool)), this, SLOT(reviewIsBeamOn()));
 	connect(psh2_, SIGNAL(connected(bool)), this, SLOT(reviewIsBeamOn()));
 	connect(psh4_, SIGNAL(connected(bool)), this, SLOT(reviewIsBeamOn()));
-	connect(ssh1_, SIGNAL(stateChanged(int)), this, SLOT(reviewIsBeamOn()));
-	connect(psh2_, SIGNAL(stateChanged(int)), this, SLOT(reviewIsBeamOn()));
-	connect(psh4_, SIGNAL(stateChanged(int)), this, SLOT(reviewIsBeamOn()));
+	connect(ssh1_, SIGNAL(valueChanged(double)), this, SLOT(reviewIsBeamOn()));
+	connect(psh2_, SIGNAL(valueChanged(double)), this, SLOT(reviewIsBeamOn()));
+	connect(psh4_, SIGNAL(valueChanged(double)), this, SLOT(reviewIsBeamOn()));
 
 	reviewIsBeamOn();
 }


### PR DESCRIPTION
Changed some connect statements in IDEASBeamline from connecting to a stateChanged(int) to valueChanged(double). I think stateChanged(int) was a signal that the CLSBiStateControl emitted, but the CLSExclusiveStatesControl does not. These statements should have been updated with the change in controls in #1940, but were missed.