### PR TITLE
PullRequest for Issue2244: reorder the call-order of setupUserConfiguration()

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -54,6 +54,7 @@ bool BioXASAppController::startup()
 		// Ensuring we automatically switch scan editors for new scans.
 		setAutomaticBringScanEditorToFront(true);
 
+		setupUserConfiguration();
 		result = true;
 	}
 

--- a/source/application/CLS/CLSAppController.cpp
+++ b/source/application/CLS/CLSAppController.cpp
@@ -28,7 +28,7 @@ bool CLSAppController::startup()
 		initializeBeamline();
 		registerClasses();
 		setupExporterOptions();
-		setupUserConfiguration();
+//		setupUserConfiguration();
 		setupUserInterface();
 		makeConnections();
 

--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -95,6 +95,7 @@ bool IDEASAppController::startup()
 		// Github setup for adding VESPERS specific comment.
 		additionalIssueTypesAndAssignees_.append("I think it's a IDEAS specific issue", "epengr");
 
+		setupUserConfiguration();
 
 		return true;
 	}

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -75,6 +75,7 @@ bool SGMAppController::startup() {
 		return false;
 
 	setupAMDSClientAppController();
+	setupUserConfiguration();
 
 	return true;
 }

--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -148,6 +148,8 @@ bool VESPERSAppController::startup()
 		if (!ensureProgramStructure())
 			return false;
 
+		setupUserConfiguration();
+
 		// Github setup for adding VESPERS specific comment.
 		additionalIssueTypesAndAssignees_.append("I think it's a VESPERS specific issue", "dretrex");
 


### PR DESCRIPTION
@dretrex 
I changed the order back to what it was. For example, in VESPERS, it should be called after the setupUserInterface.