### PR TITLE
Pull Request for Issue2139: Selectable cryostat

### DIFF
--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -347,6 +347,14 @@ AMBasicControlDetectorEmulator* BioXASBeamline::detectorForControl(AMControl *co
 	return controlDetectorMap_.value(control, 0);
 }
 
+void BioXASBeamline::useCryostat(bool useCryostat)
+{
+	if (useCryostat && canUseCryostat() && cryostat())
+		setUsingCryostat(true);
+	else if (!useCryostat)
+		setUsingCryostat(false);
+}
+
 bool BioXASBeamline::addDetectorStageLateralMotor(CLSMAXvMotor *newMotor)
 {
 	bool result = false;
@@ -605,6 +613,14 @@ void BioXASBeamline::clearFlowTransducers()
 {
 	if (utilities_)
 		utilities_->clearFlowTransducers();
+}
+
+void BioXASBeamline::setUsingCryostat(bool usingCryostat)
+{
+	if (usingCryostat_ != usingCryostat) {
+		usingCryostat_ = usingCryostat;
+		emit usingCryostatChanged(usingCryostat_);
+	}
 }
 
 bool BioXASBeamline::addDetectorElement(AMDetector *detector, AMDetector *element)
@@ -967,6 +983,8 @@ BioXASBeamline::BioXASBeamline(const QString &controlName) :
 
 	beamStatus_ = 0;
 	utilities_ = 0;
+
+	usingCryostat_ = false;
 
 	// Setup procedures.
 

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -137,6 +137,11 @@ public:
 	virtual BioXASFastShutter* fastShutter() const { return 0; }
 	/// Returns the detector stage control.
 	virtual AMControlSet* detectorStageLateralMotors() const { return detectorStageLateralMotors_; }
+
+	/// Returns true if this beamline can use a cryostat, false otherwise.
+	virtual bool canUseCryostat() const { return false; }
+	/// Returns the flag indicating whether this beamline is currently using the cryostat.
+	bool usingCryostat() const { return usingCryostat_; }
 	/// Returns the cryostat.
 	virtual BioXASCryostat* cryostat() const { return 0; }
 
@@ -190,6 +195,8 @@ public:
 signals:
 	/// Notifier that the current connected state has changed.
 	void connectedChanged(bool isConnected);
+	/// Notifier that the flag indicating whether this beamline is using the cryostat has changed.
+	void usingCryostatChanged(bool usingCryostat);
 	/// Notifier that the detector stage lateral motors list has changed.
 	void detectorStageLateralMotorsChanged();
 	/// Notifier that the 32Ge detectors have changed.
@@ -202,6 +209,9 @@ signals:
 	void lytleDetectorChanged(AMDetector *newDetector);
 
 public slots:
+	/// Sets whether the beamline is using the cryostat.
+	void useCryostat(bool useCryostat);
+
 	/// Adds a detector stage lateral motor.
 	bool addDetectorStageLateralMotor(CLSMAXvMotor *newMotor);
 	/// Removes a detector stage lateral motor.
@@ -293,6 +303,9 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
+	/// Sets whether the beamline is using the cryostat.
+	void setUsingCryostat(bool usingCryostat);
+
 	/// Adds an element to the set of elements for the given detector.
 	bool addDetectorElement(AMDetector *detector, AMDetector *element);
 	/// Removes an element from the set of elements for the given detector.
@@ -336,6 +349,10 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
+
+	/// Flag indicating whether this beamline is using the cryostat.
+	bool usingCryostat_;
+
 	/// The set of detector stage motors.
 	AMControlSet *detectorStageLateralMotors_;
 	/// The 32Ge detectors.

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -512,6 +512,8 @@ void BioXASSideBeamline::setupComponents()
 	cryostat_ = new BioXASSideCryostat("BioXASSideCryostat", this);
 	connect( cryostat_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
+	setUsingCryostat(true); // We want to have Side using the cryostat by default.
+
 	// Zebra.
 
 	zebra_ = new BioXASZebra("TRG1607-601", this);

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -87,6 +87,9 @@ public:
 	virtual BioXASSideFilterFlipper* filterFlipper() const { return filterFlipper_; }
 	/// Returns the Soller slit.
 	virtual BioXASSollerSlit* sollerSlit() const { return sollerSlit_; }
+
+	/// Returns true if this beamline can use a cryostat, false otherwise.
+	virtual bool canUseCryostat() const { return true; }
 	/// Returns the cryostat.
 	virtual BioXASSideCryostat* cryostat() const { return cryostat_; }
 

--- a/source/ui/BioXAS/BioXASBeamlineConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASBeamlineConfigurationView.cpp
@@ -4,10 +4,22 @@
 BioXASBeamlineConfigurationView::BioXASBeamlineConfigurationView(QWidget *parent) :
     QWidget(parent)
 {
-	extraChannelDetectorsButtonGroup_ = new QButtonGroup(this);
-	connect( extraChannelDetectorsButtonGroup_, SIGNAL(buttonClicked(int)), this, SLOT(onButtonClicked(int)) );
+	// Create the cryostat options view.
+
+	QVBoxLayout *cryostatBoxLayout = new QVBoxLayout();
+
+	cryostatButton_ = new QCheckBox("Use cryostat");
+	cryostatBoxLayout->addWidget(cryostatButton_);
+
+	QGroupBox *cryostatBox = new QGroupBox("Cryostat");
+	cryostatBox->setLayout(cryostatBoxLayout);
+
+	connect( cryostatButton_, SIGNAL(clicked(bool)), this, SLOT(onCryostatButtonClicked()) );
 
 	// Create the optional detectors view.
+
+	extraChannelDetectorsButtonGroup_ = new QButtonGroup(this);
+	connect( extraChannelDetectorsButtonGroup_, SIGNAL(buttonClicked(int)), this, SLOT(onChannelDetectorButtonClicked(int)) );
 
 	QVBoxLayout *extraChannelDetectorsLayout = new QVBoxLayout();
 
@@ -33,11 +45,14 @@ BioXASBeamlineConfigurationView::BioXASBeamlineConfigurationView(QWidget *parent
 	// Create and set main layout.
 
 	QVBoxLayout *layout = new QVBoxLayout();
+	layout->addWidget(cryostatBox);
 	layout->addWidget(extraChannelDetectorsBox);
 
 	setLayout(layout);
 
 	// Make beamline connections.
+
+	connect( BioXASBeamline::bioXAS(), SIGNAL(usingCryostatChanged(bool)), this, SLOT(updateCryostatButton()) );
 
 	connect( BioXASBeamline::bioXAS(), SIGNAL(diodeDetectorChanged(AMDetector*)), this, SLOT(refresh()) );
 	connect( BioXASBeamline::bioXAS(), SIGNAL(pipsDetectorChanged(AMDetector*)), this, SLOT(refresh()) );
@@ -55,10 +70,38 @@ BioXASBeamlineConfigurationView::~BioXASBeamlineConfigurationView()
 
 void BioXASBeamlineConfigurationView::refresh()
 {
+	updateCryostatButton();
+
 	updateNoneButton();
 	updateDiodeButton();
 	updatePIPSButton();
 	updateLytleButton();
+}
+
+void BioXASBeamlineConfigurationView::updateCryostatButton()
+{
+	// Uncheck and disable the button.
+
+	cryostatButton_->blockSignals(true);
+	cryostatButton_->setChecked(false);
+	cryostatButton_->blockSignals(false);
+
+	cryostatButton_->setEnabled(false);
+
+	// Enable the button if the beamlin can use a cryostat, and check it if
+	// the beamline has one.
+
+	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
+
+	if (beamline->canUseCryostat()) {
+		cryostatButton_->setEnabled(true);
+
+		if (beamline->usingCryostat()) {
+			cryostatButton_->blockSignals(true);
+			cryostatButton_->setChecked(true);
+			cryostatButton_->blockSignals(false);
+		}
+	}
 }
 
 void BioXASBeamlineConfigurationView::updateNoneButton()
@@ -153,7 +196,12 @@ void BioXASBeamlineConfigurationView::updateLytleButton()
 	}
 }
 
-void BioXASBeamlineConfigurationView::onButtonClicked(int buttonIndex)
+void BioXASBeamlineConfigurationView::onCryostatButtonClicked()
+{
+	BioXASBeamline::bioXAS()->useCryostat(cryostatButton_->isChecked());
+}
+
+void BioXASBeamlineConfigurationView::onChannelDetectorButtonClicked(int buttonIndex)
 {
 	BioXASBeamline *beamline = BioXASBeamline::bioXAS();
 

--- a/source/ui/BioXAS/BioXASBeamlineConfigurationView.h
+++ b/source/ui/BioXAS/BioXASBeamlineConfigurationView.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include <QGroupBox>
+#include <QCheckBox>
 #include <QButtonGroup>
 #include <QRadioButton>
 #include <QLayout>
@@ -27,6 +28,9 @@ public slots:
 	void refresh();
 
 protected slots:
+	/// Updates the cryostat button.
+	void updateCryostatButton();
+
 	/// Updates the none button.
 	void updateNoneButton();
 	/// Updates the diode button.
@@ -36,12 +40,17 @@ protected slots:
 	/// Updates the Lytle button.
 	void updateLytleButton();
 
+	/// Handles updating the beamline with the cryostat button selection.
+	void onCryostatButtonClicked();
 	/// Handles updating the beamline with the current extra detector selection.
-	void onButtonClicked(int buttonIndex);
+	void onChannelDetectorButtonClicked(int buttonIndex);
 
 protected:
 	/// The button group for the optional detectors.
 	QButtonGroup *extraChannelDetectorsButtonGroup_;
+
+	/// The cryostat button.
+	QCheckBox *cryostatButton_;
 
 	/// The none button, an extra channel detectors option.
 	QRadioButton *noneButton_;

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -67,19 +67,18 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 
 	// Create the cryostat view.
 
-	BioXASCryostat *cryostat = BioXASBeamline::bioXAS()->cryostat();
-	if (cryostat) {
-		BioXASCryostatView *cryostatView = new BioXASCryostatView(cryostat);
+	cryostatView_ = new BioXASCryostatView(0);
 
-		QVBoxLayout *cryostatBoxLayout = new QVBoxLayout();
-		cryostatBoxLayout->addWidget(cryostatView);
+	QVBoxLayout *cryostatBoxLayout = new QVBoxLayout();
+	cryostatBoxLayout->addWidget(cryostatView_);
 
-		QGroupBox *cryostatBox = new QGroupBox();
-		cryostatBox->setTitle("Cryostat");
-		cryostatBox->setLayout(cryostatBoxLayout);
+	cryostatBox_ = new QGroupBox();
+	cryostatBox_->setTitle("Cryostat");
+	cryostatBox_->setLayout(cryostatBoxLayout);
 
-		layout->addWidget(cryostatBox);
-	}
+	layout->addWidget(cryostatBox_);
+
+	connect( BioXASBeamline::bioXAS(), SIGNAL(usingCryostatChanged(bool)), this, SLOT(updateCryostatBox()) );
 
 	// Create the scaler channels view.
 
@@ -100,9 +99,28 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 	// Add final stretch to the layout, so the widgets appear new the top of the view.
 
 	layout->addStretch();
+
+	// Current settings.
+
+	refresh();
 }
 
 BioXASPersistentView::~BioXASPersistentView()
 {
 
+}
+
+void BioXASPersistentView::refresh()
+{
+	updateCryostatBox();
+}
+
+void BioXASPersistentView::updateCryostatBox()
+{
+	if (BioXASBeamline::bioXAS()->usingCryostat()) {
+		cryostatView_->setControl(BioXASBeamline::bioXAS()->cryostat());
+		cryostatBox_->show();
+	} else {
+		cryostatBox_->hide();
+	}
 }

--- a/source/ui/BioXAS/BioXASPersistentView.h
+++ b/source/ui/BioXAS/BioXASPersistentView.h
@@ -5,6 +5,8 @@
 #include <QLayout>
 #include <QGroupBox>
 
+class BioXASCryostatView;
+
 class BioXASPersistentView : public QWidget
 {
     Q_OBJECT
@@ -14,6 +16,20 @@ public:
 	explicit BioXASPersistentView(QWidget *parent = 0);
 	/// Destructor.
 	virtual ~BioXASPersistentView();
+
+public slots:
+	/// Refreshes the view.
+	void refresh();
+
+protected slots:
+	/// Updates the cryostat box.
+	void updateCryostatBox();
+
+protected:
+	/// The cryostat view.
+	BioXASCryostatView *cryostatView_;
+	/// The cryostat box.
+	QGroupBox *cryostatBox_;
 };
 
 #endif // BIOXASPERSISTENTVIEW_H


### PR DESCRIPTION
Added new option to the beamline configuration view for a user to be able to select whether they use the cryostat. Selecting it causes the cryostat view to show/hide from the persistent view.