### PR TITLE
Pull Request for Issue2202: dark current check in scan initialization

### DIFF
--- a/source/beamline/AMDetector.cpp
+++ b/source/beamline/AMDetector.cpp
@@ -122,6 +122,16 @@ bool AMDetector::darkCurrentValidState() const {
 	return false;
 }
 
+bool AMDetector::darkCurrentValidState(double dwellTime) const
+{
+	bool result = false;
+
+	if (canDoDarkCurrentCorrection() && darkCurrentTime_ < dwellTime)
+		result = darkCurrentValidState_;
+
+	return result;
+}
+
 QString AMDetector::acquisitionStateDescription(AMDetector::AcqusitionState state){
 	switch(state){
 	case NotReadyForAcquisition:

--- a/source/beamline/AMDetector.cpp
+++ b/source/beamline/AMDetector.cpp
@@ -126,7 +126,7 @@ bool AMDetector::darkCurrentValidState(double dwellTime) const
 {
 	bool result = false;
 
-	if (canDoDarkCurrentCorrection() && darkCurrentTime_ <= dwellTime)
+	if (canDoDarkCurrentCorrection() && darkCurrentTime_ >= dwellTime)
 		result = darkCurrentValidState_;
 
 	return result;

--- a/source/beamline/AMDetector.cpp
+++ b/source/beamline/AMDetector.cpp
@@ -126,7 +126,7 @@ bool AMDetector::darkCurrentValidState(double dwellTime) const
 {
 	bool result = false;
 
-	if (canDoDarkCurrentCorrection() && darkCurrentTime_ < dwellTime)
+	if (canDoDarkCurrentCorrection() && darkCurrentTime_ <= dwellTime)
 		result = darkCurrentValidState_;
 
 	return result;

--- a/source/beamline/AMDetector.h
+++ b/source/beamline/AMDetector.h
@@ -230,6 +230,8 @@ public:
 	virtual double darkCurrentTime() const;
 	/// Returns the valid state of the current dark current measurement.
 	virtual bool darkCurrentValidState() const;
+	/// Returns what the valid state of the current dark current measurement would be if the dwell time was changed to the given time.
+	virtual bool darkCurrentValidState(double dwellTime) const;
 
 	/// Returns the current acquisition state
 	AMDetector::AcqusitionState acquisitionState() const { return acquisitionState_; }

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -118,30 +118,15 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 			scalerInitialization = new AMListAction3(new AMListActionInfo3("BioXAS scaler initialization", "BioXAS scaler initialization"));
 			scalerInitialization->addSubAction(scaler->createContinuousEnableAction3(false)); // Check that the scaler is in single shot mode and is not acquiring.
 
-			// Determine the longest region time for the scan.
+			// Determine the longest region time of all axis in the scan.
 
 			double maxRegionTime = configuration->scanAxisAt(0)->regionAt(0)->regionTime();
 
-			for (int axisIndex = 0, axisCount = configuration->scanAxes().count(); axisIndex < axisCount; axisIndex++) {
-				for (int regionIndex = 0, regionCount = configuration->scanAxisAt(axisIndex)->regionCount(); regionIndex < regionCount; regionIndex++) {
+			for (int i = 0, count = configuration->scanAxes().count(); i < count; i++) {
+				double regionTime = configuration->scanAxisAt(i)->maximumRegionTime();
 
-					AMScanAxisRegion *region = configuration->scanAxisAt(axisIndex)->regionAt(regionIndex);
-					AMScanAxisEXAFSRegion *exafsRegion = qobject_cast<AMScanAxisEXAFSRegion*>(region);
-
-					double regionDwell = 0;
-
-					// If the region is an EXAFS region, the dwell time at a particular point could vary.
-					// In this case, the best way to make sure the largest possible dwell time is taken
-					// into account is to compare against the maximumTime() instead of the regionTime().
-
-					if (exafsRegion)
-						regionDwell = double(exafsRegion->maximumTime());
-					else
-						regionDwell = double(region->regionTime());
-
-					if (maxRegionTime < regionDwell)
-						maxRegionTime = regionDwell;
-				}
+				if (maxRegionTime < regionTime)
+					maxRegionTime = regionTime;
 			}
 
 			// Determine whether a dark current measurement is needed, by asking each scaler channel detector

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -72,7 +72,7 @@ AMAction3* BioXASBeamline::createDarkCurrentMeasurementAction(double dwellSecond
 
 	return result;
 }
-#include <QDebug>
+
 AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfiguration *configuration)
 {
 	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("BioXAS scan initialization", "BioXAS scan initialization"), AMListAction3::Parallel);

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -74,7 +74,7 @@ AMAction3* BioXASBeamline::createDarkCurrentMeasurementAction(double dwellSecond
 
 AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfiguration *configuration)
 {
-	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("BioXAS scan initialization", "BioXAS scan intialization"), AMListAction3::Parallel);
+	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("BioXAS scan initialization", "BioXAS scan initialization"), AMListAction3::Parallel);
 
 	if (configuration) {
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -59,7 +59,7 @@ AMAction3* BioXASBeamline::createDarkCurrentMeasurementAction(double dwellSecond
 
 		// Create dark current measurement action.
 
-		result = new AMListAction3(new AMListActionInfo3("BioXAS dark current measurement", "BioXAS dark current measurement action"), AMListAction3::Sequential);
+		result = new AMListAction3(new AMListActionInfo3("BioXAS dark current measurement", "BioXAS dark current measurement"), AMListAction3::Sequential);
 		result->addSubAction(AMActionSupport::buildControlMoveAction(soeShutter, CLSExclusiveStatesControl::Closed));
 		result->addSubAction(scaler->createMeasureDarkCurrentAction(dwellSeconds));
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -60,13 +60,13 @@ AMAction3* BioXASBeamline::createDarkCurrentMeasurementAction(double dwellSecond
 		// Create dark current measurement action.
 
 		result = new AMListAction3(new AMListActionInfo3("BioXAS dark current measurement", "BioXAS dark current measurement action"), AMListAction3::Sequential);
-		result->addSubAction(AMActionSupport::buildControlMoveAction(soeShutter, BioXASShutters::Closed));
+		result->addSubAction(AMActionSupport::buildControlMoveAction(soeShutter, CLSExclusiveStatesControl::Closed));
 		result->addSubAction(scaler->createMeasureDarkCurrentAction(dwellSeconds));
 
 		// Return shutter to initial settings.
 
 		if (shutterOpen)
-			result->addSubAction(AMActionSupport::buildControlMoveAction(soeShutter, BioXASShutters::Open));
+			result->addSubAction(AMActionSupport::buildControlMoveAction(soeShutter, CLSExclusiveStatesControl::Open));
 	}
 
 	return result;
@@ -665,6 +665,22 @@ void BioXASBeamline::clearFlowTransducers()
 {
 	if (utilities_)
 		utilities_->clearFlowTransducers();
+}
+
+void BioXASBeamline::setSOEShutter(CLSExclusiveStatesControl *shutter)
+{
+	if (soeShutter_ != shutter) {
+
+		if (soeShutter_)
+			removeShutter(soeShutter_);
+
+		soeShutter_ = shutter;
+
+		if (soeShutter_)
+			addShutter(soeShutter_, CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
+
+		emit soeShutterChanged(soeShutter_);
+	}
 }
 
 void BioXASBeamline::setUsingCryostat(bool usingCryostat)
@@ -1271,6 +1287,8 @@ BioXASBeamline::BioXASBeamline(const QString &controlName) :
 
 	beamStatus_ = 0;
 	utilities_ = 0;
+
+	soeShutter_ = 0;
 
 	usingCryostat_ = false;
 

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -117,6 +117,8 @@ public:
 	virtual BioXASSSRLMonochromator* mono() const { return 0; }
 	/// Returns the m2 mirror.
 	virtual BioXASM2Mirror* m2Mirror() const { return 0; }
+	/// Returns the SOE shutter.
+	virtual CLSExclusiveStatesControl* soeShutter() const { return 0; }
 
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return 0; }

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -78,6 +78,8 @@ public:
 	/// Returns the current connected state.
 	virtual bool isConnected() const;
 
+	/// Creates and returns an action that performs a dark current measurement.
+	virtual AMAction3* createDarkCurrentMeasurementAction(double dwellSeconds);
 	/// Creates and returns an action that initializes the beamline before a scan.
 	virtual AMAction3* createScanInitializationAction(AMGenericStepScanConfiguration *configuration);
 	/// Creates and returna an action that cleans up the beamline after a scan.

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -120,7 +120,7 @@ public:
 	/// Returns the m2 mirror.
 	virtual BioXASM2Mirror* m2Mirror() const { return 0; }
 	/// Returns the SOE shutter.
-	virtual CLSExclusiveStatesControl* soeShutter() const { return 0; }
+	virtual CLSExclusiveStatesControl* soeShutter() const { return soeShutter_; }
 
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return 0; }
@@ -209,6 +209,8 @@ public:
 signals:
 	/// Notifier that the current connected state has changed.
 	void connectedChanged(bool isConnected);
+	/// Notifier that the SOE shutter control has changed.
+	void soeShutterChanged(CLSExclusiveStatesControl *newShutter);
 	/// Notifier that the flag indicating whether this beamline is using the cryostat has changed.
 	void usingCryostatChanged(bool usingCryostat);
 	/// Notifier that the detector stage lateral motors list has changed.
@@ -317,6 +319,9 @@ protected slots:
 	/// Clears the flow transducers.
 	void clearFlowTransducers();
 
+	/// Sets the SOE shutter.
+	void setSOEShutter(CLSExclusiveStatesControl *shutter);
+
 	/// Sets whether the beamline is using the cryostat.
 	void setUsingCryostat(bool usingCryostat);
 
@@ -403,6 +408,9 @@ protected:
 	BioXASBeamStatus *beamStatus_;
 	/// The beamline utilities.
 	BioXASUtilities* utilities_;
+
+	/// The SOE shutter.
+	CLSExclusiveStatesControl *soeShutter_;
 
 	/// Flag indicating whether this beamline is using the cryostat.
 	bool usingCryostat_;

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -258,10 +258,9 @@ bool BioXASMainBeamline::useLytleDetector(bool useDetector)
 
 void BioXASMainBeamline::setupComponents()
 {
-	// Utilities - Main endstation shutter.
+	// SOE shutter.
 
-	soeShutter_ = new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I21-01:state", "SSH1607-5-I21-01:opr:open", "SSH1607-5-I21-01:opr:close", this);
-	addShutter(soeShutter_, CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
+	setSOEShutter(new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I21-01:state", "SSH1607-5-I21-01:opr:open", "SSH1607-5-I21-01:opr:close", this));
 
 	// Utilities - Main valves (non-beampath--beampath valves are added in BioXASBeamline).
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -260,7 +260,8 @@ void BioXASMainBeamline::setupComponents()
 {
 	// Utilities - Main endstation shutter.
 
-	addShutter(new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I21-01:state", "SSH1607-5-I21-01:opr:open", "SSH1607-5-I21-01:opr:close", this), CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
+	soeShutter_ = new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I21-01:state", "SSH1607-5-I21-01:opr:open", "SSH1607-5-I21-01:opr:close", this);
+	addShutter(soeShutter_, CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
 
 	// Utilities - Main valves (non-beampath--beampath valves are added in BioXASBeamline).
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -67,8 +67,6 @@ public:
 	virtual BioXASMainMonochromator *mono() const { return mono_; }
 	/// Returns the beamline M2 mirror.
 	virtual BioXASM2Mirror *m2Mirror() const { return m2Mirror_; }
-	/// Returns the SOE shutter.
-	virtual CLSExclusiveStatesControl* soeShutter() const { return soeShutter_; }
 
 	/// Returns the JJ slits.
 	virtual AMSlits* jjSlits() const { return jjSlits_; }

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -67,6 +67,8 @@ public:
 	virtual BioXASMainMonochromator *mono() const { return mono_; }
 	/// Returns the beamline M2 mirror.
 	virtual BioXASM2Mirror *m2Mirror() const { return m2Mirror_; }
+	/// Returns the SOE shutter.
+	virtual CLSExclusiveStatesControl* soeShutter() const { return soeShutter_; }
 
 	/// Returns the JJ slits.
 	virtual AMSlits* jjSlits() const { return jjSlits_; }
@@ -162,6 +164,8 @@ protected:
 	BioXASMainMonochromator *mono_;
 	/// The M2 mirror.
 	BioXASMainM2Mirror *m2Mirror_;
+	/// The SOE shutter.
+	CLSExclusiveStatesControl *soeShutter_;
 
 	/// JJ slits
 	AMSlits *jjSlits_;

--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
@@ -7,7 +7,7 @@
 #include "beamline/AMDetectorTriggerSource.h"
 
 BioXASSIS3820Scaler::BioXASSIS3820Scaler(const QString &baseName, BioXASZebraSoftInputControl *softInput, QObject *parent) :
-    CLSSIS3820Scaler(baseName, parent)
+	CLSSIS3820Scaler(baseName, parent)
 {
 	scanning_ = false;
 
@@ -246,7 +246,7 @@ AMAction3* BioXASSIS3820Scaler::createMoveToContinuousAction()
 	return result;
 }
 
-AMAction3* BioXASSIS3820Scaler::createMeasureDarkCurrentAction(int secondsDwell)
+AMAction3* BioXASSIS3820Scaler::createMeasureDarkCurrentAction(double secondsDwell)
 {
 	return new BioXASSIS3820ScalerDarkCurrentMeasurementAction(new CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(secondsDwell));
 }

--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.h
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.h
@@ -60,7 +60,7 @@ public:
 	virtual AMAction3* createMoveToContinuousAction();
 
 	/// Creates a new action that causes this scaler to take a dark current measurement.
-	virtual AMAction3* createMeasureDarkCurrentAction(int secondsDwell);
+	virtual AMAction3* createMeasureDarkCurrentAction(double secondsDwell);
 
 public slots:
 	/// The BioXAS scaler requires arming

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -262,7 +262,8 @@ void BioXASSideBeamline::setupComponents()
 {
 	// Utilities - Side endstation shutter.
 
-	addShutter(new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I22-01:state", "SSH1607-5-I22-01:opr:open", "SSH1607-5-I22-01:opr:close", this), CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
+	soeShutter_ = new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I22-01:state", "SSH1607-5-I22-01:opr:open", "SSH1607-5-I22-01:opr:close", this);
+	addShutter(soeShutter_, CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
 
 	// Utilities - Side valves (non-beampath--beampath valves are added in BioXASBeamline).
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -260,10 +260,9 @@ bool BioXASSideBeamline::useLytleDetector(bool useDetector)
 
 void BioXASSideBeamline::setupComponents()
 {
-	// Utilities - Side endstation shutter.
+	// SOE shutter.
 
-	soeShutter_ = new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I22-01:state", "SSH1607-5-I22-01:opr:open", "SSH1607-5-I22-01:opr:close", this);
-	addShutter(soeShutter_, CLSExclusiveStatesControl::Open, CLSExclusiveStatesControl::Closed);
+	setSOEShutter(new CLSExclusiveStatesControl("Endstation shutter", "SSH1607-5-I22-01:state", "SSH1607-5-I22-01:opr:open", "SSH1607-5-I22-01:opr:close", this));
 
 	// Utilities - Side valves (non-beampath--beampath valves are added in BioXASBeamline).
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -68,6 +68,8 @@ public:
 	virtual BioXASSideMonochromator* mono() const { return mono_; }
 	/// Returns the m2 mirror.
 	virtual BioXASSideM2Mirror* m2Mirror() const { return m2Mirror_; }
+	/// Returns the SOE shutter.
+	virtual CLSExclusiveStatesControl* soeShutter() const { return soeShutter_; }
 
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return beWindow_; }
@@ -175,6 +177,8 @@ protected:
 	BioXASSideMonochromator *mono_;
 	/// The M2 mirror.
 	BioXASSideM2Mirror *m2Mirror_;
+	/// The SOE shutter.
+	CLSExclusiveStatesControl *soeShutter_;
 
 	/// The Be window motor.
 	CLSMAXvMotor *beWindow_;

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -68,8 +68,6 @@ public:
 	virtual BioXASSideMonochromator* mono() const { return mono_; }
 	/// Returns the m2 mirror.
 	virtual BioXASSideM2Mirror* m2Mirror() const { return m2Mirror_; }
-	/// Returns the SOE shutter.
-	virtual CLSExclusiveStatesControl* soeShutter() const { return soeShutter_; }
 
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return beWindow_; }

--- a/source/beamline/CLS/CLSBasicScalerChannelDetector.cpp
+++ b/source/beamline/CLS/CLSBasicScalerChannelDetector.cpp
@@ -163,14 +163,8 @@ void CLSBasicScalerChannelDetector::onScalerSensitivityChanged()
 
 void CLSBasicScalerChannelDetector::onScalerDwellTimeChanged()
 {
-	if (scaler_) {
-
-		double newTime = scaler_->dwellTime();
-
-		if (newTime > darkCurrentTime()) {
-			setDarkCurrentValidState(false);
-		}
-	}
+	if (scaler_)
+		setDarkCurrentValidState( darkCurrentValidState(scaler_->dwellTime()) );
 }
 
 bool CLSBasicScalerChannelDetector::initializeImplementation(){

--- a/source/beamline/CLS/CLSSIS3820Scaler.cpp
+++ b/source/beamline/CLS/CLSSIS3820Scaler.cpp
@@ -308,7 +308,7 @@ AMAction3* CLSSIS3820Scaler::createTriggerAction(AMDetectorDefinitions::ReadMode
 	return new CLSSIS3820ScalerTriggerAction(new CLSSIS3820ScalerTriggerActionInfo(readMode));
 }
 
-AMAction3* CLSSIS3820Scaler::createMeasureDarkCurrentAction(int secondsDwell)
+AMAction3* CLSSIS3820Scaler::createMeasureDarkCurrentAction(double secondsDwell)
 {
 	return new CLSSIS3820ScalerDarkCurrentMeasurementAction(new CLSSIS3820ScalerDarkCurrentMeasurementActionInfo(secondsDwell));
 }
@@ -374,7 +374,7 @@ void CLSSIS3820Scaler::setTotalScans(int totalScans){
 		totalScans_->move(totalScans);
 }
 
-void CLSSIS3820Scaler::measureDarkCurrent(int secondsDwell)
+void CLSSIS3820Scaler::measureDarkCurrent(double secondsDwell)
 {
 	AMAction3 *action = createMeasureDarkCurrentAction(secondsDwell);
 

--- a/source/beamline/CLS/CLSSIS3820Scaler.h
+++ b/source/beamline/CLS/CLSSIS3820Scaler.h
@@ -124,7 +124,7 @@ public:
 	virtual AMAction3* createTriggerAction(AMDetectorDefinitions::ReadMode readMode);
 
 	/// Creates a new action that causes this scaler to take a dark current measurement.
-	virtual AMAction3* createMeasureDarkCurrentAction(int secondsDwell);
+	virtual AMAction3* createMeasureDarkCurrentAction(double secondsDwell);
 
 	/// Subclasses of the CLS scaler may require arming, the standard implementation does not
 	virtual bool requiresArming() const { return false; }
@@ -142,7 +142,7 @@ public slots:
 	void setTotalScans(int totalScans);
 
 	/// Creates the needed actions to perform a dark current correction on all available and able channels, and executes them.
-	void measureDarkCurrent(int secondsDwell);
+	void measureDarkCurrent(double secondsDwell);
 
 	/// Subclasses of the CLS scaler may require arming, the standard implementation does not
 	virtual void arm();

--- a/source/dataman/AMScanAxis.cpp
+++ b/source/dataman/AMScanAxis.cpp
@@ -21,6 +21,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "AMScanAxis.h"
 #include "dataman/AMScanAxisEXAFSRegion.h"
+#include "float.h"
 
 AMScanAxis::~AMScanAxis(){}
 
@@ -373,15 +374,15 @@ QString AMScanAxis::toString(const QString &units) const
 
 double AMScanAxis::minimumRegionTime() const
 {
-	double minTime = 0;
+	double minTime = DBL_MAX;
 
 	// Iterate through the regions, identify the smallest region time.
 
 	for (int i = 0, count = regionCount(); i < count; i++) {
 
-		double regionDwell = regionAt(i)->regionTime();
+		double regionDwell = double(regionAt(i)->regionTime());
 
-		if (minTime > regionDwell)
+		if (minTime > regionDwell && regionDwell >= 0)
 			minTime = regionDwell;
 	}
 

--- a/source/dataman/AMScanAxis.cpp
+++ b/source/dataman/AMScanAxis.cpp
@@ -20,6 +20,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "AMScanAxis.h"
+#include "dataman/AMScanAxisEXAFSRegion.h"
 
 AMScanAxis::~AMScanAxis(){}
 
@@ -368,4 +369,50 @@ QString AMScanAxis::toString(const QString &units) const
 		string.append(region->toString(units));
 
 	return string;
+}
+
+double AMScanAxis::minimumRegionTime() const
+{
+	double minTime = 0;
+
+	// Iterate through the regions, identify the smallest region time.
+
+	for (int i = 0, count = regionCount(); i < count; i++) {
+
+		double regionDwell = regionAt(i)->regionTime();
+
+		if (minTime > regionDwell)
+			minTime = regionDwell;
+	}
+
+	return minTime;
+}
+
+double AMScanAxis::maximumRegionTime() const
+{
+	double maxTime = 0;
+
+	// Iterate through the regions, identify the longest region time.
+
+	for (int i = 0, count = regionCount(); i < count; i++) {
+
+		double regionDwell = 0;
+
+		AMScanAxisRegion *region = regionAt(i);
+		AMScanAxisEXAFSRegion *exafsRegion = qobject_cast<AMScanAxisEXAFSRegion*>(region);
+
+		// If the region is an EXAFS region, the dwell time at a particular point could vary.
+		// In this case, the best way to make sure the largest possible dwell time is taken
+		// into account is to compare against the maximumTime() instead of the regionTime().
+
+		if (exafsRegion)
+			regionDwell = double(exafsRegion->maximumTime());
+		else
+			regionDwell = double(region->regionTime());
+
+		if (maxTime < regionDwell)
+			maxTime = regionDwell;
+	}
+
+	return maxTime;
 }

--- a/source/dataman/AMScanAxis.h
+++ b/source/dataman/AMScanAxis.h
@@ -83,6 +83,11 @@ public:
 	/// Returns a string containing the information in a standard way.
 	virtual QString toString(const QString &units = "") const;
 
+	/// Returns the minimum region time.
+	double minimumRegionTime() const;
+	/// Returns the maximum region time.
+	double maximumRegionTime() const;
+
 signals:
 	/// Notifier that a scan axis region has been added to the axis.  Passes a pointer to the new region.
 	void regionAdded(AMScanAxisRegion *);

--- a/source/ui/CLS/CLSSIS3820ScalerDarkCurrentWidget.cpp
+++ b/source/ui/CLS/CLSSIS3820ScalerDarkCurrentWidget.cpp
@@ -122,5 +122,5 @@ void CLSSIS3820ScalerDarkCurrentWidget::updateCollectButton()
 void CLSSIS3820ScalerDarkCurrentWidget::onCollectButtonClicked()
 {
 	if (scaler_)
-		scaler_->measureDarkCurrent(int(timeBox_->value()));
+		scaler_->measureDarkCurrent(timeBox_->value());
 }


### PR DESCRIPTION
Changes:
- There wasn't an explicit getter for the SOE shutter previously, so added class variable, getter, signal, setter for the SOE shutter to BioXASSideBeamline, BioXASMainBeamline, and BioXASBeamline.
- Added method to AMDetector that returns the dark current valid state for the given acquisition time.
- Added `BioXASBeamline::createDarkCurrentMeasurementAction(double)`, returns an action that performs a dark current measurement if the beamline has a valid scaler and SOE shutter to use.
- Added check to the scan initialization actions in BioXASBeamline. If one of the scaler channel detectors requires a dark current measurement, a call to `createDarkCurrentMeasurementAction(double)` is added to the initialization actions.

Testing:
- [x] No DC measurement (startup), XAS scan 1s --> should measure DC in scan init
- [x] DC measurement 1s, XAS scan 1s --> should NOT measure DC in scan init
- [x] DC measurement 1s, change gain, XAS scan 1s --> should measure DC in scan init
- [x] DC measurement 1s, XAS scan 2s --> should measure DC in scan init
- [x] DC measurement 2s, XAS scan 1s --> should NOT measure DC in scan init
- [x] DC measurement 1s, EXAFS scan (some points > 1s) --> should measure DC in scan init

In all cases, the DC corrected data sources should be included in scan data.