### PR TITLE
Pull Request for Issue2156: Add scaler dwell time detector to scans automatically

### DIFF
--- a/source/application/BioXAS/BioXASMainAppController.cpp
+++ b/source/application/BioXAS/BioXASMainAppController.cpp
@@ -77,39 +77,3 @@ bool BioXASMainAppController::setupDataFolder()
 {
 	return AMChooseDataFolderDialog::getDataFolder("/AcquamanLocalData/bioxas-m/AcquamanMainData", "/home/bioxas-m/AcquamanMainData", "users", QStringList());
 }
-
-void BioXASMainAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *configuration)
-{
-	// Start with default XAS settings.
-
-	BioXASAppController::setupXASScanConfiguration(configuration);
-
-	if (configuration) {
-
-		// Set the configuration detectors.
-
-		AMDetector *energySetpoint = BioXASMainBeamline::bioXAS()->energySetpointDetector();
-		if (energySetpoint)
-			configuration->addDetector(energySetpoint->toInfo());
-
-		AMDetector *encoderEnergyFeedback = BioXASMainBeamline::bioXAS()->encoderEnergyFeedbackDetector();
-		if (encoderEnergyFeedback && encoderEnergyFeedback->isConnected())
-			configuration->addDetector(encoderEnergyFeedback->toInfo());
-
-		AMDetector *stepEnergyFeedback = BioXASMainBeamline::bioXAS()->stepEnergyFeedbackDetector();
-		if (stepEnergyFeedback && stepEnergyFeedback->isConnected())
-			configuration->addDetector(stepEnergyFeedback->toInfo());
-
-		AMDetector *goniometerAngle = BioXASMainBeamline::bioXAS()->braggDetector();
-		if (goniometerAngle && goniometerAngle->isConnected())
-			configuration->addDetector(goniometerAngle->toInfo());
-
-		AMDetector *goniometerStepSetpoint = BioXASMainBeamline::bioXAS()->braggStepSetpointDetector();
-		if (goniometerStepSetpoint && goniometerStepSetpoint->isConnected())
-			configuration->addDetector(goniometerStepSetpoint->toInfo());
-
-		AMDetector *goniometerEncoderStepFeedback = BioXASMainBeamline::bioXAS()->braggEncoderStepDegFeedbackDetector();
-		if (goniometerEncoderStepFeedback && goniometerEncoderStepFeedback->isConnected())
-			configuration->addDetector(goniometerEncoderStepFeedback->toInfo());
-	}
-}

--- a/source/application/BioXAS/BioXASMainAppController.h
+++ b/source/application/BioXAS/BioXASMainAppController.h
@@ -44,9 +44,6 @@ protected:
 	virtual void setupUserInterface();
 	/// Sets up local and remote data paths.
 	virtual bool setupDataFolder();
-
-	/// Sets up an XAS scan configuration.
-	virtual void setupXASScanConfiguration(BioXASXASScanConfiguration *configuration);
 };
 
 #endif // BIOXASMAINAPPCONTROLLER_H

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -84,31 +84,3 @@ bool BioXASSideAppController::setupDataFolder()
 {
 	return AMChooseDataFolderDialog::getDataFolder("/AcquamanLocalData/bioxas-s/AcquamanSideData", "/home/bioxas-s/AcquamanSideData", "users", QStringList());
 }
-
-void BioXASSideAppController::setupXASScanConfiguration(BioXASXASScanConfiguration *configuration)
-{
-	// Start with default XAS settings.
-
-	BioXASAppController::setupXASScanConfiguration(configuration);
-
-	if (configuration) {
-
-		// Set the configuration detectors.
-
-		AMDetector *encoderEnergyFeedback = BioXASSideBeamline::bioXAS()->encoderEnergyFeedbackDetector();
-		if (encoderEnergyFeedback && encoderEnergyFeedback->isConnected())
-			configuration->addDetector(encoderEnergyFeedback->toInfo());
-
-		AMDetector *stepEnergyFeedback = BioXASSideBeamline::bioXAS()->stepEnergyFeedbackDetector();
-		if (stepEnergyFeedback && stepEnergyFeedback->isConnected())
-			configuration->addDetector(stepEnergyFeedback->toInfo());
-
-		AMDetector *goniometerAngle = BioXASSideBeamline::bioXAS()->braggDetector();
-		if (goniometerAngle && goniometerAngle->isConnected())
-			configuration->addDetector(goniometerAngle->toInfo());
-
-		AMDetector *goniometerStepSetpoint = BioXASSideBeamline::bioXAS()->braggStepSetpointDetector();
-		if (goniometerStepSetpoint && goniometerStepSetpoint->isConnected())
-			configuration->addDetector(goniometerStepSetpoint->toInfo());
-	}
-}

--- a/source/application/BioXAS/BioXASSideAppController.h
+++ b/source/application/BioXAS/BioXASSideAppController.h
@@ -44,9 +44,6 @@ protected:
 	virtual void setupUserInterface();
 	/// Sets up local and remote data paths.
 	virtual bool setupDataFolder();
