### PR TITLE
Pull Request for Issue2182: Using name instead of configuration user scan name.

### DIFF
--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
@@ -170,7 +170,7 @@ void BioXASXASScanConfigurationEditor::updateNameLineEdit()
 	bool enabled = false;
 
 	if (configuration_) {
-		text = configuration_->userScanName();
+		text = configuration_->name();
 		enabled = true;
 	}
 

--- a/source/ui/BioXAS/BioXASXASScanConfigurationView.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationView.cpp
@@ -20,8 +20,8 @@ const AMScanConfiguration* BioXASXASScanConfigurationView::configuration() const
 
 void BioXASXASScanConfigurationView::setConfigurationName(BioXASXASScanConfiguration *configuration, const QString &newName)
 {
-	if (configuration && configuration->userScanName() != newName)
-		configuration->setUserScanName(newName);
+	if (configuration)
+		configuration->setName(newName);
 }
 
 void BioXASXASScanConfigurationView::setConfigurationEdge(BioXASXASScanConfiguration *configuration, const AMAbsorptionEdge &newEdge)


### PR DESCRIPTION
- Modified the view classes for BioXAS XAS scan configurations to use the scan name instead of the user scan name.
- I see a lot about these classes that could stand to be refactored. Another issue.