### PR TITLE
Pull Request for Issue2054: exporting spectra data for Ge detectors

### DIFF
--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -50,12 +50,11 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 				AMDetectorSet *elements = BioXASBeamline::bioXAS()->elementsForDetector(geDetector);
 
 				if (elements) {
-
 					for (int j = 0, elementsCount = elements->count(); j < elementsCount; j++) {
-						AMDetector *detector = elements->at(i);
+						AMDetector *element = elements->at(j);
 
-						if (detector)
-							configuration_->addDetector(detector->toInfo());
+						if (element)
+							configuration_->addDetector(element->toInfo());
 					}
 				}
 			}

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -36,6 +36,31 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 		if (bioXASDefaultXAS->id() > 0)
 			AMAppControllerSupport::registerClass<BioXASXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(bioXASDefaultXAS->id());
 	}
+
+	// Add the Ge detectors spectra, if a Ge detector is being used.
+
+	AMDetectorSet *geDetectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();
+
+	if (geDetectors) {
+
+		for (int i = 0, detectorsCount = geDetectors->count(); i < detectorsCount; i++) {
+			BioXAS32ElementGeDetector *geDetector = qobject_cast<BioXAS32ElementGeDetector*>(geDetectors->at(i));
+
+			if (geDetector && configuration_->detectorConfigurations().contains(geDetector->name())) {
+				AMDetectorSet *elements = BioXASBeamline::bioXAS()->elementsForDetector(geDetector);
+
+				if (elements) {
+
+					for (int j = 0, elementsCount = elements->count(); j < elementsCount; j++) {
+						AMDetector *detector = elements->at(i);
+
+						if (detector)
+							configuration_->addDetector(detector->toInfo());
+					}
+				}
+			}
+		}
+	}
 }
 
 BioXASXASScanActionController::~BioXASXASScanActionController()

--- a/source/application/BioXAS/BioXAS.h
+++ b/source/application/BioXAS/BioXAS.h
@@ -24,7 +24,7 @@ namespace BioXAS
 			xasDefault->loadFromDb(AMDatabase::database("user"), matchIDs.at(0));
 
 		xasDefault->setName(name);
