### PR TITLE
Pull Request for Issue2240: Fixing mono stop button.

### DIFF
--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.cpp
@@ -86,6 +86,33 @@ bool BioXASSSRLMonochromator::isConnected() const
 	return connected;
 }
 
+bool BioXASSSRLMonochromator::canStop() const
+{
+	bool result = false;
+
+	if (isConnected()) {
+		result = (
+					paddle_->canStop() &&
+					crystalChange_->canStop() &&
+					vertical_->canStop() &&
+					lateral_->canStop() &&
+					crystal1Pitch_->canStop() &&
+					crystal1Roll_->canStop() &&
+					crystal2Pitch_->canStop() &&
+					crystal2Roll_->canStop() &&
+					stepBragg_->canStop() &&
+					encoderBragg_->canStop() &&
+					bragg_->canStop() &&
+					stepEnergy_->canStop() &&
+					encoderEnergy_->canStop() &&
+					mask_->upperBlade() && mask_->upperBlade()->canStop() &&
+					mask_->lowerBlade() && mask_->lowerBlade()->canStop()
+					);
+	}
+
+	return result;
+}
+
 void BioXASSSRLMonochromator::setSettlingTime(double newTimeSeconds)
 {
 	if (settlingTime_ != newTimeSeconds) {

--- a/source/beamline/BioXAS/BioXASSSRLMonochromator.h
+++ b/source/beamline/BioXAS/BioXASSSRLMonochromator.h
@@ -41,6 +41,9 @@ public:
 	/// Returns true if the mono is connected, false otherwise.
 	virtual bool isConnected() const;
 
+	/// Returns true if this control can be stopped right now, false otherwise. Finds this out be examining all child controls. Subclasses can reimplement to achieve their particular behavior.
+	virtual bool canStop() const;
+
 	/// Returns the paddle control.
 	CLSMAXvMotor* paddle() const { return paddle_; }
 	/// Returns the paddle status control.


### PR DESCRIPTION
Reimplemented 'canStop' for the SSRL mono. Pressing the stop button now causes the mono to stop.