### PR TITLE
Pull Request Issue2076: Adding diode, PIPS, and Lytle detectors to Main

### DIFF
--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -607,6 +607,61 @@ void BioXASBeamline::clearFlowTransducers()
 		utilities_->clearFlowTransducers();
 }
 
+bool BioXASBeamline::addScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex, const QString &channelName, CLSBasicScalerChannelDetector *detector)
+{
+	bool result = false;
+
+	if (scaler && detector) {
+
+		CLSSIS3820ScalerChannel *channel = scaler->channelAt(channelIndex);
+
+		if (channel) {
+
+			channel->setCustomChannelName(channelName);
+			channel->setDetector(detector);
+
+			addExposedDetector(detector);
+			addExposedScientificDetector(detector);
+			addDefaultScanDetector(detector);
+			addScanDetectorOption(detector);
+
+			result = true;
+		}
+	}
+
+	return result;
+}
+
+bool BioXASBeamline::removeScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex)
+{
+	bool result = false;
+
+	if (scaler) {
+
+		CLSSIS3820ScalerChannel *channel = scaler->channelAt(channelIndex);
+
+		if (channel) {
+
+			AMDetector *detector = channel->detector();
+
+			if (detector) {
+
+				channel->setCustomChannelName("");
+				channel->setDetector(0);
+
+				removeExposedDetector(detector);
+				removeExposedScientificDetector(detector);
+				removeDefaultScanDetector(detector);
+				removeScanDetectorOption(detector);
+			}
+
+			result = true;
+		}
+	}
+
+	return result;
+}
+
 bool BioXASBeamline::addDetectorElement(AMDetector *detector, AMDetector *element)
 {
 	bool result = false;

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -612,27 +612,39 @@ void BioXASBeamline::clearFlowTransducers()
 		utilities_->clearFlowTransducers();
 }
 