-		xasDefault->setFileName("$name_$fsIndex.dat");
+		xasDefault->setFileName("$name_$number.dat");
 		xasDefault->setHeaderText("Scan: $name #$number\nDate: $dateTime\nSample: $sample\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
 		xasDefault->setHeaderIncluded(true);
 		xasDefault->setColumnHeader("$dataSetName $dataSetInfoDescription");
@@ -36,7 +36,7 @@ namespace BioXAS
 		xasDefault->setFirstColumnOnly(true);
 		xasDefault->setIncludeHigherDimensionSources(includeHigherOrderSources);
 		xasDefault->setSeparateHigherDimensionalSources(true);
-		xasDefault->setSeparateSectionFileName("$name_$dataSetName_$fsIndex.dat");
+		xasDefault->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
 		xasDefault->setElementSymbol(elementSymbol);
 		xasDefault->setElementEdge(elementEdge);
 		xasDefault->storeToDb(AMDatabase::database("user"));

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -208,7 +208,7 @@ void BioXASAppController::updateScanConfigurationDetectors(AMGenericStepScanConf
 
 		configuration->detectorConfigurations().clear();
 
-		// Add the valid, connected detectors from the XAS detectors set.
+		// Add the valid, connected detectors from the detectors set.
 
 		AMDetectorSet *defaultDetectors = BioXASBeamline::bioXAS()->defaultScanDetectors();
 

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -113,6 +113,11 @@ protected slots:
 	/// Implementation method that individual applications can flesh out if extra cleanup is required when a scan action finishes.  This is not pure virtual because there is no requirement to do anything to scan actions.
 	virtual void onCurrentScanActionFinishedImplementation(AMScanAction *action);
 
+	/// Handles updating the scan configuration detectors for all scans.
+	void onDefaultScanDetectorsChanged();
+	/// Updates the scan configuration's detectors, using the default detectors provided by BioXASBeamline.
+	void updateScanConfigurationDetectors(AMGenericStepScanConfiguration *configuration);
+
 protected:
 	/// Registers all of the necessary classes that are BioXAS-specific.
 	virtual void registerClasses();

--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -86,6 +86,9 @@ public:
 	/// Returns whether the element is enabled or not.  Elements are zero indexed.
 	bool isElementEnabled(int index) const;
 
+	// Returns the list of spectra controls.
+	QList<AMReadOnlyPVControl*> spectraControls() const { return spectraControls_; }
+
 	// The dead time data sources.  Dead time corrections are input/output and to get the percentage, 1 - output/input.
 	/// Returns the input count data sources.
 	QList<AMDataSource *> inputCountSources() const { return icrSources_; }

--- a/source/beamline/AMXspress3XRFDetector.cpp
+++ b/source/beamline/AMXspress3XRFDetector.cpp
@@ -6,6 +6,8 @@
 AMXspress3XRFDetector::AMXspress3XRFDetector(const QString &name, const QString &description, QObject *parent)
 	: AMXRFDetector(name, description, parent)
 {
+	triggerSource_ = 0;
+
 	autoInitialize_ = false;
 	dataReady_ = false;
 	dataReadyCounter_ = -1;

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -356,13 +356,12 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 		addDefaultScanDetector(newDetector);
 		addScanDetectorOption(newDetector);
 
+		addSynchronizedXRFDetector(newDetector);
+
 		// Add each detector spectrum control.
 
-		foreach (AMControl *spectra, newDetector->spectraControls()) {
-			AMDetector *element = new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 2048, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
-
-			addDetectorElement(newDetector, element);
-		}
+		foreach (AMControl *spectra, newDetector->spectraControls())
+			addDetectorElement(newDetector, new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 2048, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this));
 
 		result = true;
 		emit ge32DetectorsChanged();

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -360,8 +360,11 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 
 		// Add each detector spectrum control.
 
-		foreach (AMControl *spectra, newDetector->spectraControls())
-			addDetectorElement(newDetector, new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 4096, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this));
+		foreach (AMControl *spectra, newDetector->spectraControls()) {
+			AM1DControlDetectorEmulator *element = new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 4096, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+			element->setAccessAsDouble(true);
+			addDetectorElement(newDetector, element);
+		}
 
 		result = true;
 		emit ge32DetectorsChanged();

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -361,7 +361,7 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 		// Add each detector spectrum control.
 
 		foreach (AMControl *spectra, newDetector->spectraControls())
-			addDetectorElement(newDetector, new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 2048, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this));
+			addDetectorElement(newDetector, new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 4096, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this));
 
 		result = true;
 		emit ge32DetectorsChanged();

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -354,6 +354,7 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 		addExposedScientificDetector(newDetector);
 		addExposedDetector(newDetector);
 		addDefaultScanDetector(newDetector);
+		addScanDetectorOption(newDetector);
 
 		// Add each detector spectrum control.
 
@@ -657,6 +658,22 @@ bool BioXASBeamline::clearDefaultScanDetectors()
 	return true;
 }
 
+bool BioXASBeamline::addScanDetectorOption(AMDetector *detector)
+{
+	return scanDetectorsOptions_->addDetector(detector);
+}
+
+bool BioXASBeamline::removeScanDetectorOption(AMDetector *detector)
+{
+	return scanDetectorsOptions_->removeDetector(detector);
+}
+
+bool BioXASBeamline::clearScanDetectorOptions()
+{
+	scanDetectorsOptions_->clear();
+	return true;
+}
+
 void BioXASBeamline::setupComponents()
 {
 	// Utilities.
@@ -870,6 +887,10 @@ void BioXASBeamline::setupComponents()
 	// The set of default detectors for XAS scans.
 
 	defaultScanDetectors_ = new AMDetectorSet(this);
+
+	// The set of detectors to use as options for a scan, a subset of the default detectors.
+
+	scanDetectorsOptions_ = new AMDetectorSet(this);
 }
 
 AMBasicControlDetectorEmulator* BioXASBeamline::createDetectorEmulator(const QString &name, const QString &description, AMControl *control, bool hiddenFromUsers, bool isVisible)
@@ -890,6 +911,8 @@ void BioXASBeamline::addControlAsDetector(const QString &name, const QString &de
 	if (control && !controlDetectorMap_.contains(control)) {
 		AMBasicControlDetectorEmulator *detector = createDetectorEmulator(name, description, control, hiddenFromUsers, isVisible);
 		controlDetectorMap_.insert(control, detector);
+		addExposedDetector(detector);
+		addScanDetectorOption(detector);
 	}
 }
 

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -175,6 +175,11 @@ public:
 	/// Returns the detector for the given control, if one has been created and added to the control/detector map.
 	AMBasicControlDetectorEmulator* detectorForControl(AMControl *control) const;
 
