### PR TITLE
Pull Request for Issue2249: Adding Be window motor control to Main.

### DIFF
--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -37,6 +37,7 @@ bool BioXASMainBeamline::isConnected() const
 				mono_ && mono_->isConnected() &&
 				m2Mirror_ && m2Mirror_->isConnected() &&
 
+				beWindow_ && beWindow_->isConnected() &&
 				jjSlits_ && jjSlits_->isConnected() &&
 				xiaFilters_ && xiaFilters_->isConnected() &&
 				dbhrMirrors_ && dbhrMirrors_->isConnected() &&
@@ -301,6 +302,11 @@ void BioXASMainBeamline::setupComponents()
 
 	beamStatus_->addComponent(m1Mirror_->mask()->state(), BioXASM1MirrorMaskState::Open);
 	beamStatus_->addComponent(mono_->mask()->state(), BioXASSSRLMonochromatorMaskState::Open);
+
+	// Be window.
+
+	beWindow_ = new CLSMAXvMotor("SMTR1607-7-I21-01", "SMTR1607-7-I21-01", "SMTR1607-7-I21-01", true, 0.01, 2.0, this);
+	connect( beWindow_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// JJ slits.
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -68,6 +68,8 @@ public:
 	/// Returns the beamline M2 mirror.
 	virtual BioXASM2Mirror *m2Mirror() const { return m2Mirror_; }
 
+	/// Returns the Be window motor.
+	virtual CLSMAXvMotor* beWindow() const { return beWindow_; }
 	/// Returns the JJ slits.
 	virtual AMSlits* jjSlits() const { return jjSlits_; }
 	/// Returns the XIA filters.
@@ -165,6 +167,8 @@ protected:
 	/// The SOE shutter.
 	CLSExclusiveStatesControl *soeShutter_;
 
+	/// The Be window motor.
+	CLSMAXvMotor *beWindow_;
 	/// JJ slits
 	AMSlits *jjSlits_;
 	/// XIA filters

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -44,6 +44,7 @@ bool BioXASSideBeamline::isConnected() const
 				mono_ && mono_->isConnected() &&
 				m2Mirror_ && m2Mirror_->isConnected() &&
 
+				beWindow_ && beWindow_->isConnected() &&
 				jjSlits_ && jjSlits_->isConnected() &&
 				xiaFilters_ && xiaFilters_->isConnected() &&
 				dbhrMirrors_ && dbhrMirrors_->isConnected() &&


### PR DESCRIPTION
Added the Be window height motor to BioXAS Main application. The motor control editor appears as expected. Noticed small bug where the Be window on Side wasn't being queried for its connected state in `BioXASSideBeamline::isConnected()`--fixed now.