### PR TITLE
Pull Request for Issue2185: making exporting spectra optional

### DIFF
--- a/source/acquaman/BioXAS/BioXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.cpp
@@ -21,6 +21,7 @@ QString BioXASScanConfiguration::toString() const
 
 	text.append(QString("Edge: %1").arg(edge()));
 	text.append(QString("\nEnergy: %1").arg(energy()));
+	text.append(QString("\nSpectra export preference: %1").arg(exportSpectraPreference()));
 
 	return text;
 }

--- a/source/acquaman/BioXAS/BioXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.h
@@ -46,16 +46,13 @@ public:
 	/// Sets the edge.
 	void setEdge(const QString &newEdge) { dbObject_->setEdge(newEdge); }
 	/// Sets the export spectra preference.
-	virtual void setExportSpectraPreference(bool exportSpectra) { dbObject_->setExportSpectraPreference(exportSpectra); }
+	void setExportSpectraPreference(bool exportSpectra) { dbObject_->setExportSpectraPreference(exportSpectra); }
 
 protected:
 	/// The database reading member function.
 	AMDbObject *dbReadScanConfigurationDbObject() { return dbObject_; }
 	/// The database writing member function.
 	void dbWriteScanConfigurationDbObject(AMDbObject *object);
-
-	/// Sets the flag for whether the XRF detector spectra are exported.
-	void setExportSpectra(bool spectraExported) { dbObject_->setExportSpectra(spectraExported); }
 
 	// Header method and helper methods.
 	////////////////////////////////////////

--- a/source/acquaman/BioXAS/BioXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASScanConfiguration.h
@@ -32,6 +32,9 @@ public:
 	double energy() const { return dbObject_->energy(); }
 	/// Returns the edge.
 	QString edge() const { return dbObject_->edge(); }
+	/// Returns the export spectra preference.
+	bool exportSpectraPreference() const { return dbObject_->exportSpectraPreference(); }
+
 	/// Returns a string representation of the scan configuration.
 	virtual QString toString() const;
 
@@ -42,12 +45,17 @@ public:
 	void setEnergy(double newEnergy) { dbObject_->setEnergy(newEnergy); }
 	/// Sets the edge.
 	void setEdge(const QString &newEdge) { dbObject_->setEdge(newEdge); }
+	/// Sets the export spectra preference.
+	virtual void setExportSpectraPreference(bool exportSpectra) { dbObject_->setExportSpectraPreference(exportSpectra); }
 
 protected:
 	/// The database reading member function.
 	AMDbObject *dbReadScanConfigurationDbObject() { return dbObject_; }
 	/// The database writing member function.
 	void dbWriteScanConfigurationDbObject(AMDbObject *object);
+
+	/// Sets the flag for whether the XRF detector spectra are exported.
+	void setExportSpectra(bool spectraExported) { dbObject_->setExportSpectra(spectraExported); }
 
 	// Header method and helper methods.
 	////////////////////////////////////////

--- a/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.cpp
+++ b/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.cpp
@@ -5,6 +5,9 @@ BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(QObject *parent
 {
 	energy_ = 0.0;
 	edge_ = "";
+
+	exportSpectraPreference_ = false;
+	exportSpectra_ = false;
 }
 
 BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(const BioXASScanConfigurationDbObject &original)
@@ -13,7 +16,8 @@ BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(const BioXASSca
 	energy_ = original.energy();
 	edge_ = original.edge();
 
-
+	exportSpectraPreference_ = false;
+	exportSpectra_ = false;
 }
 
 BioXASScanConfigurationDbObject::~BioXASScanConfigurationDbObject()
@@ -35,6 +39,24 @@ void BioXASScanConfigurationDbObject::setEdge(const QString &newEdge)
 	if (edge_ != newEdge){
 		edge_ = newEdge;
 		emit edgeChanged(edge_);
+		setModified(true);
+	}
+}
+
+void BioXASScanConfigurationDbObject::setExportSpectraPreference(bool spectraExported)
+{
+	if (exportSpectraPreference_ != spectraExported) {
+		exportSpectraPreference_ = spectraExported;
+		emit exportSpectraPreferenceChanged(exportSpectraPreference_);
+		setModified(true);
+	}
+}
+
+void BioXASScanConfigurationDbObject::setExportSpectra(bool spectraExported)
+{
+	if (exportSpectra_ != spectraExported) {
+		exportSpectra_ = spectraExported;
+		emit exportSpectraChanged(exportSpectra_);
 		setModified(true);
 	}
 }

