### PR TITLE
Pull Request for Issue2128: Adding beam status bar to persistent view.

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -154,6 +154,23 @@ void BioXASAppController::onRegionOfInterestBoundingRangeChanged(AMRegionOfInter
 		xasConfiguration_->setRegionOfInterestBoundingRange(region);
 }
 
+void BioXASAppController::goToBeamStatusView(AMControl *control)
+{
+	if (beamStatusView_) {
+
+		// Set the given control as the view's selected control.
+
+		beamStatusView_->setSelectedComponent(control);
+
+		// Set the beam status pane as the current pane.
+
+		QWidget *windowPane = viewPaneMapping_.value(beamStatusView_, 0);
+
+		if (windowPane)
+			mw_->setCurrentPane(windowPane);
+	}
+}
+
 void BioXASAppController::goToEnergyCalibrationScanConfigurationView()
 {
 	if (energyCalibrationConfigurationView_) {
@@ -279,7 +296,10 @@ void BioXASAppController::setupUserInterface()
 	////////////////////////////////////
 
 	addGeneralView(BioXASBeamline::bioXAS(), "Configuration");
-	addGeneralView(BioXASBeamline::bioXAS()->beamStatus(), "Beam Status");
+
+	beamStatusView_ = new BioXASBeamStatusView(BioXASBeamline::bioXAS()->beamStatus());
+	addViewToGeneralPane(beamStatusView_, "Beam status");
+
 	addGeneralView(BioXASBeamline::bioXAS()->utilities(), "Utilities");
 
 	addComponentView(BioXASBeamline::bioXAS()->carbonFilterFarm(), "Carbon Filter Farm");
@@ -321,7 +341,10 @@ void BioXASAppController::setupUserInterface()
 	// Create persistent view:
 	////////////////////////////////////
 
-	addPersistentView(new BioXASPersistentView());
+	BioXASPersistentView *persistentView = new BioXASPersistentView();
+	connect( persistentView, SIGNAL(beamStatusButtonsSelectedControlChanged(AMControl*)), this, SLOT(goToBeamStatusView(AMControl*)) );
+	addPersistentView(persistentView);
+
 }
 
 void BioXASAppController::setupScanConfigurations()

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -104,9 +104,10 @@ protected slots:
 	/// Handles updating the regions of interest to all the configurations that would care.
 	virtual void onRegionOfInterestBoundingRangeChanged(AMRegionOfInterest *region);
 
+	/// Sets the beam status view as the current view, with the given control as the selected control.
+	void goToBeamStatusView(AMControl *control);
 	/// Sets the monochromator energy calibration scan configuration view as the current pane.
 	void goToEnergyCalibrationScanConfigurationView();
-
 	/// Sets the monochromator energy calibration view as the current pane, and sets the desired scan.
 	void goToEnergyCalibrationView(AMScan *toView);
 
@@ -199,6 +200,9 @@ protected:
 	BioXASUserConfiguration *userConfiguration_;
 	/// Mapping between views and window panes. Used for switching the current pane.
 	QMap<QWidget*, QWidget*> viewPaneMapping_;
+
+	/// The beam status view.
+	BioXASBeamStatusView *beamStatusView_;
 
 	/// The XAS scan configuration.
 	BioXASXASScanConfiguration *xasConfiguration_;

--- a/source/ui/BioXAS/BioXASBeamStatusView.cpp
+++ b/source/ui/BioXAS/BioXASBeamStatusView.cpp
@@ -99,7 +99,7 @@ void BioXASBeamStatusView::setBeamStatus(BioXASBeamStatus *newStatus)
 
 void BioXASBeamStatusView::setSelectedComponent(AMControl *newControl)
 {
-	if (selectedComponent_ != newControl) {
+	if (selectedComponent_ != newControl && beamStatus_->components().contains(newControl)) {
 		selectedComponent_ = newControl;
 
 		buttonBar_->setSelectedControl(selectedComponent_);

--- a/source/ui/BioXAS/BioXASBeamStatusView.h
+++ b/source/ui/BioXAS/BioXASBeamStatusView.h
@@ -37,11 +37,10 @@ public slots:
 
 	/// Sets the beam status being viewed.
 	void setBeamStatus(BioXASBeamStatus *newStatus);
-
-protected slots:
 	/// Sets the selected component.
 	void setSelectedComponent(AMControl *newControl);
 
+protected slots:
 	/// Updates the selected component view.
 	void updateSelectedComponentView();
 

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -22,6 +22,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "beamline/BioXAS/BioXASBeamline.h"
 
+#include "ui/BioXAS/BioXASBeamStatusButtonBar.h"
 #include "ui/BioXAS/BioXASSSRLMonochromatorBasicView.h"
 #include "ui/BioXAS/BioXASControlEditor.h"
 #include "ui/BioXAS/BioXASCryostatView.h"
@@ -36,6 +37,26 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 	layout->setMargin(0);
 
 	setLayout(layout);
+
+	// Create the beam status view.
+
+	BioXASBeamStatus *beamStatus = BioXASBeamline::bioXAS()->beamStatus();
+
+	if (beamStatus) {
+
+		BioXASBeamStatusButtonBar *beamStatusButtons = new BioXASBeamStatusButtonBar(BioXASBeamline::bioXAS()->beamStatus());
+		connect( beamStatusButtons, SIGNAL(selectedControlChanged(AMControl*)), this, SIGNAL(beamStatusButtonsSelectedControlChanged(AMControl*)) );
+
+		QHBoxLayout *beamStatusBoxLayout = new QHBoxLayout();
+		beamStatusBoxLayout->addStretch();
+		beamStatusBoxLayout->addWidget(beamStatusButtons);
+		beamStatusBoxLayout->addStretch();
+
+		QGroupBox *beamStatusBox = new QGroupBox("Beam status");
+		beamStatusBox->setLayout(beamStatusBoxLayout);
+
+		layout->addWidget(beamStatusBox);
+	}
 
 	// Create mono view.
 

--- a/source/ui/BioXAS/BioXASPersistentView.h
+++ b/source/ui/BioXAS/BioXASPersistentView.h
@@ -5,6 +5,7 @@
 #include <QLayout>
 #include <QGroupBox>
 
+class AMControl;
 class BioXASCryostatView;
 
 class BioXASPersistentView : public QWidget
@@ -16,6 +17,10 @@ public:
 	explicit BioXASPersistentView(QWidget *parent = 0);
 	/// Destructor.
 	virtual ~BioXASPersistentView();
+
+signals:
+	/// Notifier that the selected control in the beam status buttons view has changed.
+	void beamStatusButtonsSelectedControlChanged(AMControl *control);
 
 public slots:
 	/// Refreshes the view.


### PR DESCRIPTION
Added an instance of the BioXASBeamStatusButtonBar to BioXASPersistentView. The view now emits a signal when the selected control in the button bar changes. Modified the app controller to listen for this signal and change the current pane to the main beam status view in response. It additionally sets the current control to the newly selected control too.