+void BioXASBeamline::addExposedScalerChannelDetector(AMDetector *detector)
+{
+	if (detector) {
+		addExposedDetector(detector);
+		addExposedScientificDetector(detector);
+		addDefaultScanDetector(detector);
+		addScanDetectorOption(detector);
+	}
+}
+
+void BioXASBeamline::removeExposedScalerChannelDetector(AMDetector *detector)
+{
+	if (detector) {
+		removeExposedDetector(detector);
+		removeExposedScientificDetector(detector);
+		removeDefaultScanDetector(detector);
+		removeScanDetectorOption(detector);
+	}
+}
+
 bool BioXASBeamline::setUsingDiodeDetector(bool usingDetector)
 {
 	bool result = false;
 
 	if (canUseDiodeDetector() && diodeDetector_ && usingDiodeDetector_ != usingDetector) {
 
-		if (usingDiodeDetector_) {
-			removeExposedDetector(diodeDetector_);
-			removeExposedScientificDetector(diodeDetector_);
-			removeDefaultScanDetector(diodeDetector_);
-			removeScanDetectorOption(diodeDetector_);
-		}
+		if (usingDiodeDetector_)
+			removeExposedScalerChannelDetector(diodeDetector_);
 
 		usingDiodeDetector_ = usingDetector;
 
-		if (usingDiodeDetector_) {
-			addExposedDetector(diodeDetector_);
-			addExposedScientificDetector(diodeDetector_);
-			addDefaultScanDetector(diodeDetector_);
-			addScanDetectorOption(diodeDetector_);
-		}
+		if (usingDiodeDetector_)
+			addExposedScalerChannelDetector(diodeDetector_);
 
 		result = true;
 
@@ -670,21 +682,13 @@ bool BioXASBeamline::setUsingPIPSDetector(bool usingDetector)
 
 	if (canUsePIPSDetector() && pipsDetector_ && usingPIPSDetector_ != usingDetector) {
 
-		if (usingPIPSDetector_) {
-			removeExposedDetector(pipsDetector_);
-			removeExposedScientificDetector(pipsDetector_);
-			removeDefaultScanDetector(pipsDetector_);
-			removeScanDetectorOption(pipsDetector_);
-		}
+		if (usingPIPSDetector_)
+			removeExposedScalerChannelDetector(pipsDetector_);
 
 		usingPIPSDetector_ = usingDetector;
 
-		if (usingPIPSDetector_) {
-			addExposedDetector(pipsDetector_);
-			addExposedScientificDetector(pipsDetector_);
-			addDefaultScanDetector(pipsDetector_);
-			addScanDetectorOption(pipsDetector_);
-		}
+		if (usingPIPSDetector_)
+			addExposedScalerChannelDetector(pipsDetector_);
 
 		result = true;
 
@@ -722,21 +726,13 @@ bool BioXASBeamline::setUsingLytleDetector(bool usingDetector)
 
 	if (canUseLytleDetector() && lytleDetector_ && usingLytleDetector_ != usingDetector) {
 
-		if (usingLytleDetector_) {
-			removeExposedDetector(lytleDetector_);
-			removeExposedScientificDetector(lytleDetector_);
-			removeDefaultScanDetector(lytleDetector_);
-			removeScanDetectorOption(lytleDetector_);
-		}
+		if (usingLytleDetector_)
+			removeExposedScalerChannelDetector(lytleDetector_);
 
 		usingLytleDetector_ = usingDetector;
 
-		if (usingLytleDetector_) {
-			addExposedDetector(lytleDetector_);
-			addExposedScientificDetector(lytleDetector_);
-			addDefaultScanDetector(lytleDetector_);
-			addScanDetectorOption(lytleDetector_);
-		}
+		if (usingLytleDetector_)
+			addExposedScalerChannelDetector(lytleDetector_);
 
 		result = true;
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -612,59 +612,6 @@ void BioXASBeamline::clearFlowTransducers()
 		utilities_->clearFlowTransducers();
 }
 
-bool BioXASBeamline::addScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex, const QString &channelName, CLSBasicScalerChannelDetector *detector)
-{
-	bool detectorAdded = false;
-
-	if (scaler && detector) {
-
-		CLSSIS3820ScalerChannel *channel = scaler->channelAt(channelIndex);
-
-		if (channel) {
-
-			detectorAdded = scaler->addChannelDetector(channelIndex, channelName, detector);
-
-			if (detectorAdded) {
-				addExposedDetector(detector);
-				addExposedScientificDetector(detector);
-				addDefaultScanDetector(detector);
-				addScanDetectorOption(detector);
-			}
-		}
-	}
-
-	return detectorAdded;
-}
-
-bool BioXASBeamline::removeScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex)
-{
-	bool detectorRemoved = false;
-
-	if (scaler) {
-
-		CLSSIS3820ScalerChannel *channel = scaler->channelAt(channelIndex);
-
-		if (channel) {
-
-			AMDetector *detector = channel->detector();
-
-			if (detector) {
-
-				detectorRemoved = scaler->removeChannelDetector(channelIndex);
-
-				if (detectorRemoved) {
-					removeExposedDetector(detector);
-					removeExposedScientificDetector(detector);
-					removeDefaultScanDetector(detector);
-					removeScanDetectorOption(detector);
-				}
-			}
-		}
-	}
-
-	return detectorRemoved;
-}
-
 bool BioXASBeamline::setUsingDiodeDetector(bool usingDetector)
 {
 	bool result = false;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -296,6 +296,9 @@ protected slots:
 	/// Removes a scaler channel detector.
 	bool removeScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex);
 
+	/// Sets the diode detector.
+	void setDiodeDetector(CLSBasicScalerChannelDetector *detector);
+
 	/// Adds an element to the set of elements for the given detector.
 	bool addDetectorElement(AMDetector *detector, AMDetector *element);
 	/// Removes an element from the set of elements for the given detector.
@@ -339,13 +342,6 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
-
-	/// The scaler channel detector scaler map.
-	QMap<CLSBasicScalerChannelDetector*, CLSSIS3820Scaler*> scalerChannelDetectorScalerMap_;
-	/// The scaler channel detector index map.
-	QMap<CLSBasicScalerChannelDetector*, int> scalerChannelDetectorIndexMap_;
-	/// The scaler channel detector name map.
-	QMap<CLSBasicScalerChannelDetector*, QString> scalerChannelDetectorNameMap_;
 
 	/// The set of detector stage motors.
 	AMControlSet *detectorStageLateralMotors_;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -149,32 +149,30 @@ public:
 	virtual CLSSIS3820Scaler* scaler() const { return 0; }
 
 	/// Returns the I0 scaler channel detector.
-	virtual AMDetector* i0Detector() const { return 0; }
+	virtual CLSBasicScalerChannelDetector* i0Detector() const { return 0; }
 	/// Returns the I1 scaler channel detector.
-	virtual AMDetector* i1Detector() const { return 0; }
+	virtual CLSBasicScalerChannelDetector* i1Detector() const { return 0; }
 	/// Returns the I2 scaler channel detector.
-	virtual AMDetector* i2Detector() const { return 0; }
+	virtual CLSBasicScalerChannelDetector* i2Detector() const { return 0; }
+	/// Returns true if this beamline can have a diode detector.
+	virtual bool canHaveDiodeDetector() const { return false; }
+	/// Returns the diode detector.
+	virtual CLSBasicScalerChannelDetector* diodeDetector() const { return 0; }
+	/// Returns true if this beamline can have a PIPS detector.
+	virtual bool canHavePIPSDetector() const { return false; }
+	/// Returns the PIPS detector.
+	virtual CLSBasicScalerChannelDetector* pipsDetector() const { return 0; }
+	/// Returns true if this beamline can have a Lytle detector.
+	virtual bool canHaveLytleDetector() const { return false; }
+	/// Returns the Lytle detector.
+	virtual CLSBasicScalerChannelDetector* lytleDetector() const { return 0; }
+
 	/// Returns the 32-element Germanium detector.
 	virtual AMDetectorSet* ge32ElementDetectors() const { return ge32Detectors_; }
 	/// Returns the four-element Vortex detector.
 	virtual BioXASFourElementVortexDetector* fourElementVortexDetector() const { return 0; }
 	/// Returns the elements for the given detector.
 	virtual AMDetectorSet* elementsForDetector(AMDetector *detector) const { return detectorElementsMap_.value(detector, 0); }
-
-	/// Returns true if this beamline can have a diode detector.
-	virtual bool canHaveDiodeDetector() const { return false; }
-	/// Returns the diode detector.
-	virtual AMDetector* diodeDetector() const { return 0; }
-
-	/// Returns true if this beamline can have a PIPS detector.
-	virtual bool canHavePIPSDetector() const { return false; }
-	/// Returns the PIPS detector.
-	virtual AMDetector* pipsDetector() const { return 0; }
-
-	/// Returns true if this beamline can have a Lytle detector.
-	virtual bool canHaveLytleDetector() const { return false; }
-	/// Returns the Lytle detector.
-	virtual AMDetector* lytleDetector() const { return 0; }
 
 	/// Returns the scaler dwell time detector.
 	virtual AMBasicControlDetectorEmulator* scalerDwellTimeDetector() const { return 0; }
@@ -293,6 +291,11 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
+	/// Adds a scaler channel detector.
+	bool addScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex, const QString &channelName, CLSBasicScalerChannelDetector *detector);
+	/// Removes a scaler channel detector.
+	bool removeScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex);
+
 	/// Adds an element to the set of elements for the given detector.
 	bool addDetectorElement(AMDetector *detector, AMDetector *element);
 	/// Removes an element from the set of elements for the given detector.
@@ -336,10 +339,20 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
+
+	/// The scaler channel detector scaler map.
+	QMap<CLSBasicScalerChannelDetector*, CLSSIS3820Scaler*> scalerChannelDetectorScalerMap_;
+	/// The scaler channel detector index map.
+	QMap<CLSBasicScalerChannelDetector*, int> scalerChannelDetectorIndexMap_;
+	/// The scaler channel detector name map.
+	QMap<CLSBasicScalerChannelDetector*, QString> scalerChannelDetectorNameMap_;
+
 	/// The set of detector stage motors.
 	AMControlSet *detectorStageLateralMotors_;
+
 	/// The 32Ge detectors.
 	AMDetectorSet *ge32Detectors_;
+
 	/// The detector-elements mapping.
 	QMap<AMDetector*, AMDetectorSet*> detectorElementsMap_;
 

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -154,18 +154,27 @@ public:
 	virtual CLSBasicScalerChannelDetector* i1Detector() const { return 0; }
 	/// Returns the I2 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i2Detector() const { return 0; }
-	/// Returns true if this beamline can have a diode detector.
-	virtual bool canHaveDiodeDetector() const { return false; }
+
+	/// Returns true if this beamline can use a diode detector.
+	virtual bool canUseDiodeDetector() const { return false; }
+	/// Returns true if this beamline is using a diode detector.
+	virtual bool usingDiodeDetector() const { return usingDiodeDetector_; }
 	/// Returns the diode detector.
