### PR TITLE
Pull Request for Issue2098: Diode/PIPS/Lytle detector dark current updates

### DIFF
--- a/source/ui/BioXAS/BioXASSIS3820ScalerChannelView.cpp
+++ b/source/ui/BioXAS/BioXASSIS3820ScalerChannelView.cpp
@@ -1,89 +1,70 @@
 #include "BioXASSIS3820ScalerChannelView.h"
+#include "beamline/CLS/CLSSIS3820Scaler.h"
 #include "beamline/CLS/CLSKeithley428.h"
 #include "ui/beamline/AMExtendedControlEditor.h"
-#include "ui/CLS/CLSSIS3820ScalerView.h"
 
 BioXASSIS3820ScalerChannelView::BioXASSIS3820ScalerChannelView(CLSSIS3820ScalerChannel *channel, bool biasEnabledVisible, bool biasVisible, bool darkCurrentVisible, QWidget *parent) :
 	CLSSIS3820ScalerChannelView(channel, parent)
 {
 	// Initialize member variables.
 
+	detector_ = 0;
+
 	biasEnabledVisible_ = false;
 	biasVisible_ = false;
 	darkCurrentVisible_ = false;
 
-	biasEnabledEditor_ = 0;
-	biasEditor_ = 0;
-	darkCurrentDisplay_ = 0;
-
-	// Create UI elements and sub-layouts.
-
-	if (channel_) {
-
-		// Create Keithley 428 UI elements.
-
-		QHBoxLayout *keithleyLayout = new QHBoxLayout();
-		keithleyLayout->setMargin(0);
-
-		if (channel_->currentAmplifier()) {
-
-			CLSKeithley428 *keithley = qobject_cast<CLSKeithley428*>(channel_->currentAmplifier());
-
-			if (keithley) {
-
-				biasEnabledEditor_ = new AMExtendedControlEditor(keithley->biasVoltageEnabledControl());
-				biasEnabledEditor_->setNoUnitsBox(true);
-				biasEnabledEditor_->setTitle("Bias enabled");
-				biasEnabledEditor_->setFixedWidth(100);
-
-				biasEditor_ = new AMExtendedControlEditor(keithley->biasVoltageControl());
-				biasEditor_->setTitle("Bias");
-				biasEditor_->setUnits("V");
-				biasEditor_->setFixedWidth(100);
-
-				keithleyLayout->addWidget(biasEnabledEditor_);
-				keithleyLayout->addWidget(biasEditor_);
-			}
-		}
-
-		// Create dark current UI elements.
-
-		darkCurrentDisplay_ = new QLabel();
-		darkCurrentDisplay_->setFixedWidth(150);
-		darkCurrentDisplay_->setAlignment(Qt::AlignCenter);
-
-		QHBoxLayout *darkCurrentLayout = new QHBoxLayout();
-		darkCurrentLayout->setMargin(0);
-		darkCurrentLayout->addWidget(darkCurrentDisplay_, Qt::AlignCenter);
-
-		// Add sublayouts to main layout.
-
-		channelLayout_->addLayout(keithleyLayout);
-		channelLayout_->addLayout(darkCurrentLayout);
-	}
-
-
-	// Initial settings.
-
-	if (biasEnabledEditor_)
-		biasEnabledEditor_->hide();
-
-	if (biasEditor_)
-		biasEditor_->hide();
-
-	if (darkCurrentDisplay_)
-		darkCurrentDisplay_->hide();
+	// CLS scaler channel settings.
 
 	scalerOutput_->setFixedWidth(100);
-
 	channelName_->setAlignment(Qt::AlignCenter);
+
+	// Create Keithley 428 UI elements, add to main channel layout.
+
+	QHBoxLayout *keithleyLayout = new QHBoxLayout();
+	keithleyLayout->setMargin(0);
+
+	if (channel_->currentAmplifier()) {
+
+		CLSKeithley428 *keithley = qobject_cast<CLSKeithley428*>(channel_->currentAmplifier());
+
+		if (keithley) {
+
+			biasEnabledEditor_ = new AMExtendedControlEditor(keithley->biasVoltageEnabledControl());
+			biasEnabledEditor_->setNoUnitsBox(true);
+			biasEnabledEditor_->setTitle("Bias enabled");
+			biasEnabledEditor_->setFixedWidth(100);
+			biasEnabledEditor_->hide();
+
+			biasEditor_ = new AMExtendedControlEditor(keithley->biasVoltageControl());
+			biasEditor_->setTitle("Bias");
+			biasEditor_->setUnits("V");
+			biasEditor_->setFixedWidth(100);
+			biasEditor_->hide();
+
+			keithleyLayout->addWidget(biasEnabledEditor_);
+			keithleyLayout->addWidget(biasEditor_);
+		}
+	}
+
+	channelLayout_->addLayout(keithleyLayout);
+
+	// Create dark current UI elements.
+
+	darkCurrentDisplay_ = new QLabel();
+	darkCurrentDisplay_->setFixedWidth(150);
+	darkCurrentDisplay_->setAlignment(Qt::AlignCenter);
+	darkCurrentDisplay_->hide();
+
+	QHBoxLayout *darkCurrentLayout = new QHBoxLayout();
+	darkCurrentLayout->setMargin(0);
+	darkCurrentLayout->addWidget(darkCurrentDisplay_, Qt::AlignCenter);
+
+	channelLayout_->addLayout(darkCurrentLayout);
 
 	// Make connections.
 
-	if (channel_ && channel_->detector()) {
-		connect( channel_->detector(), SIGNAL(darkCurrentValidStateChanged(bool)), this, SLOT(setDarkCurrentState(bool)) );
-		connect( channel_->detector(), SIGNAL(darkCurrentValueChanged(double)), this, SLOT(setDarkCurrentValue(double)) );
-	}
+	connect( channel_, SIGNAL(detectorChanged(AMDetector*)), this, SLOT(setDetector(AMDetector*)) );
 
 	// Current settings.
 
@@ -91,10 +72,7 @@ BioXASSIS3820ScalerChannelView::BioXASSIS3820ScalerChannelView(CLSSIS3820ScalerC
 	setBiasEditorVisible(biasVisible);
 	setDarkCurrentVisible(darkCurrentVisible);
 
-	if (channel_ && channel_->detector()) {
-		setDarkCurrentValue(channel_->detector()->darkCurrentValue());
-		setDarkCurrentState(channel_->detector()->darkCurrentValidState());
-	}
+	setDetector(channel_->detector());
 }
 
 BioXASSIS3820ScalerChannelView::~BioXASSIS3820ScalerChannelView()
@@ -104,45 +82,65 @@ BioXASSIS3820ScalerChannelView::~BioXASSIS3820ScalerChannelView()
 
 void BioXASSIS3820ScalerChannelView::setBiasEnabledEditorVisible(bool isVisible)
 {
-	// if the scaler channel given in the constructor is invalid or doesn't have a Keithley amplifier,
+	// If the scaler channel given in the constructor is invalid or doesn't have a Keithley amplifier,
 	// then the bias enabled editor will never have been instantiated. Must check whether it's possible
 	// to show the editor, as well as whether the 'isVisible' arg is different than the current state.
 
-	if (biasEnabledEditor_ && biasEnabledVisible_ != isVisible) {
+	if (biasEnabledEditor_ && biasEnabledVisible_ != isVisible)
 		biasEnabledEditor_->setVisible(biasEnabledVisible_ = isVisible);
-	}
 }
 
 void BioXASSIS3820ScalerChannelView::setBiasEditorVisible(bool isVisible)
 {
-	// if the scaler channel given in the constructor is invalid or doesn't have a Keithley amplifier,
+	// If the scaler channel given in the constructor is invalid or doesn't have a Keithley amplifier,
 	// then the bias editor will never have been instantiated. Must check whether it's possible
 	// to show the editor, as well as whether the 'isVisible' arg is different than the current state.
 
-	if (biasEditor_ && biasVisible_ != isVisible) {
+	if (biasEditor_ && biasVisible_ != isVisible)
 		biasEditor_->setVisible(biasVisible_ = isVisible);
-	}
 }
 
 void BioXASSIS3820ScalerChannelView::setDarkCurrentVisible(bool isVisible)
 {
-	if (darkCurrentDisplay_ && darkCurrentVisible_ != isVisible) {
+	if (darkCurrentVisible_ != isVisible)
 		darkCurrentDisplay_->setVisible(darkCurrentVisible_ = isVisible);
-	}
 }
 
 void BioXASSIS3820ScalerChannelView::setDarkCurrentValue(double newValue)
 {
-	if (darkCurrentDisplay_) {
-		darkCurrentDisplay_->setText(QString("%1 counts/sec").arg(newValue));
-	}
+	darkCurrentDisplay_->setText(QString("%1 counts/sec").arg(newValue));
 }
 
 void BioXASSIS3820ScalerChannelView::setDarkCurrentState(bool valid)
 {
-	if (darkCurrentDisplay_ && valid) {
+	if (valid)
 		darkCurrentDisplay_->setStyleSheet("color: black;");
-	} else if (darkCurrentDisplay_) {
+	else
 		darkCurrentDisplay_->setStyleSheet("color: red;");
+}
+
+void BioXASSIS3820ScalerChannelView::setDetector(AMDetector *newDetector)
+{
+	if (detector_ != newDetector) {
+
+		if (detector_)
+			disconnect( detector_, 0, this, 0 );
+
+		detector_ = newDetector;
+
+		if (detector_) {
+			connect( detector_, SIGNAL(darkCurrentValueChanged(double)), this, SLOT(updateDarkCurrentDisplay()) );
+			connect( detector_, SIGNAL(darkCurrentValidStateChanged(bool)), this, SLOT(updateDarkCurrentDisplay()) );
+		}
+
+		updateDarkCurrentDisplay();
+	}
+}
+
+void BioXASSIS3820ScalerChannelView::updateDarkCurrentDisplay()
+{
+	if (detector_) {
+		setDarkCurrentValue(detector_->darkCurrentValue());
+		setDarkCurrentState(detector_->darkCurrentValidState());
 	}
 }

--- a/source/ui/BioXAS/BioXASSIS3820ScalerChannelView.cpp
+++ b/source/ui/BioXAS/BioXASSIS3820ScalerChannelView.cpp
@@ -14,6 +14,10 @@ BioXASSIS3820ScalerChannelView::BioXASSIS3820ScalerChannelView(CLSSIS3820ScalerC
 	biasVisible_ = false;
 	darkCurrentVisible_ = false;
 
+	biasEnabledEditor_ = 0;
+	biasEditor_ = 0;
+	darkCurrentDisplay_ = 0;
+
 	// CLS scaler channel settings.
 
 	scalerOutput_->setFixedWidth(100);

--- a/source/ui/BioXAS/BioXASSIS3820ScalerChannelView.h
+++ b/source/ui/BioXAS/BioXASSIS3820ScalerChannelView.h
@@ -4,10 +4,10 @@
 #include <QWidget>
 #include <QLayout>
 
-#include "beamline/CLS/CLSSIS3820Scaler.h"
 #include "ui/CLS/CLSSIS3820ScalerView.h"
 
 class AMExtendedControlEditor;
+class CLSSIS3820ScalerChannel;
 
 class BioXASSIS3820ScalerChannelView : public CLSSIS3820ScalerChannelView
 {
@@ -39,7 +39,16 @@ public slots:
 	/// Sets whether the dark current displayed is valid (black) or invalid (red).
 	void setDarkCurrentState(bool valid);
 
+protected slots:
+	/// Sets the scaler channel detector.
+	void setDetector(AMDetector *newDetector);
+	/// Updates the dark current display.
+	void updateDarkCurrentDisplay();
+
 protected:
+	/// The channel detector being viewed.
+	AMDetector *detector_;
+
 	/// Bool indicating whether the bias enabled editor should be shown.
 	bool biasEnabledVisible_;
 	/// Bool indicating whether the bias editor should be shown.


### PR DESCRIPTION
Made a few small modifications to the BioXAS-specific scaler channel view. Added a detector as a class variable, the scaler channel's detector. This variable is updated every time the scaler channel reports a change in detector, as is what happens when the diode/PIPS/Lytle detectors are added/removed from the beamline. When the detector reports a change in the dark current value or state, the dark current display is updated.