### PR TITLE
Pull Request for Issue2191: Adding 'all good events' to Ge detector ICRs.

### DIFF
--- a/source/acquaman/AMXRFScanController.cpp
+++ b/source/acquaman/AMXRFScanController.cpp
@@ -97,7 +97,7 @@ void AMXRFScanController::onDetectorAcquisitionFinished()
 		}
 	}
 
-	else {
+	else if (!detector_->inputCountSources().isEmpty() && !detector_->outputCountSources().isEmpty()){
 		for (int i = 0, elements = detector_->elements(); i < elements; i++){
 
 			detector_->rawSpectrumSources().at(i)->values(AMnDIndex(0), AMnDIndex(detector_->size(0)-1), spectrum.data());

--- a/source/acquaman/AMXRFScanController.cpp
+++ b/source/acquaman/AMXRFScanController.cpp
@@ -97,7 +97,7 @@ void AMXRFScanController::onDetectorAcquisitionFinished()
 		}
 	}
 
-	else if (!detector_->inputCountSources().isEmpty() && !detector_->outputCountSources().isEmpty()){
+	else if (!detector_->outputCountSources().isEmpty()){
 		for (int i = 0, elements = detector_->elements(); i < elements; i++){
 
 			detector_->rawSpectrumSources().at(i)->values(AMnDIndex(0), AMnDIndex(detector_->size(0)-1), spectrum.data());

--- a/source/beamline/AMXRFDetector.cpp
+++ b/source/beamline/AMXRFDetector.cpp
@@ -83,6 +83,7 @@ void AMXRFDetector::allControlsCreated()
 
 	else if (!icrControls_.isEmpty() && ocrControls_.isEmpty()){
 		doDeadTimeCorrection_ = false;
+		buildDeadTimeDataSources();
 		buildAllAnalysisBlocks();
 	}
 
@@ -204,13 +205,19 @@ double AMXRFDetector::deadTime() const
 
 double AMXRFDetector::deadTimeAt(int index) const
 {
-	double inputCounts = icrSources_.at(index)->value(AMnDIndex());
-	double outputCounts = ocrSources_.at(index)->value(AMnDIndex());
+	double result = 0;
 
-	if (inputCounts == 0 || outputCounts == 0 || inputCounts < outputCounts)
-		return 0;
+	if (!icrSources_.isEmpty() && !ocrSources_.isEmpty()) {
+		double inputCounts = icrSources_.at(index)->value(AMnDIndex());
+		double outputCounts = ocrSources_.at(index)->value(AMnDIndex());
 
-	return 1 - outputCounts/inputCounts;
+		if (inputCounts == 0 || outputCounts == 0 || inputCounts < outputCounts)
+			return 0;
+
+		result = 1 - outputCounts/inputCounts;
+	}
+
+	return result;
 }
 
 AMNumber AMXRFDetector::reading(const AMnDIndex &indexes) const

--- a/source/beamline/AMXRFDetector.cpp
+++ b/source/beamline/AMXRFDetector.cpp
@@ -81,6 +81,11 @@ void AMXRFDetector::allControlsCreated()
 		buildAllAnalysisBlocks();
 	}
 
+	else if (!icrControls_.isEmpty() && ocrControls_.isEmpty()){
+		doDeadTimeCorrection_ = false;
+		buildAllAnalysisBlocks();
+	}
+
 	else {
 
 		AMErrorMon::error(this,

--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -93,11 +93,11 @@ public:
 	/// Returns the input count data sources.
 	QList<AMDataSource *> inputCountSources() const { return icrSources_; }
 	/// Returns the input count data source at the given index.
-	AMDataSource *inputCountSourceAt(int index) const { return icrSources_.at(index); }
+	AMDataSource *inputCountSourceAt(int index) const { return (index >= 0 && index < icrSources_.count()) ? icrSources_.at(index) : 0; }
 	/// Returns the output count data sources.
 	QList<AMDataSource *> outputCountSources() const { return ocrSources_; }
 	/// Returns the output count data source at the given index.
-	AMDataSource *outputCountSourceAt(int index) const { return ocrSources_.at(index); }
+	AMDataSource *outputCountSourceAt(int index) const { return (index >= 0 && index < ocrSources_.count()) ? ocrSources_.at(index) : 0; }
 
 	/// Returns the primary data source for viewing the detector's output.
 	virtual AMDataSource *dataSource() const { return primarySpectrumDataSource_; }

--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
@@ -12,6 +12,7 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 			channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
 			spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("PDTR1607-7-I21-01:ARR%1:ArrayData").arg(i+1), this));
 			thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));
+			icrControls_.append(new AMReadOnlyPVControl(QString("ICR %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4:Value_RBV").arg(i+1), this));
 		}
 	}
 

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -8,10 +8,10 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 	acquisitionStatusControl_ = new AMReadOnlyPVControl("Status", "DXP1607-I22-01:DetectorState_RBV", this);
 
 	for (int i = 0; i < 20; i++) { // Elements 21-32 (start 1) are disabled for this detector.
-
 		channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("DXP1607-I22-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
 		spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("DXP1607-I22-01:ARR%1:ArrayData").arg(i+1), this, QString("spectra%1").arg(i+1)));
 		thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));