-	virtual CLSBasicScalerChannelDetector* diodeDetector() const { return 0; }
-	/// Returns true if this beamline can have a PIPS detector.
-	virtual bool canHavePIPSDetector() const { return false; }
+	virtual CLSBasicScalerChannelDetector* diodeDetector() const { return diodeDetector_; }
+
+	/// Returns true if this beamline can use a PIPS detector.
+	virtual bool canUsePIPSDetector() const { return false; }
+	/// Returns true if this beamline is using the PIPS detector.
+	virtual bool usingPIPSDetector() const { return usingPIPSDetector_; }
 	/// Returns the PIPS detector.
-	virtual CLSBasicScalerChannelDetector* pipsDetector() const { return 0; }
-	/// Returns true if this beamline can have a Lytle detector.
-	virtual bool canHaveLytleDetector() const { return false; }
+	virtual CLSBasicScalerChannelDetector* pipsDetector() const { return pipsDetector_; }
+
+	/// Returns true if this beamline can use a Lytle detector.
+	virtual bool canUseLytleDetector() const { return false; }
+	/// Returns true if this beamline is using the Lytle detector.
+	virtual bool usingLytleDetector() const { return usingLytleDetector_; }
 	/// Returns the Lytle detector.
-	virtual CLSBasicScalerChannelDetector* lytleDetector() const { return 0; }
+	virtual CLSBasicScalerChannelDetector* lytleDetector() const { return lytleDetector_; }
 
 	/// Returns the 32-element Germanium detector.
 	virtual AMDetectorSet* ge32ElementDetectors() const { return ge32Detectors_; }
@@ -192,12 +201,18 @@ signals:
 	void detectorStageLateralMotorsChanged();
 	/// Notifier that the 32Ge detectors have changed.
 	void ge32DetectorsChanged();
+	/// Notifier that the flag for whether this beamline is using the diode detector has changed.
+	void usingDiodeDetectorChanged(bool usingDetector);
 	/// Notifier that the diode detector has changed.
-	void diodeDetectorChanged(AMDetector *newDetector);
+	void diodeDetectorChanged(CLSBasicScalerChannelDetector *newDetector);
+	/// Notifier that the flag for whether this beamline is using the PIPS detector has changed.
+	void usingPIPSDetectorChanged(bool usingDetector);
 	/// Notifier that the PIPS detector has changed.
-	void pipsDetectorChanged(AMDetector *newDetector);
+	void pipsDetectorChanged(CLSBasicScalerChannelDetector *newDetector);
+	/// Notifier that the flag for whether this beamline is using the Lytle detector has changed.
+	void usingLytleDetectorChanged(bool usingDetector);
 	/// Notifier that the Lytle detector has changed.
-	void lytleDetectorChanged(AMDetector *newDetector);
+	void lytleDetectorChanged(CLSBasicScalerChannelDetector *newDetector);
 
 public slots:
 	/// Adds a detector stage lateral motor.
@@ -214,20 +229,12 @@ public slots:
 	/// Clears the 32Ge detectors. Returns true if successful, false otherwise.
 	bool clearGe32Detectors();
 
-	/// Adds the diode detector. Returns true if successful, false otherwise.
-	virtual bool addDiodeDetector() { return false; }
-	/// Removes the diode detector. Returns true if successful, false otherwise.
-	virtual bool removeDiodeDetector() { return false; }
-
-	/// Adds the PIPS detector. Returns true if successful, false otherwise.
-	virtual bool addPIPSDetector() { return false; }
-	/// Removes the PIPS detector. Returns true if successful, false otherwise.
-	virtual bool removePIPSDetector() { return false; }
-
-	/// Adds the Lytle detector. Returns true if successful, false otherwise.
-	virtual bool addLytleDetector() { return false; }
-	/// Removes the Lytle detector. Returns true if successful, false otherwise.
-	virtual bool removeLytleDetector() { return false; }
+	/// Adds or removes the diode detector. Returns true if successful, false otherwise.
+	virtual bool useDiodeDetector(bool useDetector) { Q_UNUSED(useDetector) return false; }
+	/// Adds or removes the PIPS detector. Returns true if successful, false otherwise.
+	virtual bool usePIPSDetector(bool useDetector) { Q_UNUSED(useDetector) return false; }
+	/// Adds or removes the Lytle detector. Returns true if successful, false otherwise.
+	virtual bool useLytleDetector(bool useDetector) { Q_UNUSED(useDetector) return false; }
 
 protected slots:
 	/// Sets the cached connected state.
@@ -296,8 +303,20 @@ protected slots:
 	/// Removes a scaler channel detector.
 	bool removeScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex);
 
+	/// Sets the flag for whether we are using the diode detector.
+	bool setUsingDiodeDetector(bool usingDetector);
 	/// Sets the diode detector.
-	void setDiodeDetector(CLSBasicScalerChannelDetector *detector);
+	bool setDiodeDetector(CLSBasicScalerChannelDetector *detector);
+
+	/// Sets the flag for whether we are using the PIPS detector.
+	bool setUsingPIPSDetector(bool usingDetector);
+	/// Sets the PIPS detector.
+	bool setPIPSDetector(CLSBasicScalerChannelDetector *detector);
+
+	/// Sets the flag for whether we are using the Lytle detector.
+	bool setUsingLytleDetector(bool usingDetector);
+	/// Sets the Lytle detector.
+	bool setLytleDetector(CLSBasicScalerChannelDetector *detector);
 
 	/// Adds an element to the set of elements for the given detector.
 	bool addDetectorElement(AMDetector *detector, AMDetector *element);
