### PR TITLE
Pull Request for Issue2183: EXAFS scans need different data collection paradigm

### DIFF
--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -306,7 +306,7 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 						AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1").arg(newRegion->name()), newRegion, normalizationSource);
 
 						if (normalizedRegion)
-							scan_->addAnalyzedDataSource(normalizedRegion, newRegion->name().contains(edgeSymbol), !newRegion->name().contains(edgeSymbol));
+							scan_->addAnalyzedDataSource(normalizedRegion, false, false);
 					}
 				}
 
@@ -314,7 +314,7 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 
 					for (int i = 0, size = elements->count(); i < size; i++){
 
-						newRegion = createRegionOfInterestAB(QString("%1_%2").arg(region->name().remove(' ')).arg(elements->name()),
+						newRegion = createRegionOfInterestAB(QString("%1_%2").arg(region->name().remove(' ')).arg(elements->at(i)->description()),
 										     region,
 										     scan_->dataSourceAt(scan_->indexOfDataSource(elements->at(i)->name())));
 
@@ -324,13 +324,14 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 
 							if (canNormalize) {
 
-								AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1").arg(newRegion->name()), newRegion, normalizationSource);
+								AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1_%2").arg(newRegion->name()).arg(elements->at(i)->description()),
+															  newRegion,
+															  normalizationSource);
 
 								if (normalizedRegion)
 									scan_->addAnalyzedDataSource(normalizedRegion, newRegion->name().contains(edgeSymbol), !newRegion->name().contains(edgeSymbol));
 							}
 						}
-
 					}
 				}
 			}
@@ -358,9 +359,9 @@ AMAnalysisBlock *BioXASXASScanActionController::createNormalizationAB(const QStr
 	if (source && normalizer && source->rank() == normalizer->rank()){
 
 		AMNormalizationAB *normalizedSource = new AMNormalizationAB(name);
-		normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << normalizedSource);
+		normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << normalizer);
 		normalizedSource->setDataName(source->name());
-		normalizedSource->setNormalizationName(normalizedSource->name());
+		normalizedSource->setNormalizationName(normalizer->name());
 
 		return normalizedSource;
 	}

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -9,7 +9,7 @@
 #include "analysis/AM1DExpressionAB.h"
 #include "analysis/AM1DDerivativeAB.h"
 #include "analysis/AM1DDarkCurrentCorrectionAB.h"
-#include "analysis/AM1DNormalizationAB.h"
+#include "analysis/AMNormalizationAB.h"
 
 #include "beamline/AMDetector.h"
 #include "beamline/BioXAS/BioXASBeamline.h"
@@ -283,31 +283,87 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 			// Create normalized analysis block for each region, add to scan.
 
 			AMDataSource *spectraSource = BioXASBeamlineSupport::geDetectorSource(scan_, ge32Detector);
+			AMDetectorSet *elements = BioXASBeamline::bioXAS()->elementsForDetector(ge32Detector);
 			QString edgeSymbol = bioXASConfiguration_->edge().split(" ").first();
 			bool canNormalize = (i0DetectorSource || i0CorrectedDetectorSource);
+			AMDataSource *normalizationSource = 0;
+
+			if (canNormalize)
+				normalizationSource = (i0CorrectedDetectorSource != 0) ? i0CorrectedDetectorSource : i0DetectorSource;
 
 			foreach (AMRegionOfInterest *region, bioXASConfiguration_->regionsOfInterest()){
 
-				AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
-
-				AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
-				newRegion->setBinningRange(regionAB->binningRange());
-				newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
-
-				scan_->addAnalyzedDataSource(newRegion, false, true);
 				ge32Detector->addRegionOfInterest(region);
 
-				if (canNormalize) {
-					AMDataSource *normalizationSource = (i0CorrectedDetectorSource != 0) ? i0CorrectedDetectorSource : i0DetectorSource;
+				AMAnalysisBlock *newRegion = createRegionOfInterestAB(region->name().remove(' '), region, spectraSource);
 
-					AM1DNormalizationAB *normalizedRegion = new AM1DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
-					normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << normalizationSource);
-					normalizedRegion->setDataName(newRegion->name());
-					normalizedRegion->setNormalizationName(normalizationSource->name());
+				if (newRegion){
 
-					scan_->addAnalyzedDataSource(normalizedRegion, newRegion->name().contains(edgeSymbol), !newRegion->name().contains(edgeSymbol));
+					scan_->addAnalyzedDataSource(newRegion, false, true);
+
+					if (canNormalize) {
+
+						AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1").arg(newRegion->name()), newRegion, normalizationSource);
+
+						if (normalizedRegion)
+							scan_->addAnalyzedDataSource(normalizedRegion, newRegion->name().contains(edgeSymbol), !newRegion->name().contains(edgeSymbol));
+					}
+				}
+
+				if (elements){
+
+					for (int i = 0, size = elements->count(); i < size; i++){
+
+						newRegion = createRegionOfInterestAB(QString("%1_%2").arg(region->name().remove(' ')).arg(elements->name()),
+										     region,
+										     scan_->dataSourceAt(scan_->indexOfDataSource(elements->at(i)->name())));
+
+						if (newRegion){
+
+							scan_->addAnalyzedDataSource(newRegion, false, true);
+
+							if (canNormalize) {
+
+								AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1").arg(newRegion->name()), newRegion, normalizationSource);
+
+								if (normalizedRegion)
+									scan_->addAnalyzedDataSource(normalizedRegion, newRegion->name().contains(edgeSymbol), !newRegion->name().contains(edgeSymbol));
+							}
+						}
+
+					}
 				}
 			}
 		}
 	}