+		icrControls_.append(new AMReadOnlyPVControl(QString("ICR %1").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4:Value_RBV").arg(i+1), this));
 	}
 
 	initializationControl_ = new AMSinglePVControl("Initialization", "DXP1607-I22-01:Acquire", this, 0.1);

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -80,7 +80,7 @@ void AMDeadTimeButton::paintEvent(QPaintEvent *e)
 	else if (!isChecked()){
 
 		if (hasDeadTimeSources() || hasICRDataSource()) {
-			double newValue = 0;
+			double newValue = badReferencecPoint_;
 
 			if (hasDeadTimeSources()){
 				newValue = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -33,23 +33,32 @@ AMDeadTimeButton::AMDeadTimeButton(QWidget *parent)
 	outputCountSource_ = 0;
 	goodReferencePoint_ = 0;
 	badReferencecPoint_ = 0;
+	displayPercent_ = true;
 }
 
-AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, QWidget *parent)
+AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, bool displayPercent, QWidget *parent)
 	: QToolButton(parent)
 {
 	inputCountSource_ = inputCountSource;
 	outputCountSource_ = outputCountSource;
 	goodReferencePoint_ = goodReferencePoint;
 	badReferencecPoint_ = badReferencePoint;
+	displayPercent_ = displayPercent;
 
-	connect(inputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onDeadTimeUpdated()));
-	connect(outputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onDeadTimeUpdated()));
+	if (inputCountSource_)
+		connect(inputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onDeadTimeUpdated()));
+
+	if (outputCountSource_)
+		connect(outputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(onDeadTimeUpdated()));
 }
 
 void AMDeadTimeButton::onDeadTimeUpdated()
 {
-	setToolTip(QString("%1%").arg(100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex()))), 0, 'f', 0));
+	if (displayPercent_ && inputCountSource_ && outputCountSource_)
+		setToolTip(QString("%1%").arg(100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex()))), 0, 'f', 0));
+	else if (!displayPercent_ && inputCountSource_)
+		setToolTip(QString("%1 counts").arg(double(inputCountSource_->value(AMnDIndex()))));
+
 	update();
 }
 
