### PR TITLE
Pull Request for Issue2181: Updating default mono settling time.

### DIFF
--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -37,7 +37,7 @@ BioXASSSRLMonochromator::BioXASSSRLMonochromator(const QString &name, QObject *p
 
 	// Current settings.
 
-	setSettlingTime(0.01);
+	setSettlingTime(0.1);
 	setMode(Mode::Step);
 }
 


### PR DESCRIPTION
Modified the SSRL mono settling time from 0.01s to 0.1s. This latter value is the value that is actually used on the beamline to get useful data.