### PR TITLE
Pull Request for Issue2114: Hide commissioning tool

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -270,8 +270,8 @@ void BioXASAppController::setupUserInterface()
 	xasConfigurationView_ = createScanConfigurationViewWithHolder(xasConfiguration_);
 	addViewToScansPane(xasConfigurationView_, "XAS Scan");
 
-	commissioningConfigurationView_ = createScanConfigurationViewWithHolder(commissioningConfiguration_);
-	addViewToScansPane(commissioningConfigurationView_, "Commissioning Tool");
+	//commissioningConfigurationView_ = createScanConfigurationViewWithHolder(commissioningConfiguration_);
+	//addViewToScansPane(commissioningConfigurationView_, "Commissioning Tool");
 
 	energyCalibrationConfigurationView_ = createScanConfigurationViewWithHolder(energyCalibrationConfiguration_);
 	addViewToScansPane(energyCalibrationConfigurationView_, "Energy Calibration");

--- a/source/application/BioXAS/BioXASMainAppController.cpp
+++ b/source/application/BioXAS/BioXASMainAppController.cpp
@@ -67,6 +67,9 @@ void BioXASMainAppController::setupUserInterface()
 
 	mw_->setWindowTitle("Acquaman - BioXAS Main");
 
+	commissioningConfigurationView_ = createScanConfigurationViewWithHolder(commissioningConfiguration_);
+	addViewToScansPane(commissioningConfigurationView_, "Commissioning Tool");
+
 	addPersistentView(new BioXASMainPersistentView());
 }
 


### PR DESCRIPTION
Commented out the commissioning tool view from BioXASAppController. Added the commissioning tool view code explicitly to BioXASMainAppController. The Side application doesn't support the commissioning tool right now, because zebra initialization actions haven't been done yet. Main still supports the commissioning tool because the Zebra hasn't been implemented yet.