-
-	/// Sets up an XAS scan configuration.
-	virtual void setupXASScanConfiguration(BioXASXASScanConfiguration *configuration);
 };
 
 #endif // BIOXASSIDEAPPCONTROLLER_H

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -154,34 +154,32 @@ public:
 
 	/// Returns the scaler.
 	virtual CLSSIS3820Scaler* scaler() const { return 0; }
-
 	/// Returns the I0 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i0Detector() const { return 0; }
 	/// Returns the I1 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i1Detector() const { return 0; }
 	/// Returns the I2 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i2Detector() const { return 0; }
-
 	/// Returns true if this beamline can use a diode detector.
 	virtual bool canUseDiodeDetector() const { return false; }
 	/// Returns true if this beamline is using a diode detector.
 	virtual bool usingDiodeDetector() const { return usingDiodeDetector_; }
 	/// Returns the diode detector.
 	virtual CLSBasicScalerChannelDetector* diodeDetector() const { return diodeDetector_; }
-
 	/// Returns true if this beamline can use a PIPS detector.
 	virtual bool canUsePIPSDetector() const { return false; }
 	/// Returns true if this beamline is using the PIPS detector.
 	virtual bool usingPIPSDetector() const { return usingPIPSDetector_; }
 	/// Returns the PIPS detector.
 	virtual CLSBasicScalerChannelDetector* pipsDetector() const { return pipsDetector_; }
-
 	/// Returns true if this beamline can use a Lytle detector.
 	virtual bool canUseLytleDetector() const { return false; }
 	/// Returns true if this beamline is using the Lytle detector.
 	virtual bool usingLytleDetector() const { return usingLytleDetector_; }
 	/// Returns the Lytle detector.
 	virtual CLSBasicScalerChannelDetector* lytleDetector() const { return lytleDetector_; }
+	/// Returns the scaler dwell time detector.
+	virtual AMDetector* scalerDwellTimeDetector() const { return scalerDwellTimeDetector_; }
 
 	/// Returns the 32-element Germanium detector.
 	virtual AMDetectorSet* ge32ElementDetectors() const { return ge32Detectors_; }
@@ -189,9 +187,6 @@ public:
 	virtual BioXASFourElementVortexDetector* fourElementVortexDetector() const { return 0; }
 	/// Returns the elements for the given detector.
 	virtual AMDetectorSet* elementsForDetector(AMDetector *detector) const { return detectorElementsMap_.value(detector, 0); }
-
-	/// Returns the scaler dwell time detector.
-	virtual AMBasicControlDetectorEmulator* scalerDwellTimeDetector() const { return 0; }
 
 	/// Returns the detector for the given control, if one has been created and added to the control/detector map.
 	AMBasicControlDetectorEmulator* detectorForControl(AMControl *control) const;
@@ -227,6 +222,8 @@ signals:
 	void usingLytleDetectorChanged(bool usingDetector);
 	/// Notifier that the Lytle detector has changed.
 	void lytleDetectorChanged(CLSBasicScalerChannelDetector *newDetector);
+	/// Notifier that the scaler dwell time detector has changed.
+	void scalerDwellTimeDetectorChanged(AMDetector *newDetector);
 
 public slots:
 	/// Sets whether the beamline is using the cryostat.
@@ -338,6 +335,9 @@ protected slots:
 	/// Sets the Lytle detector.
 	bool setLytleDetector(CLSBasicScalerChannelDetector *detector);
 
+	/// Sets the scaler dwell time detector.
+	bool setScalerDwellTimeDetector(AMDetector *detector);
+
 	/// Adds an element to the set of elements for the given detector.
 	bool addDetectorElement(AMDetector *detector, AMDetector *element);
 	/// Removes an element from the set of elements for the given detector.
@@ -379,6 +379,9 @@ protected:
 	/// Sets up controls for front end beamline components and/or components that are common to all three BioXAS beamlines.
 	virtual void setupComponents();
 
+	/// Creates and returns a new scaler dwell time detector for the given scaler.
+	virtual AMDetector* createScalerDwellTimeDetector(CLSSIS3820Scaler *scaler);
+
 	/// Creates and returns a control detector emulator for the given control.
 	AMBasicControlDetectorEmulator* createDetectorEmulator(const QString &name, const QString &description, AMControl *control, bool hiddenFromUsers = false, bool isVisible = true);
 	/// Creates a control detector emulator for the given control and adds the pair to the controlDetectorMap.
@@ -413,6 +416,9 @@ protected:
 	bool usingLytleDetector_;
 	/// The Lytle detector.
 	CLSBasicScalerChannelDetector *lytleDetector_;
+
+	/// The scaler dwell time detector.
+	AMDetector *scalerDwellTimeDetector_;
 
 	/// The set of detector stage motors.
 	AMControlSet *detectorStageLateralMotors_;

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -139,11 +139,6 @@ QList<AMControl *> BioXASMainBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 	return matchedMotors;
 }
 
