### PR TITLE
Pull Request for Issue2230: Adding downstream blade current control to M1 mirrors.

### DIFF
--- a/source/beamline/BioXAS/BioXASM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASM1Mirror.cpp
@@ -7,6 +7,8 @@ BioXASM1Mirror::BioXASM1Mirror(const QString &name, QObject *parent) :
 	// Initialize member variables.
 
 	mask_ = 0;
+
+	downstreamBladeCurrent_ = 0;
 }
 
 BioXASM1Mirror::~BioXASM1Mirror()
@@ -47,5 +49,21 @@ void BioXASM1Mirror::setMask(BioXASM1MirrorMask *newControl)
 			addChildControl(mask_);
 
 		emit maskChanged(mask_);
+	}
+}
+
+void BioXASM1Mirror::setDownstreamBladeCurrent(AMControl *newControl)
+{
+	if (downstreamBladeCurrent_ != newControl) {
+
+		if (downstreamBladeCurrent_)
+			removeChildControl(downstreamBladeCurrent_);
+
+		downstreamBladeCurrent_ = newControl;
+
+		if (downstreamBladeCurrent_)
+			addChildControl(downstreamBladeCurrent_);
+
+		emit downstreamBladeCurrentChanged(downstreamBladeCurrent_);
 	}
 }

--- a/source/beamline/BioXAS/BioXASM1Mirror.h
+++ b/source/beamline/BioXAS/BioXASM1Mirror.h
@@ -25,18 +25,26 @@ public:
 
 	/// Returns the mask control.
 	BioXASM1MirrorMask* mask() const { return mask_; }
+	/// Returns the downstream blade current control.
+	AMControl* downstreamBladeCurrent() const { return downstreamBladeCurrent_; }
 
 signals:
 	/// Notifier that the mask control has changed.
 	void maskChanged(BioXASM1MirrorMask *newControl);
+	/// Notifier that the downstream blade current control has changed.
+	void downstreamBladeCurrentChanged(AMControl *newControl);
 
 public slots:
 	/// Sets the mask control.
 	void setMask(BioXASM1MirrorMask *newControl);
+	/// Sets the downstream blade current control.
+	void setDownstreamBladeCurrent(AMControl *newControl);
 
 protected:
 	/// The mask control.
 	BioXASM1MirrorMask *mask_;
+	/// The downstream blade current.
+	AMControl *downstreamBladeCurrent_;
 };
 
 #endif // BIOXASM1MIRROR_H

--- a/source/beamline/BioXAS/BioXASMainM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASMainM1Mirror.cpp
@@ -28,6 +28,8 @@ BioXASMainM1Mirror::BioXASMainM1Mirror(QObject *parent) :
 	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
 	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
 	setBend(new BioXASMainM1MirrorBendControl(name()+"BendControl", "m", this));
+
+	setDownstreamBladeCurrent(new AMReadOnlyPVControl(QString("%1%2").arg(name()).arg("DownstreamBladeCurrent"), QString("A1607-5-02:A:fbk"), this));
 }
 
 BioXASMainM1Mirror::~BioXASMainM1Mirror()

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -28,6 +28,8 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
 	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
 	setBend(new BioXASSideM1MirrorBendControl(name()+"BendControl", "m", this));
+
+	setDownstreamBladeCurrent(new AMReadOnlyPVControl(QString("%1%2").arg(name()).arg("DownstreamBladeCurrent"), QString("A1607-5-03:A:fbk"), this));
 }
 
 BioXASSideM1Mirror::~BioXASSideM1Mirror()

--- a/source/ui/BioXAS/BioXASM1MirrorView.cpp
+++ b/source/ui/BioXAS/BioXASM1MirrorView.cpp
@@ -1,5 +1,6 @@
 #include "BioXASM1MirrorView.h"
 #include "beamline/BioXAS/BioXASM1MirrorMask.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 BioXASM1MirrorView::BioXASM1MirrorView(BioXASM1Mirror *mirror, QWidget *parent) :
     QWidget(parent)
@@ -27,6 +28,11 @@ BioXASM1MirrorView::BioXASM1MirrorView(BioXASM1Mirror *mirror, QWidget *parent) 
 
 	mirrorView_ = new BioXASMirrorView(0);
 
+	// The downstream blade current editor.
+
+	downstreamBladeCurrentEditor_ = new BioXASControlEditor(0);
+	downstreamBladeCurrentEditor_->setTitle("Downstream blade current");
+
 	// Create and set layouts.
 
 	QHBoxLayout *buttonLayout = new QHBoxLayout();
@@ -38,6 +44,7 @@ BioXASM1MirrorView::BioXASM1MirrorView(BioXASM1Mirror *mirror, QWidget *parent) 
 	layout->addLayout(buttonLayout);
 	layout->addWidget(maskBox);
 	layout->addWidget(mirrorView_);
+	layout->addWidget(downstreamBladeCurrentEditor_);
 
 	setLayout(layout);
 
@@ -58,6 +65,7 @@ void BioXASM1MirrorView::refresh()
 	stopButton_->setControl(0);
 	maskView_->setMirrorMask(0);
 	mirrorView_->setMirror(0);
+	downstreamBladeCurrentEditor_->setControl(0);
 
 	// Update view elements.
 
@@ -65,6 +73,7 @@ void BioXASM1MirrorView::refresh()
 		stopButton_->setControl(mirror_);
 		updateMaskView();
 		mirrorView_->setMirror(mirror_);
+		updateDownstreamBladeCurrentEditor();
 	}
 }
 
@@ -94,4 +103,14 @@ void BioXASM1MirrorView::updateMaskView()
 		maskControl = mirror_->mask();
 
 	maskView_->setMirrorMask(maskControl);
+}
+
+void BioXASM1MirrorView::updateDownstreamBladeCurrentEditor()
+{
+	AMControl *downstreamBladeCurrentControl = 0;
+
+	if (mirror_)
+		downstreamBladeCurrentControl = mirror_->downstreamBladeCurrent();
+
+	downstreamBladeCurrentEditor_->setControl(downstreamBladeCurrentControl);
 }

--- a/source/ui/BioXAS/BioXASM1MirrorView.h
+++ b/source/ui/BioXAS/BioXASM1MirrorView.h
@@ -36,6 +36,8 @@ public slots:
 protected slots:
 	/// Updates the mask view.
 	void updateMaskView();
+	/// Updates the downstream blade current editor.
+	void updateDownstreamBladeCurrentEditor();
 
 protected:
 	/// The mirror being viewed.
@@ -49,6 +51,8 @@ protected:
 	BioXASMirrorView *mirrorView_;
 	/// The mirror bend view.
 	BioXASMirrorBendView *bendView_;
+	/// The downstream blade current editor.
+	BioXASControlEditor *downstreamBladeCurrentEditor_;
 };
 
 #endif // BIOXASM1MIRRORVIEW_H


### PR DESCRIPTION
Added new control to BioXASM1Mirror for the downstream blade current, with getter, setter, signal. Set this control in the Side and Main subclasses. Added control editor to the M1 mirror view.