+	/// Returns the set of default detectors used in XAS scans.
+	AMDetectorSet* defaultScanDetectors() const { return defaultScanDetectors_; }
+	/// Returns the set of detectors to use as options in scans.
+	AMDetectorSet* scanDetectorsOptions() const { return scanDetectorsOptions_; }
+
 signals:
 	/// Notifier that the current connected state has changed.
 	void connectedChanged(bool isConnected);
@@ -290,6 +295,13 @@ protected slots:
 	/// Clears all elements for the given detector: removing all elements from the set, removing detector entry, and deleting the elements set.
 	bool clearDetectorElements(AMDetector *detector);
 
+	/// Adds a detector to the set of default detectors for XAS scans.
+	bool addDefaultScanDetector(AMDetector *detector);
+	/// Removes a detector from the set of default detectors for XAS scans.
+	bool removeDefaultScanDetector(AMDetector *detector);
+	/// Clears the set of default detectors for XAS scans.
+	bool clearDefaultScanDetectors();
+
 protected:
 	/// Sets up controls for front end beamline components and/or components that are common to all three BioXAS beamlines.
 	virtual void setupComponents();
@@ -316,6 +328,11 @@ protected:
 	AMDetectorSet *ge32Detectors_;
 	/// The detector-elements mapping.
 	QMap<AMDetector*, AMDetectorSet*> detectorElementsMap_;
+
+	/// The set of detectors that are added by default to a scan.
+	AMDetectorSet *defaultScanDetectors_;
+	/// The set of detector options for a scan.
+	AMDetectorSet *scanDetectorsOptions_;
 
 	/// The control/detector map. Assumes a 1-1 correlation between controls and detector emulators.
 	QMap<AMControl*, AMBasicControlDetectorEmulator*> controlDetectorMap_;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -151,6 +151,8 @@ public:
 	virtual AMDetectorSet* ge32ElementDetectors() const { return ge32Detectors_; }
 	/// Returns the four-element Vortex detector.
 	virtual BioXASFourElementVortexDetector* fourElementVortexDetector() const { return 0; }
+	/// Returns the elements for the given detector.
+	virtual AMDetectorSet* elementsForDetector(AMDetector *detector) const { return detectorElementsMap_.value(detector, 0); }
 
 	/// Returns true if this beamline can have a diode detector.
 	virtual bool canHaveDiodeDetector() const { return false; }
@@ -279,6 +281,15 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
+	/// Adds an element to the set of elements for the given detector.
+	bool addDetectorElement(AMDetector *detector, AMDetector *element);
+	/// Removes an element from the set of elements for the given detector.
+	bool removeDetectorElement(AMDetector *detector, AMDetector *element);
+	/// Removes all elements from the set of elements for the given detector.
+	bool removeDetectorElements(AMDetector *detector);
+	/// Clears all elements for the given detector: removing all elements from the set, removing detector entry, and deleting the elements set.
+	bool clearDetectorElements(AMDetector *detector);
+
 protected:
 	/// Sets up controls for front end beamline components and/or components that are common to all three BioXAS beamlines.
 	virtual void setupComponents();
@@ -303,6 +314,8 @@ protected:
 	AMControlSet *detectorStageLateralMotors_;
 	/// The 32Ge detectors.
 	AMDetectorSet *ge32Detectors_;
+	/// The detector-elements mapping.
+	QMap<AMDetector*, AMDetectorSet*> detectorElementsMap_;
 
 	/// The control/detector map. Assumes a 1-1 correlation between controls and detector emulators.
 	QMap<AMControl*, AMBasicControlDetectorEmulator*> controlDetectorMap_;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -296,11 +296,18 @@ protected slots:
 	bool clearDetectorElements(AMDetector *detector);
 
 	/// Adds a detector to the set of default detectors for XAS scans.
-	bool addDefaultScanDetector(AMDetector *detector);
+	virtual bool addDefaultScanDetector(AMDetector *detector);
 	/// Removes a detector from the set of default detectors for XAS scans.
-	bool removeDefaultScanDetector(AMDetector *detector);
+	virtual bool removeDefaultScanDetector(AMDetector *detector);
 	/// Clears the set of default detectors for XAS scans.
-	bool clearDefaultScanDetectors();
+	virtual bool clearDefaultScanDetectors();
+
+	/// Adds a detector to the set of default detectors for XAS scans.
+	virtual bool addScanDetectorOption(AMDetector *detector);
+	/// Removes a detector from the set of default detectors for XAS scans.
+	virtual bool removeScanDetectorOption(AMDetector *detector);
+	/// Clears the set of default detectors for XAS scans.
+	virtual bool clearScanDetectorOptions();
 
 protected:
 	/// Sets up controls for front end beamline components and/or components that are common to all three BioXAS beamlines.

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -302,9 +302,9 @@ protected slots:
 	/// Clears the set of default detectors for XAS scans.
 	virtual bool clearDefaultScanDetectors();
 
