### PR TITLE
Pull Request for Issue2224: BioXAS scaler modes check.

### DIFF
--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -371,6 +371,8 @@ void BioXASMainBeamline::setupComponents()
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
 	scaler_->setTriggerSource(zebraTriggerSource_);
+	scaler_->setInputsModeValuePreference(BioXASSIS3820Scaler::Mode1);
+	scaler_->setTriggerSourceModeValuePreference(BioXASSIS3820Scaler::Hardware);
 
 	// I0 channel.
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -305,7 +305,7 @@ void BioXASMainBeamline::setupComponents()
 	// JJ slits.
 
 	jjSlits_ = new AMSlits("BioXASMainJJSlits", this);
-	connect( jjSlits_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
+	connect( jjSlits_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	jjSlits_->setUpperBlade(new CLSMAXvMotor("SMTR1607-7-I21-11", "SMTR1607-7-I21-11", "SMTR1607-7-I21-11", false, 0.05, 2.0, this));
 	jjSlits_->setLowerBlade(new CLSMAXvMotor("SMTR1607-7-I21-10", "SMTR1607-7-I21-10", "SMTR1607-7-I21-10", false, 0.05, 2.0, this));

--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.cpp
@@ -16,8 +16,12 @@ BioXASSIS3820Scaler::BioXASSIS3820Scaler(const QString &baseName, BioXASZebraSof
 	inputsMode_ = new AMSinglePVControl("InputMode", baseName+":inputMode", this);
 	allControls_->addControl(inputsMode_);
 
+	connect( inputsMode_, SIGNAL(connected(bool)), this, SLOT(updateInputsModeControl()) );
+
 	triggerSourceMode_ = new AMSinglePVControl("TriggerSource", baseName+":triggerSource", this);
 	allControls_->addControl(triggerSourceMode_);
+
+	connect( triggerSourceMode_, SIGNAL(connected(bool)), this, SLOT(updateTriggerSourceModeControl()) );
 
 	softInput_ = softInput;
 	allControls_->addControl(softInput_);
@@ -77,6 +81,28 @@ void BioXASSIS3820Scaler::setTriggerSource(AMDetectorTriggerSource *triggerSourc
 	}
 }
 
+void BioXASSIS3820Scaler::setInputsModeValuePreference(double newValue)
+{
+	if (inputsModeValuePreference_ != newValue || !inputsModeValuePreferenceSet_) {
+		inputsModeValuePreferenceSet_ = true;
+		inputsModeValuePreference_ = newValue;
+		updateInputsModeControl();
+
+		emit inputsModeValuePreferenceChanged(inputsModeValuePreference_);
+	}
+}
+
+void BioXASSIS3820Scaler::setTriggerSourceModeValuePreference(double newValue)
+{
+	if (triggerSourceModeValuePreference_ != newValue || !triggerSourceModeValuePreferenceSet_) {
+		triggerSourceModeValuePreferenceSet_ = true;
+		triggerSourceModeValuePreference_ = newValue;
+		updateTriggerSourceModeControl();
+
+		emit triggerSourceModeValuePreferenceChanged(triggerSourceModeValuePreference_);
+	}
+}
+
 void BioXASSIS3820Scaler::setScanningState(bool isScanning)
 {
 	if (scanning_ != isScanning) {
@@ -118,6 +144,18 @@ void BioXASSIS3820Scaler::onTriggerSourceTriggered(AMDetectorDefinitions::ReadMo
 	Q_UNUSED(readMode)
 	initializeTriggerSource();
 	setScanningState(true);
+}
+
+void BioXASSIS3820Scaler::updateInputsModeControl()
+{
+	if (inputsMode_ && inputsMode_->canMove() && inputsModeValuePreferenceSet_)
+		inputsMode_->move(inputsModeValuePreference_);
+}
+
+void BioXASSIS3820Scaler::updateTriggerSourceModeControl()
+{
+	if (triggerSourceMode_ && triggerSourceMode_->canMove() && triggerSourceModeValuePreference_)
+		triggerSourceMode_->move(triggerSourceModeValuePreference_);
 }
 
 void BioXASSIS3820Scaler::triggerSourceSucceeded()

--- a/source/beamline/BioXAS/BioXASSIS3820Scaler.h
+++ b/source/beamline/BioXAS/BioXASSIS3820Scaler.h
@@ -17,6 +17,10 @@ class BioXASSIS3820Scaler : public CLSSIS3820Scaler
 public:
 	/// Enum describing the possible armed states.
 	enum ArmedMode { NotArmed = 0, Armed = 1 };
+	/// Enum describing the inputs mode states.
+	enum InputsMode { Mode0 = 0, Mode1 = 1 };
+	/// Enum describing the trigger source mode states.
+	enum TriggerSourceMode { Software = 0, Hardware = 1 };
 
 	/// The constructor.
 	BioXASSIS3820Scaler(const QString &baseName, BioXASZebraSoftInputControl *softInput, QObject *parent = 0);
@@ -62,12 +66,23 @@ public:
 	/// Creates a new action that causes this scaler to take a dark current measurement.
 	virtual AMAction3* createMeasureDarkCurrentAction(double secondsDwell);
 
+signals:
+	/// Notifier that the inputs mode value preference has changed.
+	void inputsModeValuePreferenceChanged(double newValue);
+	/// Notifier that the trigger source mode value preference has changed.
+	void triggerSourceModeValuePreferenceChanged(double newValue);
+
 public slots:
 	/// The BioXAS scaler requires arming
 	virtual void arm();
 
 	/// Our trigger source will need to be provided to us
 	void setTriggerSource(AMDetectorTriggerSource *triggerSource);
+
+	/// Sets the inputs mode value preference.
+	void setInputsModeValuePreference(double newValue);
+	/// Sets the trigger source mode value preference.
+	void setTriggerSourceModeValuePreference(double newValue);
 
 protected slots:
 	/// Sets the scaler's scanning state.
@@ -83,6 +98,11 @@ protected slots:
 	/// Actually handle triggering
 	virtual void onTriggerSourceTriggered(AMDetectorDefinitions::ReadMode readMode);
 
+	/// Handles applying the inputs mode value preference, if a preference has been set.
+	void updateInputsModeControl();
+	/// Handles applying the trigger source mode value preference, if a preference has been set.
+	void updateTriggerSourceModeControl();
+
 protected:
 	/// Method that calls set succeeded on the trigger source.  Reimplemented to use setSucceeded from zebra trigger source.
 	virtual void triggerSourceSucceeded();
@@ -93,8 +113,18 @@ protected:
 
 	/// Controls the inputs mode.
 	AMControl *inputsMode_;
+	/// Flag indicating whether an inputs mode preference has been set.
+	bool inputsModeValuePreferenceSet_;
+	/// The inputs mode value preference.
+	double inputsModeValuePreference_;
+
 	/// Controls the trigger source mode.
 	AMControl *triggerSourceMode_;
+	/// Flag indicating whether a trigger source mode preference has been set.
+	bool triggerSourceModeValuePreferenceSet_;
+	/// The trigger source mode value preference.
+	double triggerSourceModeValuePreference_;
+
 	/// The control for the soft input control of the zebra.  This is the actual trigger now.
 	BioXASZebraSoftInputControl *softInput_;
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -456,6 +456,8 @@ void BioXASSideBeamline::setupComponents()
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
 	scaler_->setTriggerSource(zebraTriggerSource_);
+	scaler_->setInputsModeValuePreference(BioXASSIS3820Scaler::Mode1);
+	scaler_->setTriggerSourceModeValuePreference(BioXASSIS3820Scaler::Hardware);
 
 	// I0 channel.
 


### PR DESCRIPTION
Implemented rudimentary 'preference' options for the BioXAS scaler inputs mode and trigger source mode controls. Added calls to set a preference for these controls to Side and Main beamlines. The preference should be applied every time the control's connected state changes.