### PR TITLE
Pull Request for Issue2176: Disable additional detector elements for Main inboard detector.

### DIFF
--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
@@ -8,7 +8,7 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 	acquisitionStatusControl_ = new AMReadOnlyPVControl("Status", "PDTR1607-7-I21-01:DetectorState_RBV", this);
 
 	for (int i = 0; i < 32; i++) {
-		if (i != 2 && i != 15 && i != 21 && i != 26) { // Elements 3, 16, 22, and 27 (start 1) are disabled for this detector.
+		if (i != 2 && i != 4 && i != 10 && i != 15 && i != 21 && i != 26) { // Elements 3, 5, 11, 16, 22, and 27 (start 1) are disabled for this detector.
 			channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
 			spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("PDTR1607-7-I21-01:ARR%1:ArrayData").arg(i+1), this));
 			thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));


### PR DESCRIPTION
Modified the if-check in the inboard detector constructor that excludes elements of a certain index from being created, to additionally exclude elements 5 and 11.