--- a/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.cpp
+++ b/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.cpp
@@ -5,9 +5,7 @@ BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(QObject *parent
 {
 	energy_ = 0.0;
 	edge_ = "";
-
 	exportSpectraPreference_ = false;
-	exportSpectra_ = false;
 }
 
 BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(const BioXASScanConfigurationDbObject &original)
@@ -15,9 +13,7 @@ BioXASScanConfigurationDbObject::BioXASScanConfigurationDbObject(const BioXASSca
 {
 	energy_ = original.energy();
 	edge_ = original.edge();
-
-	exportSpectraPreference_ = false;
-	exportSpectra_ = false;
+	exportSpectraPreference_ = original.exportSpectraPreference();
 }
 
 BioXASScanConfigurationDbObject::~BioXASScanConfigurationDbObject()
@@ -48,15 +44,6 @@ void BioXASScanConfigurationDbObject::setExportSpectraPreference(bool spectraExp
 	if (exportSpectraPreference_ != spectraExported) {
 		exportSpectraPreference_ = spectraExported;
 		emit exportSpectraPreferenceChanged(exportSpectraPreference_);
-		setModified(true);
-	}
-}
-
-void BioXASScanConfigurationDbObject::setExportSpectra(bool spectraExported)
-{
-	if (exportSpectra_ != spectraExported) {
-		exportSpectra_ = spectraExported;
-		emit exportSpectraChanged(exportSpectra_);
 		setModified(true);
 	}
 }

--- a/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.h
+++ b/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.h
@@ -12,7 +12,6 @@ class BioXASScanConfigurationDbObject : public AMDbObject
 	Q_PROPERTY(double energy READ energy WRITE setEnergy)
 	Q_PROPERTY(QString edge READ edge WRITE setEdge)
 	Q_PROPERTY(bool exportSpectraPreference READ exportSpectraPreference WRITE setExportSpectraPreference)
-	Q_PROPERTY(bool exportSpectra READ exportSpectra WRITE setExportSpectra)
 
 	Q_CLASSINFO("usingXRFDetector", "upgradeDefault=false")
 
@@ -30,11 +29,8 @@ public:
 	double energy() const { return energy_; }
 	/// Returns the edge.
 	QString edge() const { return edge_; }
-
 	/// Returns the preference for whether the XRF detector spectra are exported.
 	bool exportSpectraPreference() const { return exportSpectraPreference_; }
-	/// Returns true if XRF detector spectra are exported.
-	bool exportSpectra() const { return exportSpectra_; }
 
 signals:
 	/// Notifier that the energy has changed.
@@ -43,30 +39,22 @@ signals:
 	void edgeChanged(const QString &);
 	/// Notifier that the preference for whether the XRF detector spectra are exported has changed.
 	void exportSpectraPreferenceChanged(bool spectraExported);
-	/// Notifier that the flag indicating whether the spectra are exported has changed.
-	void exportSpectraChanged(bool spectraExported);
 
 public slots:
 	/// Sets the energy.
 	void setEnergy(double newEnergy);
 	/// Sets the edge.
 	void setEdge(const QString &newEdge);
-
 	/// Sets the preference for exporting XRF detector spectra.
 	void setExportSpectraPreference(bool spectraExported);
-	/// Sets the flag for whether the XRF detector spectra are exported.
-	void setExportSpectra(bool spectraExported);
 
 protected:
 	/// The energy used for this scan.
 	double energy_;
 	/// The edge associated with this scan.
 	QString edge_;
-
 	/// The preference for exporting XRF detector spectra.
 	bool exportSpectraPreference_;
-	/// The flag for whether the XRF detector spectra are exported.
-	bool exportSpectra_;
 };
 
 #endif // BIOXASSCANCONFIGURATIONDBOBJECT_H

--- a/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.h
+++ b/source/acquaman/BioXAS/BioXASScanConfigurationDbObject.h
@@ -11,6 +11,8 @@ class BioXASScanConfigurationDbObject : public AMDbObject
 
 	Q_PROPERTY(double energy READ energy WRITE setEnergy)
 	Q_PROPERTY(QString edge READ edge WRITE setEdge)
+	Q_PROPERTY(bool exportSpectraPreference READ exportSpectraPreference WRITE setExportSpectraPreference)
+	Q_PROPERTY(bool exportSpectra READ exportSpectra WRITE setExportSpectra)
 
 	Q_CLASSINFO("usingXRFDetector", "upgradeDefault=false")
 
@@ -29,11 +31,20 @@ public:
 	/// Returns the edge.
 	QString edge() const { return edge_; }
 
+	/// Returns the preference for whether the XRF detector spectra are exported.
+	bool exportSpectraPreference() const { return exportSpectraPreference_; }
+	/// Returns true if XRF detector spectra are exported.
+	bool exportSpectra() const { return exportSpectra_; }
+
 signals:
 	/// Notifier that the energy has changed.
 	void energyChanged(double);
 	/// Notifier that the edge has changed.
 	void edgeChanged(const QString &);
+	/// Notifier that the preference for whether the XRF detector spectra are exported has changed.
+	void exportSpectraPreferenceChanged(bool spectraExported);
+	/// Notifier that the flag indicating whether the spectra are exported has changed.
+	void exportSpectraChanged(bool spectraExported);
 
 public slots:
 	/// Sets the energy.
@@ -41,11 +52,21 @@ public slots:
 	/// Sets the edge.
 	void setEdge(const QString &newEdge);
 
+	/// Sets the preference for exporting XRF detector spectra.
+	void setExportSpectraPreference(bool spectraExported);
+	/// Sets the flag for whether the XRF detector spectra are exported.
+	void setExportSpectra(bool spectraExported);
+
 protected:
 	/// The energy used for this scan.
 	double energy_;
 	/// The edge associated with this scan.
 	QString edge_;
+
+	/// The preference for exporting XRF detector spectra.
+	bool exportSpectraPreference_;
+	/// The flag for whether the XRF detector spectra are exported.
+	bool exportSpectra_;
 };
 
 #endif // BIOXASSCANCONFIGURATIONDBOBJECT_H

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -31,7 +31,8 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 	scan_->setNotes(BioXASBeamline::bioXAS()->scanNotes());
 
 	if (bioXASConfiguration_) {
-		AMExporterOptionXDIFormat *bioXASDefaultXAS = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", bioXASConfiguration_->edge().split(" ").first(), bioXASConfiguration_->edge().split(" ").last(), true);
+
+		AMExporterOptionXDIFormat *bioXASDefaultXAS = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", bioXASConfiguration_->edge().split(" ").first(), bioXASConfiguration_->edge().split(" ").last(), bioXASConfiguration_->canExportSpectra() && bioXASConfiguration_->exportSpectraPreference());
 
 		if (bioXASDefaultXAS->id() > 0)
 			AMAppControllerSupport::registerClass<BioXASXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(bioXASDefaultXAS->id());

--- a/source/acquaman/BioXAS/BioXASXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanConfiguration.cpp
@@ -16,31 +16,13 @@ BioXASXASScanConfiguration::BioXASXASScanConfiguration(QObject *parent) :
 {
 	setName(description());
 	setUserScanName(description());
-
-	// We want to update the flag for whether the XRF detector spectra are
-	// exported whenever the detectors have changed (maybe an XRF detector
-	// was added) or when the export preference has changed.
-
-	connect( this, SIGNAL(detectorsChanged()), this, SLOT(updateExportSpectra()) );
-	connect( dbObject_, SIGNAL(exportSpectraPreferenceChanged(bool)), this, SLOT(updateExportSpectra()) );
-
-	updateExportSpectra();
 }
 
 BioXASXASScanConfiguration::BioXASXASScanConfiguration(const BioXASXASScanConfiguration &original) :
-	AMGenericStepScanConfiguration(original), BioXASScanConfiguration()
+	AMGenericStepScanConfiguration(original), BioXASScanConfiguration(original)
 {
 	setEdge(original.edge());
 	setEnergy(original.energy());
-
-	// We want to update the flag for whether the XRF detector spectra are
-	// exported whenever the detectors have changed (maybe an XRF detector
-	// was added) or when the export preference has changed.
-
-	connect( this, SIGNAL(detectorsChanged()), this, SLOT(updateExportSpectra()) );
-	connect( dbObject_, SIGNAL(exportSpectraPreferenceChanged(bool)), this, SLOT(updateExportSpectra()) );
-
-	updateExportSpectra();
 }
 
 BioXASXASScanConfiguration::~BioXASXASScanConfiguration()
@@ -129,11 +111,6 @@ void BioXASXASScanConfiguration::setupDefaultEXAFSRegions()
 		newRegion = createEXAFSRegionInKSpace(edgeEnergy, AMEnergyToKSpaceCalculator::k(edgeEnergy, edgeEnergy + 40), 0.05, 10, 1.0, 10.0);
 		addRegion(0, 2, newRegion);
 	}