@@ -342,6 +361,21 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
+
+	/// The flag for whether this beamline is using the diode detector.
+	bool usingDiodeDetector_;
+	/// The diode detector.
+	CLSBasicScalerChannelDetector *diodeDetector_;
+
+	/// The flag for whether this beamline is using the PIPS detector.
+	bool usingPIPSDetector_;
+	/// The PIPS detector.
+	CLSBasicScalerChannelDetector *pipsDetector_;
+
+	/// The flag for whether this beamline is using the Lytle detector.
+	bool usingLytleDetector_;
+	/// The Lytle detector.
+	CLSBasicScalerChannelDetector *lytleDetector_;
 
 	/// The set of detector stage motors.
 	AMControlSet *detectorStageLateralMotors_;

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -298,6 +298,11 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
+	/// Adds the given scaler channel detector to the appropriate detector sets.
+	virtual void addExposedScalerChannelDetector(AMDetector *detector);
+	/// Removes the given scaler channel detector from the appropriate detector sets.
+	virtual void removeExposedScalerChannelDetector(AMDetector *detector);
+
 	/// Sets the flag for whether we are using the diode detector.
 	bool setUsingDiodeDetector(bool usingDetector);
 	/// Sets the diode detector.

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -298,11 +298,6 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
-	/// Adds a scaler channel detector.
-	bool addScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex, const QString &channelName, CLSBasicScalerChannelDetector *detector);
-	/// Removes a scaler channel detector.
-	bool removeScalerChannelDetector(CLSSIS3820Scaler *scaler, int channelIndex);
-
 	/// Sets the flag for whether we are using the diode detector.
 	bool setUsingDiodeDetector(bool usingDetector);
 	/// Sets the diode detector.

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -263,51 +263,42 @@ void BioXASMainBeamline::setupComponents()
 	i0Keithley_ = new CLSKeithley428("AMP1607-701", "AMP1607-701", this);
 	connect( i0Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
 
+	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
+	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
+
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i0Detector_);
-	addExposedScientificDetector(i0Detector_);
-
-	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
-	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
-	scaler_->channelAt(16)->setDetector(i0Detector_);
-	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
-	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
+	addScalerChannelDetector(scaler_, 16, "I0 Channel", i0Detector_);
 
 	// I1 channel.
 
 	i1Keithley_ = new CLSKeithley428("AMP1607-702", "AMP1607-702", this);
 	connect( i1Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
 
+	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
+	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
+
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i1Detector_);
-	addExposedScientificDetector(i1Detector_);
-
-	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
-	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
-	scaler_->channelAt(17)->setDetector(i1Detector_);
-	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
-	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
+	addScalerChannelDetector(scaler_, 17, "I1 Detector", i1Detector_);
 
 	// I2 channel.
 
 	i2Keithley_ = new CLSKeithley428("AMP1607-703", "AMP1607-703", this);
 	connect( i2Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
 
+	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
+	scaler_->channelAt(18)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(18)->setCountsVoltsSlopePreference(0.00001);
+
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i2Detector_);
-	addExposedScientificDetector(i2Detector_);
-
-	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
-	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
-	scaler_->channelAt(18)->setDetector(i2Detector_);
-	scaler_->channelAt(18)->setVoltagRange(0.1, 9.5);
-	scaler_->channelAt(18)->setCountsVoltsSlopePreference(0.00001);
+	addScalerChannelDetector(scaler_, 18, "I2 Channel", i2Detector_);
 }
 
 void BioXASMainBeamline::setupControlsAsDetectors()

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -357,10 +357,7 @@ void BioXASMainBeamline::setupComponents()
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i0Detector_);
-	addExposedScientificDetector(i0Detector_);
-	addDefaultScanDetector(i0Detector_);
-	addScanDetectorOption(i0Detector_);
+	addExposedScalerChannelDetector(i0Detector_);
 
 	scaler_->addChannelDetector(16, "I0 Channel", i0Detector_);
 
@@ -376,10 +373,7 @@ void BioXASMainBeamline::setupComponents()
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i1Detector_);
-	addExposedScientificDetector(i1Detector_);
-	addDefaultScanDetector(i1Detector_);
-	addScanDetectorOption(i1Detector_);
+	addExposedScalerChannelDetector(i1Detector_);
 
 	scaler_->addChannelDetector(17, "I1 Channel", i1Detector_);
 
@@ -395,10 +389,7 @@ void BioXASMainBeamline::setupComponents()
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i2Detector_);
-	addExposedScientificDetector(i2Detector_);
-	addDefaultScanDetector(i2Detector_);
-	addScanDetectorOption(i2Detector_);
+	addExposedScalerChannelDetector(i2Detector_);
 
 	scaler_->addChannelDetector(18, "I2 Channel", i2Detector_);
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -79,6 +79,7 @@ public:
 	virtual BioXASEndstationTable *endstationTable() const { return endstationTable_; }
 	/// Returns the cryostat stage.
 	virtual BioXASMainCryostatStage* cryostatStage() const { return cryostatStage_; }
+
 	/// Returns the scaler.
 	virtual CLSSIS3820Scaler* scaler() const { return scaler_; }
 	/// Returns the I0 amplifier.
@@ -87,6 +88,8 @@ public:
 	CLSKeithley428* i1Keithley() const { return i1Keithley_; }
 	/// Returns the I2 amplifier.
 	CLSKeithley428* i2Keithley() const { return i2Keithley_; }
+	/// Returns the 'misc' Keithley 428 amplifier.
+	CLSKeithley428* miscKeithley() const { return miscKeithley_; }
 
 	/// Returns the I0 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i0Detector() const { return i0Detector_; }
@@ -94,6 +97,13 @@ public:
 	virtual CLSBasicScalerChannelDetector* i1Detector() const { return i1Detector_; }
 	/// Returns the I2 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i2Detector() const { return i2Detector_; }
+
+	/// Returns true if this beamline can have a diode detector.
+	virtual bool canUseDiodeDetector() const { return true; }
+	/// Returns true if this beamline can have a PIPS detector.
+	virtual bool canUsePIPSDetector() const { return true; }
+	/// Returns true if this beamline can have a Lytle detector.
+	virtual bool canUseLytleDetector() const { return true; }
 
 	/// Return the set of BioXAS Motors by given motor category.
 	QList<AMControl*> getMotorsByType(BioXASBeamlineDef::BioXASMotorType category);
@@ -112,6 +122,14 @@ public:
 	AMBasicControlDetectorEmulator* braggStepSetpointDetector() const;
 	/// Returns the bragg encoder feedback - step feedback difference detector (deg).
 	AMBasicControlDetectorEmulator* braggEncoderStepDegFeedbackDetector() const;
+
+public slots:
+	/// Adds or removes the diode detector. Returns true if successful, false otherwise.
+	virtual bool useDiodeDetector(bool useDetector);
+	/// Adds or removes the PIPS detector. Returns true if successful, false otherwise.
+	virtual bool usePIPSDetector(bool useDetector);
+	/// Adds or removes the Lytle detector. Returns true if successful, false otherwise.
+	virtual bool useLytleDetector(bool useDetector);
 
 protected:
 	/// Sets up various beamline components.
@@ -158,6 +176,8 @@ protected:
 	CLSKeithley428 *i1Keithley_;
 	/// I2 Keithley amplifier
 	CLSKeithley428 *i2Keithley_;
