### PR TITLE
Pull Request for Issue2199: VESPERS Mono can get stuck in Move Active

### DIFF
--- a/source/beamline/VESPERS/VESPERSAddOnsCoordinator.cpp
+++ b/source/beamline/VESPERS/VESPERSAddOnsCoordinator.cpp
@@ -247,6 +247,7 @@ VESPERSAddOnsCoordinator::VESPERSAddOnsCoordinator(QObject *parent)
 
 	// Atto H, V, N
 
+/*
 	allControls_->addControl(oldAttoHSetpointControl_);
 	allControls_->addControl(oldAttoHFeedbackControl_);
 
@@ -325,6 +326,7 @@ VESPERSAddOnsCoordinator::VESPERSAddOnsCoordinator(QObject *parent)
 	allControls_->addControl(oldRealAttoRxStatusControl_);
 	allControls_->addControl(oldRealAttoRyStatusControl_);
 	allControls_->addControl(oldRealAttoRzStatusControl_);
+*/
 
 	// Wire H, V, N
 

--- a/source/beamline/VESPERS/VESPERSAddOnsCoordinator.h
+++ b/source/beamline/VESPERS/VESPERSAddOnsCoordinator.h
@@ -24,6 +24,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/AMControlSet.h"
 #include "beamline/AMPVControl.h"
 
+#include <QTimer>
+
 class VESPERSAddOnsCoordinator : public QObject
 {
 Q_OBJECT
@@ -169,6 +171,11 @@ protected slots:
 
 	void restoreAddOnsWireHStatus();
 	void restoreAddOnsWireVAndNStatus();
+
+	// Mono
+
+	void onMonoStatusChanged(bool isMoving);
+	void onMonoTimerTimeout();
 
 protected:
 	/// Takes two independent motor statuses and returns a new status for the combined state.
@@ -338,6 +345,11 @@ protected:
 	AMSinglePVControl *addOnsWireNSetpointControl_;
 	AMSinglePVControl *addOnsWireNFeedbackControl_;
 	AMSinglePVControl *addOnsWireNStatusControl_;
+
+	// Mono
+	AMReadOnlyPVwStatusControl *monoFeedbackControl_;
+	AMSinglePVControl *monoMoveRelativeStepControl_;
+	QTimer *monoWaitTimer_;
 };
 
 #endif // VESPERSAddOnsCoordinator_H

--- a/source/dataman/database/AMDatabase.cpp
+++ b/source/dataman/database/AMDatabase.cpp
@@ -804,6 +804,13 @@ bool AMDatabase::startTransaction()
 		transactionOpenOnThread_.insert(QThread::currentThreadId());
 		qdbMutex_.unlock();
 	}
+
+	else {
+
+		QSqlError error = qdb().lastError();
+		AMErrorMon::error(this, 0, QString("Unable to start transaction.\nDatabase says: %1\nDriver says: %2").arg(error.databaseText()).arg(error.driverText()));
+	}
+
 	return success;
 }
 


### PR DESCRIPTION
Implemented a fix that can get the VESPERS mono out of it's stalled state.

I also added an error monitor to AMDatabase to maybe catch the crashing bug that has been plaguing VESPERS for months.  Hopefully this will give us a clue to the root cause.