### PR TITLE
PullRequest for Issue2254: synchronize the settings between the bruker detector and the 4E Detector

### DIFF
--- a/source/beamline/SXRMB/SXRMBBeamline.cpp
+++ b/source/beamline/SXRMB/SXRMBBeamline.cpp
@@ -719,6 +719,10 @@ void SXRMBBeamline::setupDetectors()
 	brukerDetector_ = new SXRMBBrukerDetector("Bruker", "Bruker XRF detector", this);
 	fourElementVortexDetector_ = new SXRMBFourElementVortexDetector("FourElementVortex", "4 elements Vortex detector", this);
 
+	addSynchronizedXRFDetector(brukerDetector_);
+	addSynchronizedXRFDetector(fourElementVortexDetector_);
+
+	// initialize the scaler detectors
 	beamlineI0Detector_ = new CLSBasicScalerChannelDetector("BeamlineI0Detector", "Beamline I0 Detector", scaler_, 16, this);
 	scaler_->channelAt(16)->setDetector(beamlineI0Detector_);
 


### PR DESCRIPTION
#2254 

When initializing the detector, we should tell the beamline to synchronize the bruker and the 4E detector