+	/// The misc detector Keithley amplifier.
+	CLSKeithley428 *miscKeithley_;
 
 	// Detectors
 	/// I0 detector

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -472,10 +472,7 @@ void BioXASSideBeamline::setupComponents()
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i0Detector_);
-	addExposedScientificDetector(i0Detector_);
-	addDefaultScanDetector(i0Detector_);
-	addScanDetectorOption(i0Detector_);
+	addExposedScalerChannelDetector(i0Detector_);
 
 	scaler_->addChannelDetector(16, "I0 Channel", i0Detector_);
 
@@ -491,10 +488,7 @@ void BioXASSideBeamline::setupComponents()
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i1Detector_);
-	addExposedScientificDetector(i1Detector_);
-	addDefaultScanDetector(i1Detector_);
-	addScanDetectorOption(i1Detector_);
+	addExposedScalerChannelDetector(i1Detector_);
 
 	scaler_->addChannelDetector(17, "I1 Channel", i1Detector_);
 
@@ -510,10 +504,7 @@ void BioXASSideBeamline::setupComponents()
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i2Detector_);
-	addExposedScientificDetector(i2Detector_);
-	addDefaultScanDetector(i2Detector_);
-	addScanDetectorOption(i2Detector_);
+	addExposedScalerChannelDetector(i2Detector_);
 
 	scaler_->addChannelDetector(18, "I2 Channel", i2Detector_);
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -160,9 +160,9 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 	return matchedMotors;
 }
 
-AMDetector* BioXASSideBeamline::diodeDetector() const
+CLSBasicScalerChannelDetector* BioXASSideBeamline::diodeDetector() const
 {
-	AMDetector *result = 0;
+	CLSBasicScalerChannelDetector *result = 0;
 
 	if (hasDiodeDetector_)
 		result = diodeDetector_;
@@ -170,9 +170,9 @@ AMDetector* BioXASSideBeamline::diodeDetector() const
 	return result;
 }
 
-AMDetector* BioXASSideBeamline::pipsDetector() const
+CLSBasicScalerChannelDetector* BioXASSideBeamline::pipsDetector() const
 {
-	AMDetector *result = 0;
+	CLSBasicScalerChannelDetector *result = 0;
 
 	if (hasPIPSDetector_)
 		result = pipsDetector_;
@@ -180,9 +180,9 @@ AMDetector* BioXASSideBeamline::pipsDetector() const
 	return result;
 }
 