@@ -70,9 +79,15 @@ void AMDeadTimeButton::paintEvent(QPaintEvent *e)
 
 	else if (!isChecked()){
 
-		if (hasDeadTimeSources()){
+		if (hasDeadTimeSources() || hasICRDataSource()) {
+			double newValue = 0;
 
-			double newValue = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
+			if (hasDeadTimeSources()){
+				newValue = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
+
+			} else if (hasICRDataSource()) {
+				newValue = inputCountSource_->value(AMnDIndex());
+			}
 
 			if (newValue < goodReferencePoint_)
 				option.palette = QPalette(Qt::black, QColor(20, 220, 20), Qt::gray, Qt::darkGray, QColor(170, 170, 170), Qt::black, Qt::red, Qt::green, QColor(0, 200, 0));
@@ -104,6 +119,12 @@ void AMDeadTimeButton::setBadReferencePoint(double newReference)
 	update();
 }
 
+void AMDeadTimeButton::setDisplayAsPercent(bool showPercent)
+{
+	displayPercent_ = showPercent;
+	onDeadTimeUpdated();
+}
+
 void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMDataSource *outputCountSource)
 {
 	disconnect(inputCountSource_->signalSource(), SIGNAL(valuesChanged(AMnDIndex,AMnDIndex)), this, SLOT(update()));
@@ -117,4 +138,9 @@ void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMData
 bool AMDeadTimeButton::hasDeadTimeSources() const
 {
 	return !(outputCountSource_ == 0 || inputCountSource_ == 0);
+}
+
+bool AMDeadTimeButton::hasICRDataSource() const
+{
+	return !(inputCountSource_ == 0);
 }

--- a/source/ui/beamline/AMDeadTimeButton.h
+++ b/source/ui/beamline/AMDeadTimeButton.h
@@ -35,7 +35,7 @@ public:
 	/// Constructor.  Makes a default button with no changing other than looking disabled.
 	AMDeadTimeButton(QWidget *parent = 0);
 	/// Constructor.  Takes two data sources (the data source is assumed to have rank 0), one for the input counts and one for the output counts, the good reference point, and the bad reference point.
-	AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, QWidget *parent = 0);
+	AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, bool displayPercent = true, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~AMDeadTimeButton();
 
@@ -53,6 +53,8 @@ public slots:
 	void setGoodReferencePoint(double newReference);
 	/// Sets the bad reference point.
 	void setBadReferencePoint(double newReference);
+	/// Sets the flag indicating whether to display dead time as percent (or counts).
+	void setDisplayAsPercent(bool showPercent);
 
 protected slots:
 	/// Method that updates the status text of the button and class update.
@@ -61,6 +63,8 @@ protected slots:
 protected:
 	/// Helper method that returns whether there are valid data sources or not.
 	bool hasDeadTimeSources() const;
+	/// Helper method that returns whether there is a valid ICR data source.
+	bool hasICRDataSource() const;
 	/// Re-implemented paint event.
 	void paintEvent(QPaintEvent *e);
 
@@ -72,6 +76,8 @@ protected:
 	double goodReferencePoint_;
 	/// The bad reference point.
 	double badReferencecPoint_;
+	/// The flag indicating whether to display dead time as percent (or counts).
+	bool displayPercent_;
 };
 
 #endif // AMDEADTIMEBUTTON_H

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -105,6 +105,7 @@ void AMXRFDetailedDetectorView::buildRegionOfInterestViews()
 void AMXRFDetailedDetectorView::buildDeadTimeView()
 {
 	bool deadTimeEnabled = detector_->hasDeadTimeCorrection();
+	bool hasICRControls = !detector_->inputCountSources().isEmpty();
 
 	deadTimeLabel_ = new QLabel("Dead Time: 0%");
 	connect(detector_, SIGNAL(deadTimeChanged()), this, SLOT(onDeadTimeChanged()));
@@ -118,6 +119,18 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 		for (int i = 0, elements = detector_->elements(); i < elements; i++){
 
 			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), detector_->outputCountSourceAt(i), 30.0, 50.0);
+			deadTimeButton->setCheckable(true);
+			deadTimeButton->setFixedSize(20, 20);
+			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
+			deadTimeButtons_->addButton(deadTimeButton, i);
+		}
+	}
+
+	else if (hasICRControls) {
+
+		for (int i = 0, elements = detector_->elements(); i < elements; i++){
+
+			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), 0, 300000, 1000000, false);
 			deadTimeButton->setCheckable(true);
 			deadTimeButton->setFixedSize(20, 20);
 			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);


### PR DESCRIPTION
- Modified the dead time button to be able to display counts information if the ICR sources are provided.
- Modified the XRF detailed detector view to use the ICR-based dead time buttons, if the detector has ICR sources.
- Added the 'all good events' controls to the Side and Main inboard Ge detectors.
- Cleaned up some stray cases in AMXRFDetector and AMXRFScanController where it was assumed that if there are ICRs then there are also OCRs--not true for the Xspress3 detectors on BioXAS.