-}
-
-void BioXASXASScanConfiguration::updateExportSpectra()
-{
-	setExportSpectra(hasXRFDetector() && exportSpectraPreference());
 }
 
 AMScanAxisEXAFSRegion* BioXASXASScanConfiguration::createDefaultXANESRegion(double edgeEnergy)

--- a/source/acquaman/BioXAS/BioXASXASScanConfiguration.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanConfiguration.cpp
@@ -16,6 +16,15 @@ BioXASXASScanConfiguration::BioXASXASScanConfiguration(QObject *parent) :
 {
 	setName(description());
 	setUserScanName(description());
+
+	// We want to update the flag for whether the XRF detector spectra are
+	// exported whenever the detectors have changed (maybe an XRF detector
+	// was added) or when the export preference has changed.
+
+	connect( this, SIGNAL(detectorsChanged()), this, SLOT(updateExportSpectra()) );
+	connect( dbObject_, SIGNAL(exportSpectraPreferenceChanged(bool)), this, SLOT(updateExportSpectra()) );
+
+	updateExportSpectra();
 }
 
 BioXASXASScanConfiguration::BioXASXASScanConfiguration(const BioXASXASScanConfiguration &original) :
@@ -23,6 +32,15 @@ BioXASXASScanConfiguration::BioXASXASScanConfiguration(const BioXASXASScanConfig
 {
 	setEdge(original.edge());
 	setEnergy(original.energy());
+
+	// We want to update the flag for whether the XRF detector spectra are
+	// exported whenever the detectors have changed (maybe an XRF detector
+	// was added) or when the export preference has changed.
+
+	connect( this, SIGNAL(detectorsChanged()), this, SLOT(updateExportSpectra()) );
+	connect( dbObject_, SIGNAL(exportSpectraPreferenceChanged(bool)), this, SLOT(updateExportSpectra()) );
+
+	updateExportSpectra();
 }
 
 BioXASXASScanConfiguration::~BioXASXASScanConfiguration()
@@ -48,6 +66,20 @@ AMScanController* BioXASXASScanConfiguration::createController()
 AMScanConfigurationView* BioXASXASScanConfiguration::createView()
 {
 	return new BioXASXASScanConfigurationEditor(this);
+}
+
+bool BioXASXASScanConfiguration::hasXRFDetector() const
+{
+	bool detectorFound = false;
+
+	for (int i = 0, count = detectorConfigurations_.count(); i < count && !detectorFound; i++) {
+		AMDetector *detector = BioXASBeamline::bioXAS()->exposedDetectorByInfo(detectorConfigurations().detectorInfoAt(i));
+
+		if (qobject_cast<AMXRFDetector*>(detector))
+			detectorFound = true;
+	}
+
+	return detectorFound;
 }
 
 void BioXASXASScanConfiguration::clearRegions()
@@ -97,6 +129,11 @@ void BioXASXASScanConfiguration::setupDefaultEXAFSRegions()
 		newRegion = createEXAFSRegionInKSpace(edgeEnergy, AMEnergyToKSpaceCalculator::k(edgeEnergy, edgeEnergy + 40), 0.05, 10, 1.0, 10.0);
 		addRegion(0, 2, newRegion);
 	}