-AMDetector* BioXASSideBeamline::lytleDetector() const
+CLSBasicScalerChannelDetector* BioXASSideBeamline::lytleDetector() const
 {
-	AMDetector *result = 0;
+	CLSBasicScalerChannelDetector *result = 0;
 
 	if (hasLytleDetector_)
 		result = lytleDetector_;
@@ -217,7 +217,7 @@ AMBasicControlDetectorEmulator* BioXASSideBeamline::braggStepSetpointDetector() 
 
 bool BioXASSideBeamline::addDiodeDetector()
 {
-	bool result = false;
+	bool detectorAdded = false;
 
 	if (canHaveDiodeDetector() && !hasDiodeDetector_) {
 
@@ -228,49 +228,37 @@ bool BioXASSideBeamline::addDiodeDetector()
 
 		// Add diode.
 
-		scaler_->channelAt(19)->setCustomChannelName("Diode");
-		scaler_->channelAt(19)->setDetector(diodeDetector_);
+		detectorAdded = addScalerChannelDetector(scaler_, 19, "Diode", diodeDetector_);
 
-		addExposedDetector(diodeDetector_);
-		addExposedScientificDetector(diodeDetector_);
-		addDefaultScanDetector(diodeDetector_);
-		addScanDetectorOption(diodeDetector_);
-
-		hasDiodeDetector_ = true;
-		result = true;
+		if (detectorAdded)
+			hasDiodeDetector_ = true;
 
 		emit diodeDetectorChanged(diodeDetector_);
 	}
 
-	return result;
+	return detectorAdded;
 }
 
 bool BioXASSideBeamline::removeDiodeDetector()
 {
-	bool result = false;
+	bool detectorRemoved = false;
 
 	if (hasDiodeDetector_) {
 
-		scaler_->channelAt(19)->setCustomChannelName("");
-		scaler_->channelAt(19)->setDetector(0);
+		detectorRemoved = removeScalerChannelDetector(scaler_, 19);
 
-		removeExposedDetector(diodeDetector_);
-		removeExposedScientificDetector(diodeDetector_);
-		removeDefaultScanDetector(diodeDetector_);
-		removeScanDetectorOption(diodeDetector_);
-
-		hasDiodeDetector_ = false;
-		result = true;
+		if (detectorRemoved)
+			hasDiodeDetector_ = false;
 
 		emit diodeDetectorChanged(0);
 	}
 
-	return result;
+	return detectorRemoved;
 }
 
 bool BioXASSideBeamline::addPIPSDetector()
 {
-	bool result = false;
+	bool detectorAdded = false;
 
 	if (canHavePIPSDetector() && !hasPIPSDetector_) {
 
@@ -281,49 +269,37 @@ bool BioXASSideBeamline::addPIPSDetector()
 
 		// Add PIPS.
 
-		scaler_->channelAt(19)->setCustomChannelName("PIPS");
-		scaler_->channelAt(19)->setDetector(pipsDetector_);
+		detectorAdded = addScalerChannelDetector(scaler_, 19, "PIPS", pipsDetector_);
 
-		addExposedDetector(pipsDetector_);
-		addExposedScientificDetector(pipsDetector_);
-		addDefaultScanDetector(pipsDetector_);
-		addScanDetectorOption(pipsDetector_);
-
-		hasPIPSDetector_ = true;
-		result = true;
+		if (detectorAdded)
+			hasPIPSDetector_ = true;
 
 		emit pipsDetectorChanged(pipsDetector_);
 	}
 
-	return result;
+	return detectorAdded;
 }
 
 bool BioXASSideBeamline::removePIPSDetector()
 {
-	bool result = false;
+	bool detectorRemoved = false;
 
 	if (hasPIPSDetector_) {
 
-		scaler_->channelAt(19)->setCustomChannelName("");
-		scaler_->channelAt(19)->setDetector(0);
+		detectorRemoved = removeScalerChannelDetector(scaler_, 19);
 
-		removeExposedDetector(pipsDetector_);
-		removeExposedScientificDetector(pipsDetector_);
-		removeDefaultScanDetector(pipsDetector_);
-		removeScanDetectorOption(pipsDetector_);
-
-		hasPIPSDetector_ = false;
-		result = true;
+		if (detectorRemoved)
+			hasPIPSDetector_ = false;
 
 		emit pipsDetectorChanged(0);
 	}
 
-	return result;
+	return detectorRemoved;
 }
 
 bool BioXASSideBeamline::addLytleDetector()
 {
-	bool result = false;
+	bool detectorAdded = false;
 
 	if (canHaveLytleDetector() && !hasLytleDetector_) {
 
@@ -334,44 +310,32 @@ bool BioXASSideBeamline::addLytleDetector()
 
 		// Add Lytle.
 
-		scaler_->channelAt(19)->setCustomChannelName("Lytle");
-		scaler_->channelAt(19)->setDetector(lytleDetector_);
+		detectorAdded = addScalerChannelDetector(scaler_, 19, "Lytle", lytleDetector_);
 
-		addExposedDetector(lytleDetector_);
-		addExposedScientificDetector(lytleDetector_);
-		addDefaultScanDetector(lytleDetector_);
-		addScanDetectorOption(lytleDetector_);
-
-		hasLytleDetector_ = true;
-		result = true;
+		if (detectorAdded)
+			hasLytleDetector_ = true;
 
 		emit lytleDetectorChanged(lytleDetector_);
 	}
 
-	return result;
+	return detectorAdded;
 }
 
 bool BioXASSideBeamline::removeLytleDetector()
 {
-	bool result = false;
+	bool detectorRemoved = false;
 
 	if (hasLytleDetector_) {
 
-		scaler_->channelAt(19)->setCustomChannelName("");
-		scaler_->channelAt(19)->setDetector(0);
+		detectorRemoved = removeScalerChannelDetector(scaler_, 19);
 
-		removeExposedDetector(lytleDetector_);
-		removeExposedScientificDetector(lytleDetector_);
-		removeDefaultScanDetector(lytleDetector_);
-		removeScanDetectorOption(lytleDetector_);
-
-		hasLytleDetector_ = false;
-		result = true;
+		if (detectorRemoved)
+			hasLytleDetector_ = false;
 
 		emit lytleDetectorChanged(0);
 	}
 
-	return result;
+	return detectorRemoved;
 }
 
 void BioXASSideBeamline::setupComponents()
@@ -575,57 +539,42 @@ void BioXASSideBeamline::setupComponents()
 	i0Keithley_ = new CLSKeithley428("AMP1607-601", "AMP1607-601", this);
 	connect( i0Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
 
+	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
+	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
+
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i0Detector_);
-	addExposedScientificDetector(i0Detector_);
-	addDefaultScanDetector(i0Detector_);
-	addScanDetectorOption(i0Detector_);
-
-	scaler_->channelAt(16)->setCustomChannelName("I0 Channel");
-	scaler_->channelAt(16)->setCurrentAmplifier(i0Keithley_);
-	scaler_->channelAt(16)->setDetector(i0Detector_);
-	scaler_->channelAt(16)->setVoltagRange(0.1, 9.5);
-	scaler_->channelAt(16)->setCountsVoltsSlopePreference(0.00001);
+	addScalerChannelDetector(scaler_, 16, "I0 Channel", i0Detector_);
 
 	// I1 channel.
 
 	i1Keithley_ = new CLSKeithley428("AMP1607-602", "AMP1607-602", this);
 	connect( i1Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
 
+	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
+	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
+
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i1Detector_);
-	addExposedScientificDetector(i1Detector_);
-	addDefaultScanDetector(i1Detector_);
-	addScanDetectorOption(i1Detector_);
-
-	scaler_->channelAt(17)->setCustomChannelName("I1 Channel");
-	scaler_->channelAt(17)->setCurrentAmplifier(i1Keithley_);
-	scaler_->channelAt(17)->setDetector(i1Detector_);
-	scaler_->channelAt(17)->setVoltagRange(0.1, 9.5);
-	scaler_->channelAt(17)->setCountsVoltsSlopePreference(0.00001);
+	addScalerChannelDetector(scaler_, 17, "I1 Channel", i1Detector_);
 
 	// I2 channel.
 
 	i2Keithley_ = new CLSKeithley428("AMP1607-603", "AMP1607-603", this);
 	connect( i2Keithley_, SIGNAL(isConnected(bool)), this, SLOT(updateConnected()) );
 
+	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
+	scaler_->channelAt(18)->setVoltagRange(0.1, 9.5);
+	scaler_->channelAt(18)->setCountsVoltsSlopePreference(0.00001);
+
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
-	addExposedDetector(i2Detector_);
-	addExposedScientificDetector(i2Detector_);
-	addDefaultScanDetector(i2Detector_);
-	addScanDetectorOption(i2Detector_);
-
-	scaler_->channelAt(18)->setCustomChannelName("I2 Channel");
-	scaler_->channelAt(18)->setCurrentAmplifier(i2Keithley_);
-	scaler_->channelAt(18)->setDetector(i2Detector_);
-	scaler_->channelAt(18)->setVoltagRange(0.1, 9.5);
-	scaler_->channelAt(18)->setCountsVoltsSlopePreference(0.00001);
+	addScalerChannelDetector(scaler_, 18, "I2 Channel", i2Detector_);
 
 	// 'Misc' channel.
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -472,6 +472,11 @@ void BioXASSideBeamline::setupComponents()
 	i0Detector_ = new CLSBasicScalerChannelDetector("I0Detector", "I0", scaler_, 16, this);
 	connect( i0Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i0Detector_);
+	addExposedScientificDetector(i0Detector_);
+	addDefaultScanDetector(i0Detector_);
+	addScanDetectorOption(i0Detector_);
+
 	scaler_->addChannelDetector(16, "I0 Channel", i0Detector_);
 
 	// I1 channel.
@@ -486,6 +491,11 @@ void BioXASSideBeamline::setupComponents()
 	i1Detector_ = new CLSBasicScalerChannelDetector("I1Detector", "I1", scaler_, 17, this);
 	connect( i1Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	addExposedDetector(i1Detector_);
+	addExposedScientificDetector(i1Detector_);
+	addDefaultScanDetector(i1Detector_);
+	addScanDetectorOption(i1Detector_);
+
 	scaler_->addChannelDetector(17, "I1 Channel", i1Detector_);
 
 	// I2 channel.
@@ -499,6 +509,11 @@ void BioXASSideBeamline::setupComponents()
 
 	i2Detector_ = new CLSBasicScalerChannelDetector("I2Detector", "I2", scaler_, 18, this);
 	connect( i2Detector_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
+
+	addExposedDetector(i2Detector_);
+	addExposedScientificDetector(i2Detector_);
+	addDefaultScanDetector(i2Detector_);
+	addScanDetectorOption(i2Detector_);
 
 	scaler_->addChannelDetector(18, "I2 Channel", i2Detector_);
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -98,6 +98,8 @@ public:
 	CLSKeithley428* i1Keithley() const { return i1Keithley_; }
 	/// Returns the I2 Keithley 428 amplifier.
 	CLSKeithley428* i2Keithley() const { return i2Keithley_; }
+	/// Returns the 'misc' Keithley 428 amplifier.
+	CLSKeithley428* miscKeithley() const { return miscKeithley_; }
 
 	/// Returns the lateral detector stage motor.
 	virtual CLSMAXvMotor* detectorStageLateralMotor() const { return detectorStageLateral_; }
@@ -115,19 +117,11 @@ public:
 	virtual BioXAS32ElementGeDetector *ge32ElementDetector() const { return ge32ElementDetector_; }
 
 	/// Returns true if this beamline can have a diode detector.
-	virtual bool canHaveDiodeDetector() const { return true; }
-	/// Returns the diode detector.
-	virtual CLSBasicScalerChannelDetector* diodeDetector() const;
-
+	virtual bool canUseDiodeDetector() const { return true; }
 	/// Returns true if this beamline can have a PIPS detector.
-	virtual bool canHavePIPSDetector() const { return true; }
-	/// Returns the PIPS detector.
-	virtual CLSBasicScalerChannelDetector* pipsDetector() const;
-
+	virtual bool canUsePIPSDetector() const { return true; }
 	/// Returns true if this beamline can have a Lytle detector.
-	virtual bool canHaveLytleDetector() const { return true; }
-	/// Returns the Lytle detector.
-	virtual CLSBasicScalerChannelDetector* lytleDetector() const;
+	virtual bool canUseLytleDetector() const { return true; }
 
 	/// Returns the zebra control box.
 	virtual BioXASZebra *zebra() const { return zebra_; }
@@ -151,20 +145,12 @@ public:
 signals:
 
 public slots:
-	/// Adds the diode detector. Returns true if successful, false otherwise.
-	virtual bool addDiodeDetector();
-	/// Removes the diode detector. Returns true if successful, false otherwise.
-	virtual bool removeDiodeDetector();
-
-	/// Adds the PIPS detector. Returns true if successful, false otherwise.
-	virtual bool addPIPSDetector();
-	/// Removes the PIPS detector. Returns true if successful, false otherwise.
-	virtual bool removePIPSDetector();
-
-	/// Adds the Lytle detector. Returns true if successful, false otherwise.
-	virtual bool addLytleDetector();
-	/// Removes the Lytle detector. Returns true if successful, false otherwise.
-	virtual bool removeLytleDetector();
+	/// Adds or removes the diode detector. Returns true if successful, false otherwise.
+	virtual bool useDiodeDetector(bool useDetector);
+	/// Adds or removes the PIPS detector. Returns true if successful, false otherwise.
+	virtual bool usePIPSDetector(bool useDetector);
+	/// Adds or removes the Lytle detector. Returns true if successful, false otherwise.
+	virtual bool useLytleDetector(bool useDetector);
 
 protected:
 	/// Sets up various beamline components.
@@ -237,21 +223,6 @@ protected:
 	CLSBasicScalerChannelDetector *i2Detector_;
 	/// Ge 32-el detector
 	BioXAS32ElementGeDetector *ge32ElementDetector_;
-
-	/// Flag indicating whether the beamline has a diode detector.
-	bool hasDiodeDetector_;
-	/// Diode detector.
-	CLSBasicScalerChannelDetector *diodeDetector_;
-
-	/// Flad indicating whether the beamline has a PIPS detector.
-	bool hasPIPSDetector_;
-	/// PIPS detector.
-	CLSBasicScalerChannelDetector *pipsDetector_;
-
-	/// Flag indicating whether the beamline has a Lytle detector.
-	bool hasLytleDetector_;
-	/// Lytle Detector.
-	CLSBasicScalerChannelDetector *lytleDetector_;
 
 	// Zebra
 	/// Zebra trigger control.

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -106,28 +106,28 @@ public:
 	QList<AMControl *> getMotorsByType(BioXASBeamlineDef::BioXASMotorType category) const;
 
 	/// Returns the I0 scaler channel detector.
-	virtual AMDetector* i0Detector() const { return i0Detector_; }
+	virtual CLSBasicScalerChannelDetector* i0Detector() const { return i0Detector_; }
 	/// Returns the I1 scaler channel detector.
-	virtual AMDetector* i1Detector() const { return i1Detector_; }
+	virtual CLSBasicScalerChannelDetector* i1Detector() const { return i1Detector_; }
 	/// Returns the I2 scaler channel detector.
-	virtual AMDetector* i2Detector() const { return i2Detector_; }
+	virtual CLSBasicScalerChannelDetector* i2Detector() const { return i2Detector_; }
 	/// Returns the 32 element Ge detector.
 	virtual BioXAS32ElementGeDetector *ge32ElementDetector() const { return ge32ElementDetector_; }
 
 	/// Returns true if this beamline can have a diode detector.
 	virtual bool canHaveDiodeDetector() const { return true; }
 	/// Returns the diode detector.
-	virtual AMDetector* diodeDetector() const;
+	virtual CLSBasicScalerChannelDetector* diodeDetector() const;
 
 	/// Returns true if this beamline can have a PIPS detector.
 	virtual bool canHavePIPSDetector() const { return true; }
 	/// Returns the PIPS detector.
-	virtual AMDetector* pipsDetector() const;
+	virtual CLSBasicScalerChannelDetector* pipsDetector() const;
 
 	/// Returns true if this beamline can have a Lytle detector.
 	virtual bool canHaveLytleDetector() const { return true; }
 	/// Returns the Lytle detector.
-	virtual AMDetector* lytleDetector() const;
+	virtual CLSBasicScalerChannelDetector* lytleDetector() const;
 
 	/// Returns the zebra control box.
 	virtual BioXASZebra *zebra() const { return zebra_; }

--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -405,6 +405,36 @@ void CLSSIS3820Scaler::trigger(AMDetectorDefinitions::ReadMode readMode)
 	}
 }
 
+bool CLSSIS3820Scaler::addChannelDetector(int channelIndex, const QString &channelName, AMDetector *detector)
+{
+	bool result = false;
+
+	CLSSIS3820ScalerChannel *channel = channelAt(channelIndex);
+
+	if (channel) {
+		channel->setCustomChannelName(channelName);
+		channel->setDetector(detector);
+		result = true;
+	}
+
+	return result;
+}
+
+bool CLSSIS3820Scaler::removeChannelDetector(int channelIndex)
+{
+	bool result = false;
+
+	CLSSIS3820ScalerChannel *channel = channelAt(channelIndex);
+
+	if (channel) {
+		channel->setCustomChannelName("");
+		channel->setDetector(0);
+		result = true;
+	}
+
+	return result;
+}
+
 void CLSSIS3820Scaler::onScanningToggleChanged(){
 
 	if(!isConnected())

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -150,6 +150,11 @@ public slots:
 	/// Triggers a scaler acquisition.
 	virtual void trigger(AMDetectorDefinitions::ReadMode readMode);
 
+	/// Adds a detector to the channel at the given index, setting the channel name too. Returns true if successful, false otherwise.
+	bool addChannelDetector(int channelIndex, const QString &channelName, AMDetector *detector);
+	/// Removes a detector from the channel at the given index, clearing the channel name too. Returns true if successful, false otherwise.
+	bool removeChannelDetector(int channelIndex);
+
 signals:
 	/// Notifier that the scanning flag has changed.  Returns the new state.
 	void scanningChanged(bool isScanning);

--- a/source/ui/BioXAS/BioXASBeamlineConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASBeamlineConfigurationView.cpp
@@ -39,9 +39,9 @@ BioXASBeamlineConfigurationView::BioXASBeamlineConfigurationView(QWidget *parent
 
 	// Make beamline connections.
 
-	connect( BioXASBeamline::bioXAS(), SIGNAL(diodeDetectorChanged(AMDetector*)), this, SLOT(refresh()) );
-	connect( BioXASBeamline::bioXAS(), SIGNAL(pipsDetectorChanged(AMDetector*)), this, SLOT(refresh()) );
-	connect( BioXASBeamline::bioXAS(), SIGNAL(lytleDetectorChanged(AMDetector*)), this, SLOT(refresh()) );
+	connect( BioXASBeamline::bioXAS(), SIGNAL(usingDiodeDetectorChanged(bool)), this, SLOT(refresh()) );
+	connect( BioXASBeamline::bioXAS(), SIGNAL(usingPIPSDetectorChanged(bool)), this, SLOT(refresh()) );
+	connect( BioXASBeamline::bioXAS(), SIGNAL(usingLytleDetectorChanged(bool)), this, SLOT(refresh()) );
 
 	// Current settings.
 
@@ -68,7 +68,7 @@ void BioXASBeamlineConfigurationView::updateNoneButton()
 
 	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
 
-	if (!beamline->diodeDetector() && !beamline->pipsDetector() && !beamline->lytleDetector()) {
+	if (!beamline->usingDiodeDetector() && !beamline->usingPIPSDetector() && !beamline->usingLytleDetector()) {
 		extraChannelDetectorsButtonGroup_->blockSignals(true);
 		noneButton_->setChecked(true);
 		extraChannelDetectorsButtonGroup_->blockSignals(false);
@@ -90,10 +90,10 @@ void BioXASBeamlineConfigurationView::updateDiodeButton()
 
 	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
 
-	if (beamline->canHaveDiodeDetector()) {
+	if (beamline->canUseDiodeDetector()) {
 		diodeButton_->setEnabled(true);
 
-		if (beamline->diodeDetector()) {
+		if (beamline->usingDiodeDetector()) {
 			extraChannelDetectorsButtonGroup_->blockSignals(true);
 			diodeButton_->setChecked(true);
 			extraChannelDetectorsButtonGroup_->blockSignals(false);
@@ -116,10 +116,10 @@ void BioXASBeamlineConfigurationView::updatePIPSButton()
 
 	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
 
-	if (beamline->canHavePIPSDetector()) {
+	if (beamline->canUsePIPSDetector()) {
 		pipsButton_->setEnabled(true);
 
-		if (beamline->pipsDetector()) {
+		if (beamline->usingPIPSDetector()) {
 			extraChannelDetectorsButtonGroup_->blockSignals(true);
 			pipsButton_->setChecked(true);
 			extraChannelDetectorsButtonGroup_->blockSignals(false);
@@ -142,10 +142,10 @@ void BioXASBeamlineConfigurationView::updateLytleButton()
 
 	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
 
-	if (beamline->canHaveLytleDetector()) {
+	if (beamline->canUseLytleDetector()) {
 		lytleButton_->setEnabled(true);
 
-		if (beamline->lytleDetector()) {
+		if (beamline->usingLytleDetector()) {
 			extraChannelDetectorsButtonGroup_->blockSignals(true);
 			lytleButton_->setChecked(true);
 			extraChannelDetectorsButtonGroup_->blockSignals(false);
@@ -158,19 +158,17 @@ void BioXASBeamlineConfigurationView::onButtonClicked(int buttonIndex)
 	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
 
 	if (buttonIndex == BIOXASBEAMLINECONFIGURATIONVIEW_NONE_BUTTON_INDEX) {
-		beamline->removeDiodeDetector();
-		beamline->removePIPSDetector();
-		beamline->removeLytleDetector();
+		beamline->useDiodeDetector(false);
+		beamline->usePIPSDetector(false);
+		beamline->useLytleDetector(false);
 
 	} else if (buttonIndex == BIOXASBEAMLINECONFIGURATIONVIEW_DIODE_BUTTON_INDEX) {
-		beamline->addDiodeDetector();
+		beamline->useDiodeDetector(true);
 
 	} else if (buttonIndex == BIOXASBEAMLINECONFIGURATIONVIEW_PIPS_BUTTON_INDEX) {
-		beamline->addPIPSDetector();
+		beamline->usePIPSDetector(true);
 
 	} else if (buttonIndex == BIOXASBEAMLINECONFIGURATIONVIEW_LYTLE_BUTTON_INDEX) {
-		beamline->addLytleDetector();
+		beamline->useLytleDetector(true);
 	}
-
-	refresh();
 }


### PR DESCRIPTION
- Added convenience methods to CLSSIS3820Scaler for adding and removing a scaler channel detector.
- Added the diode, PIPS, and Lytle channel detectors as class variables of BioXASBeamline.
- Added protected setters for the diode, PIPS, Lytle channel detectors to BioXASBeamline, and calls in BioXASSideBeamline and BioXASMainBeamline.
- Added public getters for each detector, whether the beamline can use each detector, and whether the beamline is currently using each detector to BioXASBeamline. BioXASSideBeamline and BioXASMainBeamline reimplement as necessary.
- Added public slot to BioXASBeamline, for telling the beamline to use a particular detector.