+}
+
+AMAnalysisBlock *BioXASXASScanActionController::createRegionOfInterestAB(const QString &name, AMRegionOfInterest *region, AMDataSource *spectrumSource) const
+{
+	if (region && region->isValid() && spectrumSource && ((spectrumSource->rank()-scan_->scanRank()) == 1)){
+
+		AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
+		AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(name);
+		newRegion->setBinningRange(regionAB->binningRange());
+		newRegion->setInputDataSources(QList<AMDataSource *>() << spectrumSource);
+
+		return newRegion;
+	}
+
+	return 0;
+}
+
+AMAnalysisBlock *BioXASXASScanActionController::createNormalizationAB(const QString &name, AMDataSource *source, AMDataSource *normalizer) const
+{
+	if (source && normalizer && source->rank() == normalizer->rank()){
+
+		AMNormalizationAB *normalizedSource = new AMNormalizationAB(name);
+		normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << normalizedSource);
+		normalizedSource->setDataName(source->name());
+		normalizedSource->setNormalizationName(normalizedSource->name());
+
+		return normalizedSource;
+	}
+
+	return 0;
 }

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.h
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.h
@@ -31,6 +31,11 @@ protected:
 	/// Sets the scan axis and adds anything extra.
 	virtual void buildScanControllerImplementation();
 
+	/// Creates a region of interest analysis block from the given AMRegionOfInterest and 1D spectrum source.
+	AMAnalysisBlock *createRegionOfInterestAB(const QString &name, AMRegionOfInterest *region, AMDataSource *spectrumSource) const;
+	/// Creates a normalized analysis block from a source and normalizer source.
+	AMAnalysisBlock *createNormalizationAB(const QString &name, AMDataSource *source, AMDataSource *normalizer) const;
+
 protected:
 	/// The BioXAS XAS scan configuration.
 	BioXASXASScanConfiguration *bioXASConfiguration_;

--- a/source/beamline/AM1DControlDetectorEmulator.cpp
+++ b/source/beamline/AM1DControlDetectorEmulator.cpp
@@ -87,6 +87,17 @@ AMAction3* AM1DControlDetectorEmulator::createTriggerAction(AMDetectorDefinition
 	return AMDetector::createTriggerAction(readMode);
 }
 
+void AM1DControlDetectorEmulator::setAxisInfo(const AMAxisInfo &info)
+{
+	axes_[0].name = info.name;
+	axes_[0].description = info.description;
+	axes_[0].start = info.start;
+	axes_[0].increment = info.increment;
+	axes_[0].size = info.size;
+	axes_[0].isUniform = info.isUniform;
+	axes_[0].units = info.units;
+}
+
 void AM1DControlDetectorEmulator::onControlsConnected(bool connected)
 {
 	if(connected)

--- a/source/beamline/AM1DControlDetectorEmulator.h
+++ b/source/beamline/AM1DControlDetectorEmulator.h
@@ -76,6 +76,8 @@ public slots:
 	/// Controls do not support clearing
 	virtual bool clear() { return false; }
 
+	/// Sets the axis info to the new given axis info.
+	void setAxisInfo(const AMAxisInfo &info);
 	/// Sets the flag to determine if this detector should be accessed through the lastFloatingPointValues() call. The normal is lastIntegerValues()
 	void setAccessAsDouble(bool accessAsDouble) { accessAsDouble_ = accessAsDouble; }
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -408,6 +408,7 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 		foreach (AMControl *spectra, newDetector->spectraControls()) {
 			AM1DControlDetectorEmulator *element = new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 4096, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 			element->setAccessAsDouble(true);
+			element->setAxisInfo(newDetector->axes().first());
 			addDetectorElement(newDetector, element);
 		}
 

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -10,7 +10,7 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 	for (int i = 0; i < 20; i++) { // Elements 21-32 (start 1) are disabled for this detector.
 
 		channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("DXP1607-I22-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
-		spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("DXP1607-I22-01:ARR%1:ArrayData").arg(i+1), this));
+		spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("DXP1607-I22-01:ARR%1:ArrayData").arg(i+1), this, QString("spectra%1").arg(i+1)));
 		thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));
 	}
 


### PR DESCRIPTION
I modified the BioXASXASScanController to use all the individual ROIs.  It still uses the summed spectra for the full ROI.  I needed to pass in a means of updating the axis info of the 1D detector emulator because the controls don't have the in depth knowledge of the detector.

I'm sure there are some ways to make this more general (for instance, using the createXYZAB methods in AMGenericStepScanController), but for the time being this will suffice.