+}
+
+void BioXASXASScanConfiguration::updateExportSpectra()
+{
+	setExportSpectra(hasXRFDetector() && exportSpectraPreference());
 }
 
 AMScanAxisEXAFSRegion* BioXASXASScanConfiguration::createDefaultXANESRegion(double edgeEnergy)

--- a/source/acquaman/BioXAS/BioXASXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASXASScanConfiguration.h
@@ -39,6 +39,9 @@ public:
 	/// Returns a newly-created AMScanConfigurationView that is appropriate for viewing and editing this kind of scan configuration. Ownership of the new controller becomes the responsibility of the caller.
 	virtual AMScanConfigurationView* createView();
 
+	/// Returns true if this scan configuration can export spectra, false otherwise.
+	bool canExportSpectra() const { return hasXRFDetector(); }
+
 	/// Returns true if this scan configuration has an XRF detector among the configuration detectors, false otherwise.
 	bool hasXRFDetector() const;
 
@@ -49,10 +52,6 @@ public slots:
 	void setupDefaultXANESRegions();
 	/// Sets up the default EXAFS regions.
 	void setupDefaultEXAFSRegions();
-
-protected slots:
-	/// Updates whether spectra are exported.
-	void updateExportSpectra();
 
 protected:
 	/// Creates and returns a default XANES region.