-AMBasicControlDetectorEmulator* BioXASMainBeamline::scalerDwellTimeDetector() const
-{
-	return detectorForControl(scaler_->dwellTimeControl());
-}
-
 AMBasicControlDetectorEmulator* BioXASMainBeamline::energySetpointDetector() const
 {
 	return energySetpointDetector_;
@@ -456,11 +451,14 @@ void BioXASMainBeamline::setupComponents()
 	ge32DetectorInboard_->setTriggerSource(zebraTriggerSource_);
 
 	addGe32Detector(ge32DetectorInboard_);
+
+	// The scaler dwell time detector.
+
+	setScalerDwellTimeDetector(createScalerDwellTimeDetector(scaler_));
 }
 
 void BioXASMainBeamline::setupControlsAsDetectors()
 {
-	addControlAsDetector("ScalerDwellTimeFeedback", "Scaler Dwell Time Feedback", scaler_->dwellTimeControl());
 	addControlAsDetector("MonoEncoderEnergyFeedback", "Encoder-based Energy Feedback", mono_->encoderEnergy());
 	addControlAsDetector("MonoStepEnergyFeedback", "Step-based Energy Feedback", mono_->stepEnergy());
 	addControlAsDetector("MonoStepAngleFeedback", "Step-based Goniometer Angle Feedback", mono_->stepBragg());

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -119,8 +119,6 @@ public:
 	/// Return the set of BioXAS Motors by given motor category.
 	QList<AMControl*> getMotorsByType(BioXASBeamlineDef::BioXASMotorType category);
 
-	/// Returns the scaler dwell time detector.
-	virtual AMBasicControlDetectorEmulator* scalerDwellTimeDetector() const;
 	/// Returns the energy setpoint detector.
 	AMBasicControlDetectorEmulator* energySetpointDetector() const;
 	/// Returns the bragg encoder-based energy feedback detector.

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -151,11 +151,6 @@ QList<AMControl *> BioXASSideBeamline::getMotorsByType(BioXASBeamlineDef::BioXAS
 	return matchedMotors;
 }
 
-AMBasicControlDetectorEmulator* BioXASSideBeamline::scalerDwellTimeDetector() const
-{
-	return detectorForControl(scaler_->dwellTimeControl());
-}
-
 AMBasicControlDetectorEmulator* BioXASSideBeamline::encoderEnergyFeedbackDetector() const
 {
 	return detectorForControl(mono_->encoderEnergy());
@@ -374,6 +369,7 @@ void BioXASSideBeamline::setupComponents()
 	connect( cryostatStage_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// Filter flipper.
+
 	filterFlipper_ = new BioXASSideFilterFlipper(this);
 	connect( filterFlipper_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
@@ -535,6 +531,10 @@ void BioXASSideBeamline::setupComponents()
 
 	addGe32Detector(ge32ElementDetector_);
 
+	// The scaler dwell time detector.
+
+	setScalerDwellTimeDetector(createScalerDwellTimeDetector(scaler_));
+
 	// The fast shutter.
 
 	fastShutter_ = new BioXASFastShutter("BioXASSideFastShutter", this);
@@ -546,7 +546,6 @@ void BioXASSideBeamline::setupComponents()
 
 void BioXASSideBeamline::setupControlsAsDetectors()
 {
-	addControlAsDetector("ScalerDwellTimeFeedback", "Scaler Dwell Time Feedback", scaler_->dwellTimeControl());
 	addControlAsDetector("MonoEncoderEnergyFeedback", "Encoder-based Energy Feedback", mono_->encoderEnergy());
 	addControlAsDetector("MonoStepEnergyFeedback", "Step-based Energy Feedback", mono_->stepEnergy());
 	addControlAsDetector("MonoStepAngleFeedback", "Step-based Goniometer Angle Feedback", mono_->stepBragg());

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -134,8 +134,6 @@ public:
 	/// Returns the fast shutter.
 	virtual BioXASFastShutter* fastShutter() const { return fastShutter_; }
 
-	/// Returns the scaler dwell time detector.
-	virtual AMBasicControlDetectorEmulator* scalerDwellTimeDetector() const;
 	/// Returns the bragg encoder-based energy feedback detector.
 	AMBasicControlDetectorEmulator* encoderEnergyFeedbackDetector() const;
 	/// Returns the bragg step-based energy feedback detector.


### PR DESCRIPTION
BioXASBeamline:
- Added new class variable for the scaler dwell time detector with getter, setter, signal, and entry in BioXASBeamline::isConnected(). Detector is initialized to 0. The setter handles adding/removing the detector from the relevant detector sets (exposedDetectors, defaultXASDetectors, etc).
- Added protected method that creates and returns a new scaler dwell time detector using the given scaler.

BioXASXXXBeamline:
- Removed previous implementation of the scaler dwell time detector, as an entry in a control/detector map.
- Added calls to create and set a new scaler dwell time detector using the new BioXASBeamline methods.