### PR TITLE
Pull Request for Issue2089: Photon Shutter 2 button does becomes disabled after injection

### DIFF
--- a/source/beamline/AMProcessVariablePrivate.cpp
+++ b/source/beamline/AMProcessVariablePrivate.cpp
@@ -184,6 +184,7 @@ AMProcessVariablePrivate::AMProcessVariablePrivate(const QString& pvName) : QObj
 	lastReadReady_ = false;
 	lastWriteReady_ = false;
 	connect(this, SIGNAL(connected()), this, SLOT(checkReadWriteReady()));
+	connect(this, SIGNAL(connected(bool)), this, SLOT(checkReadWriteReady()));
 	connect(this, SIGNAL(initialized()), this, SLOT(checkReadWriteReady()));
 	connect(this, SIGNAL(hasValuesChanged(bool)), this, SLOT(checkReadWriteReady()));
 


### PR DESCRIPTION
AMProcessVariablePrivate has two connected signals and isn't using the "important" one for the `checkReadWriteReady()` method.