--- a/source/acquaman/BioXAS/BioXASXASScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASXASScanConfiguration.h
@@ -39,6 +39,9 @@ public:
 	/// Returns a newly-created AMScanConfigurationView that is appropriate for viewing and editing this kind of scan configuration. Ownership of the new controller becomes the responsibility of the caller.
 	virtual AMScanConfigurationView* createView();
 
+	/// Returns true if this scan configuration has an XRF detector among the configuration detectors, false otherwise.
+	bool hasXRFDetector() const;
+
 public slots:
 	/// Clears all regions.
 	void clearRegions();
@@ -46,6 +49,10 @@ public slots:
 	void setupDefaultXANESRegions();
 	/// Sets up the default EXAFS regions.
 	void setupDefaultEXAFSRegions();
+
+protected slots:
+	/// Updates whether spectra are exported.
+	void updateExportSpectra();
 
 protected:
 	/// Creates and returns a default XANES region.

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.cpp
@@ -56,6 +56,8 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 	detectorsViews->addTab(scientificDetectorsWidget, "Scientific");
 	detectorsViews->addTab(allDetectorsWidget, "All");
 
+	exportSpectraCheckBox_ = new QCheckBox("Export spectra");
+
 	// Create and set main layouts
 
 	QHBoxLayout *edgeEditorLayout = new QHBoxLayout();
@@ -78,6 +80,7 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	QVBoxLayout *detectorBoxLayout = new QVBoxLayout();
 	detectorBoxLayout->addWidget(detectorsViews);
+	detectorBoxLayout->addWidget(exportSpectraCheckBox_);
 	detectorBoxLayout->addStretch();
 
 	QGroupBox *detectorBox = new QGroupBox("Detectors");