-	/// Adds a detector to the set of default detectors for XAS scans.
+	/// Adds a detector to the set of detectors used as options in scans.
 	virtual bool addScanDetectorOption(AMDetector *detector);
-	/// Removes a detector from the set of default detectors for XAS scans.
+	/// Removes a detector from the set of detectors used as options in scans.
 	virtual bool removeScanDetectorOption(AMDetector *detector);
 	/// Clears the set of default detectors for XAS scans.
 	virtual bool clearScanDetectorOptions();

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -231,6 +231,7 @@ bool BioXASSideBeamline::addDiodeDetector()
 
 		addExposedDetector(diodeDetector_);
 		addExposedScientificDetector(diodeDetector_);
+		addDefaultScanDetector(diodeDetector_);
 
 		hasDiodeDetector_ = true;
 		result = true;
@@ -252,6 +253,7 @@ bool BioXASSideBeamline::removeDiodeDetector()
 
 		removeExposedDetector(diodeDetector_);
 		removeExposedScientificDetector(diodeDetector_);
+		removeDefaultScanDetector(diodeDetector_);
 
 		hasDiodeDetector_ = false;
 		result = true;
@@ -280,6 +282,7 @@ bool BioXASSideBeamline::addPIPSDetector()
 
 		addExposedDetector(pipsDetector_);
 		addExposedScientificDetector(pipsDetector_);
+		addDefaultScanDetector(pipsDetector_);
 
 		hasPIPSDetector_ = true;
 		result = true;
@@ -301,6 +304,7 @@ bool BioXASSideBeamline::removePIPSDetector()
 
 		removeExposedDetector(pipsDetector_);
 		removeExposedScientificDetector(pipsDetector_);
+		removeDefaultScanDetector(pipsDetector_);
 
 		hasPIPSDetector_ = false;
 		result = true;
@@ -329,6 +333,7 @@ bool BioXASSideBeamline::addLytleDetector()
 
 		addExposedDetector(lytleDetector_);
 		addExposedScientificDetector(lytleDetector_);
+		addDefaultScanDetector(lytleDetector_);
 
 		hasLytleDetector_ = true;
 		result = true;
@@ -350,6 +355,7 @@ bool BioXASSideBeamline::removeLytleDetector()
 
 		removeExposedDetector(lytleDetector_);
 		removeExposedScientificDetector(lytleDetector_);
+		removeDefaultScanDetector(lytleDetector_);
 
 		hasLytleDetector_ = false;
 		result = true;
@@ -536,6 +542,7 @@ void BioXASSideBeamline::setupComponents()
 
 	addExposedDetector(i0Detector_);
 	addExposedScientificDetector(i0Detector_);
+	addDefaultScanDetector(i0Detector_);
 
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
@@ -553,6 +560,7 @@ void BioXASSideBeamline::setupComponents()
 
 	addExposedDetector(i1Detector_);
 	addExposedScientificDetector(i1Detector_);
+	addDefaultScanDetector(i1Detector_);
 
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
@@ -570,6 +578,7 @@ void BioXASSideBeamline::setupComponents()
 
 	addExposedDetector(i2Detector_);
 	addExposedScientificDetector(i2Detector_);
