### PR TITLE
Pull Request for Issue2129: Change scaler view spinboxes to QDoubleSpinBoxes

### DIFF
--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.cpp
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.cpp
@@ -19,7 +19,7 @@ CLSSIS3820ScalerControlsView::CLSSIS3820ScalerControlsView(CLSSIS3820Scaler *sca
 
 	statusLabel_ = new QLabel;
 
-	dwellTimeBox_ = new QSpinBox;
+	dwellTimeBox_ = new QDoubleSpinBox;
 	dwellTimeBox_->setFixedWidth(100);
 	dwellTimeBox_->setAlignment(Qt::AlignCenter);
 
@@ -220,7 +220,7 @@ void CLSSIS3820ScalerControlsView::updateDwellTimeBox()
 		dwellTimeBox_->blockSignals(true);
 		dwellTimeBox_->setRange(0, 1000000);
 		dwellTimeBox_->setSuffix(" s");
-		dwellTimeBox_->setValue(int(scaler_->dwellTime()));
+		dwellTimeBox_->setValue(scaler_->dwellTime());
 		dwellTimeBox_->blockSignals(false);
 	}
 }

--- a/source/ui/CLS/CLSSIS3820ScalerControlsView.h
+++ b/source/ui/CLS/CLSSIS3820ScalerControlsView.h
@@ -5,7 +5,7 @@
 #include <QPushButton>
 #include <QComboBox>
 #include <QLabel>
-#include <QSpinBox>
+#include <QDoubleSpinBox>
 #include <QLayout>
 
 #include "beamline/CLS/CLSSIS3820Scaler.h"
@@ -79,7 +79,7 @@ protected:
 	/// Label holding the overall scanning status of the scaler.  Matches the scanning button.
 	QLabel *statusLabel_;
 	/// Spin box holding the dwell time per point, in milliseconds.
-	QSpinBox *dwellTimeBox_;
+	QDoubleSpinBox *dwellTimeBox_;
 	/// Spin box holding the number of scans per buffer.
 	QSpinBox *scansPerBufferBox_;
 	/// Spin box holding the total number of scans.

--- a/source/ui/CLS/CLSSIS3820ScalerDarkCurrentWidget.cpp
+++ b/source/ui/CLS/CLSSIS3820ScalerDarkCurrentWidget.cpp
@@ -32,7 +32,7 @@ CLSSIS3820ScalerDarkCurrentWidget::CLSSIS3820ScalerDarkCurrentWidget(CLSSIS3820S
 
 	QLabel *timePrompt = new QLabel("Dwell time: ");
 
-	timeBox_ = new QSpinBox();
+	timeBox_ = new QDoubleSpinBox();
 
 	collectButton_ = new QPushButton("Collect");
 
@@ -96,7 +96,7 @@ void CLSSIS3820ScalerDarkCurrentWidget::updateTimeBox()
 		timeBox_->setEnabled(true);
 		timeBox_->setRange(0, INT_MAX);
 		timeBox_->setSuffix(" s");
-		timeBox_->setValue(int(scaler_->dwellTime()));
+		timeBox_->setValue(scaler_->dwellTime());
 		timeBox_->blockSignals(false);
 
 	} else {

--- a/source/ui/CLS/CLSSIS3820ScalerDarkCurrentWidget.h
+++ b/source/ui/CLS/CLSSIS3820ScalerDarkCurrentWidget.h
@@ -26,7 +26,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QPushButton>
 #include <QLayout>
 #include <QLabel>
-#include <QSpinBox>
+#include <QDoubleSpinBox>
 
 #include "beamline/CLS/CLSSIS3820Scaler.h"
 
@@ -67,7 +67,7 @@ protected:
     /// The scaler being viewed.
 	CLSSIS3820Scaler *scaler_;
 	/// The time entry box.
-	QSpinBox* timeBox_;
+	QDoubleSpinBox* timeBox_;
 	/// The collect button.
 	QPushButton* collectButton_;
 };


### PR DESCRIPTION
Changed the scaler time entry and the dark current time entry widgets from QSpinBoxes to QDoubleSpinBoxes.