@@ -93,6 +96,7 @@ BioXASXASScanConfigurationEditor::BioXASXASScanConfigurationEditor(BioXASXASScan
 
 	connect( nameLineEdit_, SIGNAL(textChanged(QString)), this, SLOT(updateConfigurationName()) );
 	connect( energySpinBox_, SIGNAL(valueChanged(double)), this, SLOT(updateConfigurationEnergy()) );
+	connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
 
 	// Current settings.
 
@@ -118,6 +122,8 @@ void BioXASXASScanConfigurationEditor::setConfiguration(BioXASXASScanConfigurati
 		if (configuration_) {
 			connect( configuration_, SIGNAL(nameChanged(QString)), this, SLOT(updateNameLineEdit()) );
 			connect( configuration_->dbObject(), SIGNAL(energyChanged(double)), this, SLOT(updateEnergySpinBox()) );
+			connect( configuration_, SIGNAL(detectorsChanged()), this, SLOT(updateExportSpectraCheckBox()) );
+			connect( configuration_->dbObject(), SIGNAL(exportSpectraPreferenceChanged(bool)), this, SLOT(updateExportSpectraCheckBox()) );
 		}
 
 		refresh();
@@ -134,6 +140,10 @@ void BioXASXASScanConfigurationEditor::clear()
 	regionsEditor_->clear();
 	scientificDetectorsView_->clear();
 	allDetectorsView_->clear();
+
+	exportSpectraCheckBox_->blockSignals(true);
+	exportSpectraCheckBox_->setChecked(false);
+	exportSpectraCheckBox_->blockSignals(false);
 }
 
 void BioXASXASScanConfigurationEditor::update()
@@ -144,6 +154,7 @@ void BioXASXASScanConfigurationEditor::update()
 	regionsEditor_->update();
 	scientificDetectorsView_->update();
 	allDetectorsView_->update();
+	updateExportSpectraCheckBox();
 }
 
 void BioXASXASScanConfigurationEditor::refresh()
@@ -192,6 +203,21 @@ void BioXASXASScanConfigurationEditor::updateEnergySpinBox()
 	energySpinBox_->setEnabled(enabled);
 }
 
+void BioXASXASScanConfigurationEditor::updateExportSpectraCheckBox()
+{
+	exportSpectraCheckBox_->blockSignals(true);
+
+	exportSpectraCheckBox_->setChecked(false);
+	exportSpectraCheckBox_->setEnabled(false);
+
+	if (configuration_ && configuration_->canExportSpectra()) {
+		exportSpectraCheckBox_->setEnabled(true);
+		exportSpectraCheckBox_->setChecked(configuration_->exportSpectraPreference());
+	}
+
+	exportSpectraCheckBox_->blockSignals(false);
+}
+
 void BioXASXASScanConfigurationEditor::updateConfigurationName()
 {
 	setConfigurationName(configuration_, nameLineEdit_->text());
@@ -200,4 +226,10 @@ void BioXASXASScanConfigurationEditor::updateConfigurationName()
 void BioXASXASScanConfigurationEditor::updateConfigurationEnergy()
 {
 	setConfigurationEnergy(configuration_, energySpinBox_->value());
+}
+
+void BioXASXASScanConfigurationEditor::updateConfigurationExportSpectraPreference()
+{
+	if (configuration_)
+		configuration_->setExportSpectraPreference(exportSpectraCheckBox_->isChecked());
 }

--- a/source/ui/BioXAS/BioXASXASScanConfigurationEditor.h
+++ b/source/ui/BioXAS/BioXASXASScanConfigurationEditor.h
@@ -39,11 +39,15 @@ protected slots:
 	void updateNameLineEdit();
 	/// Updates the displayed energy to correspond to the configuration's energy.
 	void updateEnergySpinBox();
+	/// Updates the export spectra checkbox to correspond to the configuration's export setting.
+	void updateExportSpectraCheckBox();
 
 	/// Updates the scan configuration name.
 	void updateConfigurationName();
 	/// Updates the configuration's energy.
 	void updateConfigurationEnergy();
+	/// Updates the configuration's export spectra preference.
+	void updateConfigurationExportSpectraPreference();
 
 protected:
 	/// Scan name editor.
@@ -54,6 +58,8 @@ protected:
 	BioXASXASScanConfigurationEdgeEditor *edgeEditor_;
 	/// Regions editor.
 	BioXASXASScanConfigurationRegionsEditor *regionsEditor_;
+	/// The export spectra preference checkbox.
+	QCheckBox *exportSpectraCheckBox_;
 	/// The 'scientific detectors' view.
 	AMGenericStepScanConfigurationDetectorsView *scientificDetectorsView_;
 	/// The 'all detectors' view.


### PR DESCRIPTION
- Added exportSpectraPreference_ variable to the BioXASScanConfigurationDbObject.
- Added checkbox to the scan configuration view that manipulates this value.
- Modified the BioXASXASScanActionController constructor to use this preference to set the exporter option setting.