+	addDefaultScanDetector(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -232,6 +232,7 @@ bool BioXASSideBeamline::addDiodeDetector()
 		addExposedDetector(diodeDetector_);
 		addExposedScientificDetector(diodeDetector_);
 		addDefaultScanDetector(diodeDetector_);
+		addScanDetectorOption(diodeDetector_);
 
 		hasDiodeDetector_ = true;
 		result = true;
@@ -254,6 +255,7 @@ bool BioXASSideBeamline::removeDiodeDetector()
 		removeExposedDetector(diodeDetector_);
 		removeExposedScientificDetector(diodeDetector_);
 		removeDefaultScanDetector(diodeDetector_);
+		removeScanDetectorOption(diodeDetector_);
 
 		hasDiodeDetector_ = false;
 		result = true;
@@ -283,6 +285,7 @@ bool BioXASSideBeamline::addPIPSDetector()
 		addExposedDetector(pipsDetector_);
 		addExposedScientificDetector(pipsDetector_);
 		addDefaultScanDetector(pipsDetector_);
+		addScanDetectorOption(pipsDetector_);
 
 		hasPIPSDetector_ = true;
 		result = true;
@@ -305,6 +308,7 @@ bool BioXASSideBeamline::removePIPSDetector()
 		removeExposedDetector(pipsDetector_);
 		removeExposedScientificDetector(pipsDetector_);
 		removeDefaultScanDetector(pipsDetector_);
+		removeScanDetectorOption(pipsDetector_);
 
 		hasPIPSDetector_ = false;
 		result = true;
@@ -334,6 +338,7 @@ bool BioXASSideBeamline::addLytleDetector()
 		addExposedDetector(lytleDetector_);
 		addExposedScientificDetector(lytleDetector_);
 		addDefaultScanDetector(lytleDetector_);
+		addScanDetectorOption(lytleDetector_);
 
 		hasLytleDetector_ = true;
 		result = true;
@@ -356,6 +361,7 @@ bool BioXASSideBeamline::removeLytleDetector()
 		removeExposedDetector(lytleDetector_);
 		removeExposedScientificDetector(lytleDetector_);
 		removeDefaultScanDetector(lytleDetector_);
+		removeScanDetectorOption(lytleDetector_);
 
 		hasLytleDetector_ = false;
 		result = true;
@@ -543,6 +549,7 @@ void BioXASSideBeamline::setupComponents()
 	addExposedDetector(i0Detector_);
 	addExposedScientificDetector(i0Detector_);
 	addDefaultScanDetector(i0Detector_);
+	addScanDetectorOption(i0Detector_);
 
 	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
 	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
@@ -561,6 +568,7 @@ void BioXASSideBeamline::setupComponents()
 	addExposedDetector(i1Detector_);
 	addExposedScientificDetector(i1Detector_);
 	addDefaultScanDetector(i1Detector_);
+	addScanDetectorOption(i1Detector_);
 
 	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
 	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
@@ -579,6 +587,7 @@ void BioXASSideBeamline::setupComponents()
 	addExposedDetector(i2Detector_);
 	addExposedScientificDetector(i2Detector_);
 	addDefaultScanDetector(i2Detector_);
+	addScanDetectorOption(i2Detector_);
 
 	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
 	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -625,7 +625,6 @@ void BioXASSideBeamline::setupComponents()
 	ge32ElementDetector_->setTriggerSource(zebraTriggerSource_);
 
 	addGe32Detector(ge32ElementDetector_);
-	addSynchronizedXRFDetector(ge32ElementDetector_);
 
 	// The fast shutter.
 

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
@@ -34,7 +34,7 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	// Create scan detectors editor.
 
-	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedScientificDetectors());
+	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, BioXASBeamline::bioXAS()->exposedScientificDetectors());
 
 	QVBoxLayout *scientificDetectorsWidgetLayout = new QVBoxLayout();
 	scientificDetectorsWidgetLayout->addWidget(scientificDetectorsView_);
@@ -43,7 +43,7 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 	QWidget *scientificDetectorsWidget = new QWidget();
 	scientificDetectorsWidget->setLayout(scientificDetectorsWidgetLayout);
 
-	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, AMBeamline::bl()->exposedDetectors());
+	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, BioXASBeamline::bioXAS()->scanDetectorsOptions());
 
 	QVBoxLayout *allDetectorsWidgetLayout = new QVBoxLayout();
 	allDetectorsWidgetLayout->addWidget(allDetectorsView_);

--- a/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
@@ -161,7 +161,9 @@ void AMGenericStepScanConfigurationDetectorsView::refresh()
 
 				// Create new checkbox for the detector.
 
-				QCheckBox *checkBox = new QCheckBox(detector->description());
+				QString detectorText = (detector->description().isEmpty() ? detector->name() : detector->description());
+
+				QCheckBox *checkBox = new QCheckBox(detectorText);
 				buttonGroup_->addButton(checkBox, detectorIndex);
 				layout_->addWidget(checkBox);
 


### PR DESCRIPTION
- Added getter to AMXRFDetector for the list of spectra controls.
- Added a map to BioXASBeamline, that maps detectors to the set of detector elements.
- Modified the add/remove/clearGeDetectors methods to also consider the detector's elements.
- Added two sets of detectors to BioXASBeamline, one for the detectors that should be added to scan configurations by default, and one for the detectors that should be shown as options (eg. scientific detectors + control emulators).



- setAccessAsDouble(), BioXASBeamline creating element emulators.