### PR TITLE
Pull Request for Issue2151: Xspress3 detector bad first point

### DIFF
--- a/source/beamline/AMXspress3XRFDetector.cpp
+++ b/source/beamline/AMXspress3XRFDetector.cpp
@@ -198,8 +198,7 @@ void AMXspress3XRFDetector::makeConnections()
 
 	connect(allControls_, SIGNAL(connected(bool)), this, SLOT(updateAcquisitionState()));
 
-	foreach (AMControl *control, spectraControls_)
-		connect(control, SIGNAL(valueChanged(double)), this, SLOT(onDataChanged()));
+	connect(dataSource()->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onDataChanged()));
 }
 
 void AMXspress3XRFDetector::onDataChanged()

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -107,14 +107,11 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 
 					AMListAction3 *geDetectorInitialization = new AMListAction3(new AMListActionInfo3("BioXAS Xpress3 initialization", "BioXAS Xpress3 initialization"));
 					geDetectorInitialization->addSubAction(geDetector->createDisarmAction());
-					geDetectorInitialization->addSubAction(geDetector->createFramesPerAcquisitionAction(int(configuration->scanAxisAt(0)->numberOfPoints()*1.1)));	// Adding 10% just because.
+					geDetectorInitialization->addSubAction(geDetector->createFramesPerAcquisitionAction(int(configuration->scanAxisAt(0)->numberOfPoints()*1.1+2)));	// Adding 10% just because.
 					geDetectorInitialization->addSubAction(geDetector->createInitializationAction());
 
 					AMDetectorWaitForAcquisitionStateAction *waitAction = new AMDetectorWaitForAcquisitionStateAction(new AMDetectorWaitForAcquisitionStateActionInfo(geDetector->toInfo(), AMDetector::ReadyForAcquisition), geDetector);
 					geDetectorInitialization->addSubAction(waitAction);
-
-					AMDetectorTriggerAction *triggerAction = new AMDetectorTriggerAction(new AMDetectorTriggerActionInfo(geDetector->toInfo()));
-					geDetectorInitialization->addSubAction(triggerAction);
 
 					geDetectorsInitialization->addSubAction(geDetectorInitialization);
 				}
@@ -138,6 +135,9 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 			if (braggMotor) {
 				monoInitialization = new AMListAction3(new AMListActionInfo3("BioXAS SSRL monochromator initialization", "BioXAS SSRL monochromator initialization"));
 				monoInitialization->addSubAction(braggMotor->createPowerAction(CLSMAXvMotor::PowerOn));
+
+//				monoInitialization->addSubAction(AMActionSupport::buildControlMoveAction(mono->energy(), double(configuration->scanAxisAt(0)->regionAt(0)->regionStart()) - 200));
+//				monoInitialization->addSubAction(AMActionSupport::buildWaitAction(2));
 			}
 		}
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -107,7 +107,7 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 
 					AMListAction3 *geDetectorInitialization = new AMListAction3(new AMListActionInfo3("BioXAS Xpress3 initialization", "BioXAS Xpress3 initialization"));
 					geDetectorInitialization->addSubAction(geDetector->createDisarmAction());
-					geDetectorInitialization->addSubAction(geDetector->createFramesPerAcquisitionAction(int(configuration->scanAxisAt(0)->numberOfPoints()*1.1+2)));	// Adding 10% just because.
+					geDetectorInitialization->addSubAction(geDetector->createFramesPerAcquisitionAction(int(configuration->scanAxisAt(0)->numberOfPoints()*1.1)));	// Adding 10% just because.
 					geDetectorInitialization->addSubAction(geDetector->createInitializationAction());
 
 					AMDetectorWaitForAcquisitionStateAction *waitAction = new AMDetectorWaitForAcquisitionStateAction(new AMDetectorWaitForAcquisitionStateActionInfo(geDetector->toInfo(), AMDetector::ReadyForAcquisition), geDetector);
@@ -135,9 +135,6 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 			if (braggMotor) {
 				monoInitialization = new AMListAction3(new AMListActionInfo3("BioXAS SSRL monochromator initialization", "BioXAS SSRL monochromator initialization"));
 				monoInitialization->addSubAction(braggMotor->createPowerAction(CLSMAXvMotor::PowerOn));
-
-//				monoInitialization->addSubAction(AMActionSupport::buildControlMoveAction(mono->energy(), double(configuration->scanAxisAt(0)->regionAt(0)->regionStart()) - 200));
-//				monoInitialization->addSubAction(AMActionSupport::buildWaitAction(2));
 			}
 		}
 


### PR DESCRIPTION
- Removed the extra detector trigger that was added to scan initialization in #2043. 
- Modified AMXspress3XRFDetector. Instead of listening to the spectra controls' `valueChanged(double)` signal and setting the acquisition state accordingly, the detector now listens to the data source signal source.