### PR TITLE
Pull Request for Issue2107: Adding output controls to BioXASZebra.

### DIFF
--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -134,8 +134,8 @@ HEADERS += \
 	source/ui/BioXAS/BioXASBeamStatusButtonBar.h \
 	source/beamline/BioXAS/BioXASZebraOutputControl.h \
 	source/beamline/BioXAS/BioXASSideZebra.h \
-	source/beamline/BioXAS/BioXASMainZebra.h
-
+	source/beamline/BioXAS/BioXASMainZebra.h \
+	source/ui/BioXAS/BioXASZebraOutputControlView.h
 
 SOURCES += \
 	source/beamline/BioXAS/BioXASPseudoMotorControl.cpp \
@@ -263,4 +263,5 @@ SOURCES += \
 	source/ui/BioXAS/BioXASBeamStatusButtonBar.cpp \
 	source/beamline/BioXAS/BioXASZebraOutputControl.cpp \
 	source/beamline/BioXAS/BioXASSideZebra.cpp \
-	source/beamline/BioXAS/BioXASMainZebra.cpp
+	source/beamline/BioXAS/BioXASMainZebra.cpp \
+	source/ui/BioXAS/BioXASZebraOutputControlView.cpp

--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -131,7 +131,8 @@ HEADERS += \
 	source/ui/BioXAS/BioXASControlButton.h \
 	source/ui/BioXAS/BioXASButtonBar.h \
 	source/ui/BioXAS/BioXASControlButtonBar.h \
-	source/ui/BioXAS/BioXASBeamStatusButtonBar.h
+	source/ui/BioXAS/BioXASBeamStatusButtonBar.h \
+	source/beamline/BioXAS/BioXASZebraOutputControl.h
 
 SOURCES += \
 	source/beamline/BioXAS/BioXASPseudoMotorControl.cpp \
@@ -256,4 +257,5 @@ SOURCES += \
 	source/ui/BioXAS/BioXASControlButton.cpp \
 	source/ui/BioXAS/BioXASButtonBar.cpp \
 	source/ui/BioXAS/BioXASControlButtonBar.cpp \
-	source/ui/BioXAS/BioXASBeamStatusButtonBar.cpp
+	source/ui/BioXAS/BioXASBeamStatusButtonBar.cpp \
+	source/beamline/BioXAS/BioXASZebraOutputControl.cpp

--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -132,7 +132,10 @@ HEADERS += \
 	source/ui/BioXAS/BioXASButtonBar.h \
 	source/ui/BioXAS/BioXASControlButtonBar.h \
 	source/ui/BioXAS/BioXASBeamStatusButtonBar.h \
-	source/beamline/BioXAS/BioXASZebraOutputControl.h
+	source/beamline/BioXAS/BioXASZebraOutputControl.h \
+	source/beamline/BioXAS/BioXASSideZebra.h \
+	source/beamline/BioXAS/BioXASMainZebra.h
+
 
 SOURCES += \
 	source/beamline/BioXAS/BioXASPseudoMotorControl.cpp \
@@ -258,4 +261,6 @@ SOURCES += \
 	source/ui/BioXAS/BioXASButtonBar.cpp \
 	source/ui/BioXAS/BioXASControlButtonBar.cpp \
 	source/ui/BioXAS/BioXASBeamStatusButtonBar.cpp \
-	source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+	source/beamline/BioXAS/BioXASZebraOutputControl.cpp \
+	source/beamline/BioXAS/BioXASSideZebra.cpp \
+	source/beamline/BioXAS/BioXASMainZebra.cpp

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -255,7 +255,7 @@ bool BioXASMainBeamline::useLytleDetector(bool useDetector)
 
 	return result;
 }
-#include <QDebug>
+
 void BioXASMainBeamline::setupComponents()
 {
 	// SOE shutter.
@@ -343,46 +343,6 @@ void BioXASMainBeamline::setupComponents()
 
 	zebra_ = new BioXASMainZebra("TRG1607-701", this);
 	connect(zebra_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()));
-
-	BioXASZebraPulseControl *pulse1 = zebra_->pulseControlAt(0);
-	if (pulse1)
-		pulse1->setEdgeTriggerPreference(0);
-
-	BioXASZebraPulseControl *pulse3 = zebra_->pulseControlAt(2);
-	if (pulse3)
-		pulse3->setEdgeTriggerPreference(0);
-
-	BioXASZebraSoftInputControl *softIn1 = zebra_->softInputControlAt(0);
-	if (softIn1)
-		softIn1->setTimeBeforeResetPreference(0.01);
-
-	BioXASZebraSoftInputControl *softIn3 = zebra_->softInputControlAt(2);
-	if (softIn3)
-		softIn3->setTimeBeforeResetPreference(0.01);
-
-	BioXASZebraOutputControl *out1TTL = zebra_->outputControlAt(0);
-	if (out1TTL)
-		out1TTL->setOutputValuePreference(54); // The OUT1TTL output should connect to PULSE3, or the Ge detector.
-	else
-		qDebug() << "OUT1TTL control is invalid, cannot set value preference.";
-
-	BioXASZebraOutputControl *out1NIM = zebra_->outputControlAt(1);
-	if (out1NIM)
-		out1NIM->setOutputValuePreference(37); // The OUT1NIM output should connect to OR2, or the scaler.
-	else
-		qDebug() << "OUT1NIM control is invalid, cannot set value preference.";
-
-	BioXASZebraOutputControl *out2TTL = zebra_->outputControlAt(2);
-	if (out2TTL)
-		out2TTL->setOutputValuePreference(54); // The OUT2TTL output should connect to PULSE3, or the Ge detector.
-	else
-		qDebug() << "OUT2TTL control is invalid, cannot set value preference.";
-
-	BioXASZebraOutputControl *out3TTL = zebra_->outputControlAt(3);
-	if (out3TTL)
-		out3TTL->setOutputValuePreference(32); // The OUT3TTL output should connect to AND1, or the fast shutter.
-	else
-		qDebug() << "OUT3TTL control is invalid, cannot set value preference.";
 
 	// The Zebra trigger source.
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -341,7 +341,7 @@ void BioXASMainBeamline::setupComponents()
 
 	// Zebra.
 
-	zebra_ = new BioXASZebra("TRG1607-701", this);
+	zebra_ = new BioXASMainZebra("TRG1607-701", this);
 	connect(zebra_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()));
 
 	BioXASZebraPulseControl *pulse1 = zebra_->pulseControlAt(0);

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -255,7 +255,7 @@ bool BioXASMainBeamline::useLytleDetector(bool useDetector)
 
 	return result;
 }
-
+#include <QDebug>
 void BioXASMainBeamline::setupComponents()
 {
 	// SOE shutter.
@@ -359,6 +359,30 @@ void BioXASMainBeamline::setupComponents()
 	BioXASZebraSoftInputControl *softIn3 = zebra_->softInputControlAt(2);
 	if (softIn3)
 		softIn3->setTimeBeforeResetPreference(0.01);
+
+	BioXASZebraOutputControl *out1TTL = zebra_->outputControlAt(0);
+	if (out1TTL)
+		out1TTL->setOutputValuePreference(54); // The OUT1TTL output should connect to PULSE3, or the Ge detector.
+	else
+		qDebug() << "OUT1TTL control is invalid, cannot set value preference.";
+
+	BioXASZebraOutputControl *out1NIM = zebra_->outputControlAt(1);
+	if (out1NIM)
+		out1NIM->setOutputValuePreference(37); // The OUT1NIM output should connect to OR2, or the scaler.
+	else
+		qDebug() << "OUT1NIM control is invalid, cannot set value preference.";
+
+	BioXASZebraOutputControl *out2TTL = zebra_->outputControlAt(2);
+	if (out2TTL)
+		out2TTL->setOutputValuePreference(54); // The OUT2TTL output should connect to PULSE3, or the Ge detector.
+	else
+		qDebug() << "OUT2TTL control is invalid, cannot set value preference.";
+
+	BioXASZebraOutputControl *out3TTL = zebra_->outputControlAt(3);
+	if (out3TTL)
+		out3TTL->setOutputValuePreference(32); // The OUT3TTL output should connect to AND1, or the fast shutter.
+	else
+		qDebug() << "OUT3TTL control is invalid, cannot set value preference.";
 
 	// The Zebra trigger source.
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -33,6 +33,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/BioXAS/BioXASMainStandardsWheel.h"
 #include "beamline/BioXAS/BioXASMainCryostatStage.h"
 #include "beamline/BioXAS/BioXASMainInboard32ElementGeDetector.h"
+#include "beamline/BioXAS/BioXASMainZebra.h"
 
 #include "util/AMErrorMonitor.h"
 #include "util/AMBiHash.h"
@@ -112,7 +113,7 @@ public:
 	virtual BioXAS32ElementGeDetector* ge32DetectorOutboard() const { return 0; }
 
 	/// Returns the zebra control box.
-	virtual BioXASZebra *zebra() const { return zebra_; }
+	virtual BioXASMainZebra *zebra() const { return zebra_; }
 	/// Returns the Zebra trigger source.
 	virtual AMZebraDetectorTriggerSource* zebraTriggerSource() const { return zebraTriggerSource_; }
 
@@ -204,7 +205,7 @@ protected:
 
 	// Zebra
 	/// Zebra trigger control.
-	BioXASZebra *zebra_;
+	BioXASMainZebra *zebra_;
 	/// Trigger source for the zebra (scaler and GE32)
 	AMZebraDetectorTriggerSource *zebraTriggerSource_;
 };

--- a/source/beamline/BioXAS/BioXASMainZebra.cpp
+++ b/source/beamline/BioXAS/BioXASMainZebra.cpp
@@ -12,6 +12,8 @@ BioXASMainZebra::BioXASMainZebra(const QString &baseName, QObject *parent) :
 
 	foreach (AMControl *outputControl, outputControls_)
 		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );
+
+	onConnectedChanged();
 }
 
 BioXASMainZebra::~BioXASMainZebra()

--- a/source/beamline/BioXAS/BioXASMainZebra.cpp
+++ b/source/beamline/BioXAS/BioXASMainZebra.cpp
@@ -5,10 +5,10 @@ BioXASMainZebra::BioXASMainZebra(const QString &baseName, QObject *parent) :
 {
 	// Add the Main-specific output controls.
 
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 TTL"), QString("%1:OUT1_TTL"), this);
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 NIM"), QString("%1:OUT1_NIM"), this);
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT2 TTL"), QString("%1:OUT2_TTL"), this);
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT3 TTL"), QString("%1:OUT3_TTL"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 TTL"), QString("%1:OUT1_TTL").arg(baseName), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 NIM"), QString("%1:OUT1_NIM").arg(baseName), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT2 TTL"), QString("%1:OUT2_TTL").arg(baseName), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT3 TTL"), QString("%1:OUT3_TTL").arg(baseName), this);
 
 	foreach (AMControl *outputControl, outputControls_)
 		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );

--- a/source/beamline/BioXAS/BioXASMainZebra.cpp
+++ b/source/beamline/BioXAS/BioXASMainZebra.cpp
@@ -1,0 +1,21 @@
+#include "BioXASMainZebra.h"
+
+BioXASMainZebra::BioXASMainZebra(const QString &baseName, QObject *parent) :
+	BioXASZebra(baseName, parent)
+{
+	// Add the Main-specific output controls.
+
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 TTL"), QString("%1:OUT1_TTL"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 NIM"), QString("%1:OUT1_NIM"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT2 TTL"), QString("%1:OUT2_TTL"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT3 TTL"), QString("%1:OUT3_TTL"), this);
+
+	foreach (AMControl *outputControl, outputControls_)
+		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );
+}
+
+BioXASMainZebra::~BioXASMainZebra()
+{
+
+}
+

--- a/source/beamline/BioXAS/BioXASMainZebra.cpp
+++ b/source/beamline/BioXAS/BioXASMainZebra.cpp
@@ -14,6 +14,40 @@ BioXASMainZebra::BioXASMainZebra(const QString &baseName, QObject *parent) :
 		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );
 
 	onConnectedChanged();
+
+	// Value preferences.
+
+	BioXASZebraPulseControl *pulse1 = pulseControlAt(0);
+	if (pulse1)
+		pulse1->setEdgeTriggerPreference(0);
+
+	BioXASZebraPulseControl *pulse3 = pulseControlAt(2);
+	if (pulse3)
+		pulse3->setEdgeTriggerPreference(0);
+
+	BioXASZebraSoftInputControl *softIn1 = softInputControlAt(0);
+	if (softIn1)
+		softIn1->setTimeBeforeResetPreference(0.01);
+
+	BioXASZebraSoftInputControl *softIn3 = softInputControlAt(2);
+	if (softIn3)
+		softIn3->setTimeBeforeResetPreference(0.01);
+
+	BioXASZebraOutputControl *out1TTL = outputControlAt(0);
+	if (out1TTL)
+		out1TTL->setOutputValuePreference(54); // The OUT1TTL output should connect to PULSE3, or the Ge detector.
+
+	BioXASZebraOutputControl *out1NIM = outputControlAt(1);
+	if (out1NIM)
+		out1NIM->setOutputValuePreference(37); // The OUT1NIM output should connect to OR2, or the scaler.
+
+	BioXASZebraOutputControl *out2TTL = outputControlAt(2);
+	if (out2TTL)
+		out2TTL->setOutputValuePreference(54); // The OUT2TTL output should connect to PULSE3, or the Ge detector.
+
+	BioXASZebraOutputControl *out3TTL = outputControlAt(3);
+	if (out3TTL)
+		out3TTL->setOutputValuePreference(32); // The OUT3TTL output should connect to AND1, or the fast shutter.
 }
 
 BioXASMainZebra::~BioXASMainZebra()

--- a/source/beamline/BioXAS/BioXASMainZebra.h
+++ b/source/beamline/BioXAS/BioXASMainZebra.h
@@ -1,0 +1,17 @@
+#ifndef BIOXASMAINZEBRA_H
+#define BIOXASMAINZEBRA_H
+
+#include "beamline/BioXAS/BioXASZebra.h"
+
+class BioXASMainZebra : public BioXASZebra
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	BioXASMainZebra(const QString &baseName, QObject *parent = 0);
+	/// Destructor.
+	virtual ~BioXASMainZebra();
+};
+
+#endif // BIOXASMAINZEBRA_H

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -444,6 +444,18 @@ void BioXASSideBeamline::setupComponents()
 	if (xspress3Pulse)
 		xspress3Pulse->setInputValuePreference(52); // The Xspress3 detector can be triggered using pulse 1 (#52).
 
+	BioXASZebraOutputControl *out1TTL = zebra_->outputControlAt(0);
+	if (out1TTL)
+		out1TTL->setOutputValuePreference(54); // The OUT1TTL output should connect to PULSE3, or the Ge detector.
+
+	BioXASZebraOutputControl *out1NIM = zebra_->outputControlAt(1);
+	if (out1NIM)
+		out1NIM->setOutputValuePreference(37); // The OUT1NIM output should connect to OR2, or the scaler.
+
+	BioXASZebraOutputControl *out2TTL = zebra_->outputControlAt(2);
+	if (out2TTL)
+		out2TTL->setOutputValuePreference(32); // The OUT2TTL output should connect to AND1, or the fast shutter.
+
 	// The Zebra trigger source.
 
 	zebraTriggerSource_ = new AMZebraDetectorTriggerSource("ZebraTriggerSource", this);

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -400,7 +400,7 @@ void BioXASSideBeamline::setupComponents()
 
 	// Zebra.
 
-	zebra_ = new BioXASZebra("TRG1607-601", this);
+	zebra_ = new BioXASSideZebra("TRG1607-601", this);
 	connect(zebra_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()));
 
 	BioXASZebraPulseControl *pulse1 = zebra_->pulseControlAt(0);

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -403,59 +403,6 @@ void BioXASSideBeamline::setupComponents()
 	zebra_ = new BioXASSideZebra("TRG1607-601", this);
 	connect(zebra_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()));
 
-	BioXASZebraPulseControl *pulse1 = zebra_->pulseControlAt(0);
-	if (pulse1)
-		pulse1->setEdgeTriggerPreference(0);
-
-	BioXASZebraPulseControl *pulse3 = zebra_->pulseControlAt(2);
-	if (pulse3)
-		pulse3->setEdgeTriggerPreference(0);
-
-	BioXASZebraSoftInputControl *softIn1 = zebra_->softInputControlAt(0);
-	if (softIn1)
-		softIn1->setTimeBeforeResetPreference(0.1); // The zebra has a good chance of missing triggers if this value is lower (definitely at 0.01).
-
-	BioXASZebraSoftInputControl *softIn2 = zebra_->softInputControlAt(1);
-	if (softIn2)
-		softIn2->setTimeBeforeResetPreference(0);  // The fast shutter control should toggle high or toggle low when triggered.
-
-	BioXASZebraSoftInputControl *softIn3 = zebra_->softInputControlAt(2);
-	if (softIn3)
-		softIn3->setTimeBeforeResetPreference(0.1); // The zebra has a good chance of missing triggers if this value is lower (definitely at 0.01).
-
-	BioXASZebraLogicBlock *fastShutterBlock = zebra_->andBlockAt(0);
-	if (fastShutterBlock) {
-		fastShutterBlock->setInputValuePreference(0, 61); // The fast shutter can be triggered using soft input 2 (#61).
-//		fastShutterBlock->setInputValuePreference(1, 52); // The fast shutter can be triggered using pulse 1 (#52).
-		fastShutterBlock->setInputValuePreference(1, 0); // The fast shutter is disconnected from pulse 1, until we want the fast shutter to be triggered with every acquisition point.
-	}
-
-	BioXASZebraLogicBlock *scalerBlock = zebra_->orBlockAt(1);
-	if (scalerBlock) {
-		scalerBlock->setInputValuePreference(0, 52); // The scaler can be triggered using pulse 1 (#52).
-		scalerBlock->setInputValuePreference(1, 62); // The scaler can be triggered using soft input 3 (#62).
-	}
-
-	BioXASZebraPulseControl *scanPulse = zebra_->pulseControlAt(0);
-	if (scanPulse)
-		scanPulse->setInputValuePreference(60); // The 'scan pulse' (pulse 1) can be triggered using soft input 1 (#60).
-
-	BioXASZebraPulseControl *xspress3Pulse = zebra_->pulseControlAt(2);
-	if (xspress3Pulse)
-		xspress3Pulse->setInputValuePreference(52); // The Xspress3 detector can be triggered using pulse 1 (#52).
-
-	BioXASZebraOutputControl *out1TTL = zebra_->outputControlAt(0);
-	if (out1TTL)
-		out1TTL->setOutputValuePreference(54); // The OUT1TTL output should connect to PULSE3, or the Ge detector.
-
-	BioXASZebraOutputControl *out1NIM = zebra_->outputControlAt(1);
-	if (out1NIM)
-		out1NIM->setOutputValuePreference(37); // The OUT1NIM output should connect to OR2, or the scaler.
-
-	BioXASZebraOutputControl *out2TTL = zebra_->outputControlAt(2);
-	if (out2TTL)
-		out2TTL->setOutputValuePreference(32); // The OUT2TTL output should connect to AND1, or the fast shutter.
-
 	// The Zebra trigger source.
 
 	zebraTriggerSource_ = new AMZebraDetectorTriggerSource("ZebraTriggerSource", this);
@@ -463,7 +410,7 @@ void BioXASSideBeamline::setupComponents()
 
 	// Scaler.
 
-	scaler_ = new BioXASSIS3820Scaler("MCS1607-601:mcs", softIn3, this);
+	scaler_ = new BioXASSIS3820Scaler("MCS1607-601:mcs", zebra_->softInputControlAt(2), this);
 	connect( scaler_, SIGNAL(connectedChanged(bool)), this, SLOT(updateConnected()) );
 
 	scaler_->setTriggerSource(zebraTriggerSource_);

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -35,6 +35,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/BioXAS/BioXASSideFilterFlipper.h"
 #include "beamline/BioXAS/BioXASSide32ElementGeDetector.h"
 #include "beamline/BioXAS/BioXASSideCryostat.h"
+#include "beamline/BioXAS/BioXASSideZebra.h"
 
 class AMZebraDetectorTriggerSource;
 
@@ -127,7 +128,7 @@ public:
 	virtual bool canUseLytleDetector() const { return true; }
 
 	/// Returns the zebra control box.
-	virtual BioXASZebra *zebra() const { return zebra_; }
+	virtual BioXASSideZebra *zebra() const { return zebra_; }
 	/// Returns the Zebra trigger source.
 	virtual AMZebraDetectorTriggerSource* zebraTriggerSource() const { return zebraTriggerSource_; }
 
@@ -229,7 +230,7 @@ protected:
 
 	// Zebra
 	/// Zebra trigger control.
-	BioXASZebra *zebra_;
+	BioXASSideZebra *zebra_;
 	/// The fast shutter.
 	BioXASFastShutter *fastShutter_;
 };

--- a/source/beamline/BioXAS/BioXASSideZebra.cpp
+++ b/source/beamline/BioXAS/BioXASSideZebra.cpp
@@ -11,6 +11,8 @@ BioXASSideZebra::BioXASSideZebra(const QString &baseName, QObject *parent) :
 
 	foreach (AMControl *outputControl, outputControls_)
 		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );
+
+	onConnectedChanged();
 }
 
 BioXASSideZebra::~BioXASSideZebra()

--- a/source/beamline/BioXAS/BioXASSideZebra.cpp
+++ b/source/beamline/BioXAS/BioXASSideZebra.cpp
@@ -1,0 +1,20 @@
+#include "BioXASSideZebra.h"
+
+BioXASSideZebra::BioXASSideZebra(const QString &baseName, QObject *parent) :
+	BioXASZebra(baseName, parent)
+{
+	// Add the Side-specific output controls.
+
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 TTL"), QString("%1:OUT1_TTL"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 NIM"), QString("%1:OUT1_NIM"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT2 TTL"), QString("%1:OUT2_TTL"), this);
+
+	foreach (AMControl *outputControl, outputControls_)
+		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );
+}
+
+BioXASSideZebra::~BioXASSideZebra()
+{
+
+}
+

--- a/source/beamline/BioXAS/BioXASSideZebra.cpp
+++ b/source/beamline/BioXAS/BioXASSideZebra.cpp
@@ -5,9 +5,9 @@ BioXASSideZebra::BioXASSideZebra(const QString &baseName, QObject *parent) :
 {
 	// Add the Side-specific output controls.
 
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 TTL"), QString("%1:OUT1_TTL"), this);
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 NIM"), QString("%1:OUT1_NIM"), this);
-	outputControls_ << new BioXASZebraOutputControl(QString("OUT2 TTL"), QString("%1:OUT2_TTL"), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 TTL"), QString("%1:OUT1_TTL").arg(baseName), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT1 NIM"), QString("%1:OUT1_NIM").arg(baseName), this);
+	outputControls_ << new BioXASZebraOutputControl(QString("OUT2 TTL"), QString("%1:OUT2_TTL").arg(baseName), this);
 
 	foreach (AMControl *outputControl, outputControls_)
 		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );

--- a/source/beamline/BioXAS/BioXASSideZebra.cpp
+++ b/source/beamline/BioXAS/BioXASSideZebra.cpp
@@ -13,6 +13,62 @@ BioXASSideZebra::BioXASSideZebra(const QString &baseName, QObject *parent) :
 		connect( outputControl, SIGNAL(connected(bool)), this, SLOT(onConnectedChanged()) );
 
 	onConnectedChanged();
+
+	// Value preferences.
+
+	BioXASZebraPulseControl *pulse1 = pulseControlAt(0);
+	if (pulse1)
+		pulse1->setEdgeTriggerPreference(0);
+
+	BioXASZebraPulseControl *pulse3 = pulseControlAt(2);
+	if (pulse3)
+		pulse3->setEdgeTriggerPreference(0);
+
+	BioXASZebraSoftInputControl *softIn1 = softInputControlAt(0);
+	if (softIn1)
+		softIn1->setTimeBeforeResetPreference(0.1); // The zebra has a good chance of missing triggers if this value is lower (definitely at 0.01).
+
+	BioXASZebraSoftInputControl *softIn2 = softInputControlAt(1);
+	if (softIn2)
+		softIn2->setTimeBeforeResetPreference(0);  // The fast shutter control should toggle high or toggle low when triggered.
+
+	BioXASZebraSoftInputControl *softIn3 = softInputControlAt(2);
+	if (softIn3)
+		softIn3->setTimeBeforeResetPreference(0.1); // The zebra has a good chance of missing triggers if this value is lower (definitely at 0.01).
+
+	BioXASZebraLogicBlock *fastShutterBlock = andBlockAt(0);
+	if (fastShutterBlock) {
+		fastShutterBlock->setInputValuePreference(0, 61); // The fast shutter can be triggered using soft input 2 (#61).
+//		fastShutterBlock->setInputValuePreference(1, 52); // The fast shutter can be triggered using pulse 1 (#52).
+		fastShutterBlock->setInputValuePreference(1, 0); // The fast shutter is disconnected from pulse 1, until we want the fast shutter to be triggered with every acquisition point.
+	}
+
+	BioXASZebraLogicBlock *scalerBlock = orBlockAt(1);
+	if (scalerBlock) {
+		scalerBlock->setInputValuePreference(0, 52); // The scaler can be triggered using pulse 1 (#52).
+		scalerBlock->setInputValuePreference(1, 62); // The scaler can be triggered using soft input 3 (#62).
+	}
+
+	BioXASZebraPulseControl *scanPulse = pulseControlAt(0);
+	if (scanPulse)
+		scanPulse->setInputValuePreference(60); // The 'scan pulse' (pulse 1) can be triggered using soft input 1 (#60).
+
+	BioXASZebraPulseControl *xspress3Pulse = pulseControlAt(2);
+	if (xspress3Pulse)
+		xspress3Pulse->setInputValuePreference(52); // The Xspress3 detector can be triggered using pulse 1 (#52).
+
+	BioXASZebraOutputControl *out1TTL = outputControlAt(0);
+	if (out1TTL)
+		out1TTL->setOutputValuePreference(54); // The OUT1TTL output should connect to PULSE3, or the Ge detector.
+
+	BioXASZebraOutputControl *out1NIM = outputControlAt(1);
+	if (out1NIM)
+		out1NIM->setOutputValuePreference(37); // The OUT1NIM output should connect to OR2, or the scaler.
+
+	BioXASZebraOutputControl *out2TTL = outputControlAt(2);
+	if (out2TTL)
+		out2TTL->setOutputValuePreference(32); // The OUT2TTL output should connect to AND1, or the fast shutter.
+
 }
 
 BioXASSideZebra::~BioXASSideZebra()

--- a/source/beamline/BioXAS/BioXASSideZebra.h
+++ b/source/beamline/BioXAS/BioXASSideZebra.h
@@ -1,0 +1,17 @@
+#ifndef BIOXASSIDEZEBRA_H
+#define BIOXASSIDEZEBRA_H
+
+#include "beamline/BioXAS/BioXASZebra.h"
+
+class BioXASSideZebra : public BioXASZebra
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	BioXASSideZebra(const QString &baseName, QObject *parent = 0);
+	/// Destructor.
+	virtual ~BioXASSideZebra();
+};
+
+#endif // BIOXASSIDEZEBRA_H

--- a/source/beamline/BioXAS/BioXASZebra.cpp
+++ b/source/beamline/BioXAS/BioXASZebra.cpp
@@ -115,6 +115,21 @@ BioXASZebraLogicBlock* BioXASZebra::orBlockAt(int index) const
 	return result;
 }
 
+QList<BioXASZebraOutputControl*> BioXASZebra::outputControls() const
+{
+	return outputControls_;
+}
+
+BioXASZebraOutputControl* BioXASZebra::outputControlAt(int index) const
+{
+	BioXASZebraOutputControl *result = 0;
+
+	if (index >= 0 && index < outputControls_.count())
+		result = outputControls_.at(index);
+
+	return result;
+}
+#include <QDebug>
 void BioXASZebra::onConnectedChanged()
 {
 	bool connected = true;
@@ -131,8 +146,12 @@ void BioXASZebra::onConnectedChanged()
 	foreach (AMControl *orBlock, orBlocks_)
 		connected &= orBlock->isConnected();
 
+	foreach (AMControl *outputControl, outputControls_)
+		connected &= outputControl->isConnected();
+
 	if (connected_ != connected){
 		connected_ = connected;
+		qDebug() << (connected_ ? "Zebra is connected." : "Zebra is NOT connected.");
 		emit connectedChanged(connected_);
 	}
 

--- a/source/beamline/BioXAS/BioXASZebra.cpp
+++ b/source/beamline/BioXAS/BioXASZebra.cpp
@@ -129,7 +129,7 @@ BioXASZebraOutputControl* BioXASZebra::outputControlAt(int index) const
 
 	return result;
 }
-#include <QDebug>
+
 void BioXASZebra::onConnectedChanged()
 {
 	bool connected = true;
@@ -151,7 +151,6 @@ void BioXASZebra::onConnectedChanged()
 
 	if (connected_ != connected){
 		connected_ = connected;
-		qDebug() << (connected_ ? "Zebra is connected." : "Zebra is NOT connected.");
 		emit connectedChanged(connected_);
 	}
 

--- a/source/beamline/BioXAS/BioXASZebra.h
+++ b/source/beamline/BioXAS/BioXASZebra.h
@@ -6,6 +6,7 @@
 #include "beamline/BioXAS/BioXASZebraPulseControl.h"
 #include "beamline/BioXAS/BioXASZebraSoftInputControl.h"
 #include "beamline/BioXAS/BioXASZebraLogicBlock.h"
+#include "beamline/BioXAS/BioXASZebraOutputControl.h"
 
 #include "beamline/AMPVControl.h"
 
@@ -45,6 +46,11 @@ public:
 	/// Returns the OR block at the given index.
 	BioXASZebraLogicBlock* orBlockAt(int index) const;
 
+	/// Returns the list of output controls.
+	QList<BioXASZebraOutputControl*> outputControls() const;
+	/// Returns the output contorl at the given index.
+	BioXASZebraOutputControl* outputControlAt(int index) const;
+
 signals:
 	/// Notifier that the connectivity has changed.
 	void connectedChanged(bool);
@@ -79,6 +85,8 @@ protected:
 	QList<BioXASZebraLogicBlock*> andBlocks_;
 	/// List of OR blocks.
 	QList<BioXASZebraLogicBlock*> orBlocks_;
+	/// List of output controls.
+	QList<BioXASZebraOutputControl*> outputControls_;
 
 	/// List of synchronized pulse controls.
 	QList<BioXASZebraPulseControl*> synchronizedPulseControls_;

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -9,14 +9,14 @@ BioXASZebraOutputControl::BioXASZebraOutputControl(const QString &name, const QS
 	name_ = name;
 
 	allControls_ = new AMControlSet(this);
-	connect( allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged(bool)) );
+	connect( allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged()) );
 
 	outputValueControl_ = new AMSinglePVControl(QString(baseName), QString(baseName), this);
-	connect( outputValueControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputValueChanged(int)) );
+	connect( outputValueControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputValueChanged()) );
 	allControls_->addControl(outputValueControl_);
 
 	outputStatusControl_ = new AMReadOnlyPVControl(QString("%1:%2").arg(baseName).arg("STA"), QString("%1:%2").arg(baseName).arg("STA"), this);
-	connect( outputStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputStatusChanged(bool)) );
+	connect( outputStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputStatusChanged()) );
 	allControls_->addControl(outputStatusControl_);
 
 	outputValuePreferenceSet_ = false;

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -11,7 +11,7 @@ BioXASZebraOutputControl::BioXASZebraOutputControl(const QString &name, const QS
 	allControls_ = new AMControlSet(this);
 	connect( allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged()) );
 
-	outputValueControl_ = new AMSinglePVControl(QString(baseName), QString(baseName), this);
+	outputValueControl_ = new AMSinglePVControl(QString(baseName), QString(baseName), this, 0.1);
 	connect( outputValueControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputValueChanged()) );
 	allControls_->addControl(outputValueControl_);
 
@@ -50,12 +50,14 @@ bool BioXASZebraOutputControl::outputStatusValue() const
 
 void BioXASZebraOutputControl::setOutputValue(int newValue)
 {
-	outputValueControl_->move(newValue);
+	if (!outputValueControl_->withinTolerance(double(newValue)))
+		outputValueControl_->move(double(newValue));
 }
-
+#include <QDebug>
 void BioXASZebraOutputControl::setOutputValuePreference(int newValue)
 {
 	if (outputValuePreference_ != newValue || !outputValuePreferenceSet_) {
+		qDebug() << "Setting value preference for control" << name() << "," << newValue;
 		outputValuePreferenceSet_ = true;
 		outputValuePreference_ = newValue;
 		updateOutputValueControl();
@@ -84,7 +86,9 @@ void BioXASZebraOutputControl::onOutputStatusChanged()
 
 void BioXASZebraOutputControl::updateOutputValueControl()
 {
-	if (outputValuePreferenceSet_)
+	if (outputValuePreferenceSet_) {
+		qDebug() << "Updating output value" << name();
 		setOutputValue(outputValuePreference_);
+	}
 }
 

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -1,0 +1,90 @@
+#include "BioXASZebraOutputControl.h"
+#include "beamline/AMPVControl.h"
+#include "beamline/AMControlSet.h"
+#include "beamline/BioXAS/BioXASZebraCommands.h"
+
+BioXASZebraOutputControl::BioXASZebraOutputControl(const QString &baseName, QObject *parent) :
+	QObject(parent)
+{
+	name_ = baseName;
+
+	allControls_ = new AMControlSet(this);
+	connect( allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged(bool)) );
+
+	outputValueControl_ = new AMSinglePVControl(QString(baseName), QString(baseName), this);
+	connect( outputValueControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputValueChanged(int)) );
+	allControls_->addControl(outputValueControl_);
+
+	outputStatusControl_ = new AMReadOnlyPVControl(QString("%1:%2").arg(baseName).arg("STA"), QString("%1:%2").arg(baseName).arg("STA"), this);
+	connect( outputStatusControl_, SIGNAL(valueChanged(double)), this, SLOT(onOutputStatusChanged(bool)) );
+	allControls_->addControl(outputStatusControl_);
+
+	outputValuePreferenceSet_ = false;
+	outputValuePreference_ = 0;
+}
+
+BioXASZebraOutputControl::~BioXASZebraOutputControl()
+{
+
+}
+
+bool BioXASZebraOutputControl::isConnected() const
+{
+	return allControls_->isConnected();
+}
+
+int BioXASZebraOutputControl::outputValue() const
+{
+	return int(outputValueControl_->value());
+}
+
+QString BioXASZebraOutputControl::outputValueString() const
+{
+	return BioXASZebraCommand::nameFromCommand(outputValue());
+}
+
+bool BioXASZebraOutputControl::outputStatusValue() const
+{
+	return (int(outputStatusControl()->value()) == 1);
+}
+
+void BioXASZebraOutputControl::setOutputValue(int newValue)
+{
+	outputValueControl_->move(newValue);
+}
+
+void BioXASZebraOutputControl::setOutputValuePreference(int newValue)
+{
+	if (outputValuePreference_ != newValue || !outputValuePreferenceSet_) {
+		outputValuePreferenceSet_ = true;
+		outputValuePreference_ = newValue;
+		updateOutputValueControl();
+
+		emit outputValuePreferenceChanged(outputValuePreference_);
+	}
+}
+
+void BioXASZebraOutputControl::onControlSetConnectedChanged()
+{
+	updateOutputValueControl();
+
+	emit connectedChanged(allControls_->isConnected());
+}
+
+void BioXASZebraOutputControl::onOutputValueChanged()
+{
+	emit outputValueChanged(outputValue());
+	emit outputValueStringChanged(outputValueString());
+}
+
+void BioXASZebraOutputControl::onOutputStatusChanged()
+{
+	emit outputStatusChanged(outputStatusValue());
+}
+
+void BioXASZebraOutputControl::updateOutputValueControl()
+{
+	if (outputValuePreferenceSet_)
+		setOutputValue(outputValuePreference_);
+}
+

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -3,10 +3,10 @@
 #include "beamline/AMControlSet.h"
 #include "beamline/BioXAS/BioXASZebraCommands.h"
 
-BioXASZebraOutputControl::BioXASZebraOutputControl(const QString &baseName, QObject *parent) :
-	QObject(parent)
+BioXASZebraOutputControl::BioXASZebraOutputControl(const QString &name, const QString &baseName, QObject *parent) :
+	AMControl(name, "", parent)
 {
-	name_ = baseName;
+	name_ = name;
 
 	allControls_ = new AMControlSet(this);
 	connect( allControls_, SIGNAL(connected(bool)), this, SLOT(onControlSetConnectedChanged(bool)) );

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -43,7 +43,12 @@ QString BioXASZebraOutputControl::outputValueString() const
 	return BioXASZebraCommand::nameFromCommand(outputValue());
 }
 
-bool BioXASZebraOutputControl::outputStatusValue() const
+double BioXASZebraOutputControl::outputStatusValue() const
+{
+	return outputStatusControl_->value();
+}
+
+bool BioXASZebraOutputControl::isOutputStateHigh() const
 {
 	return (int(outputStatusControl()->value()) == 1);
 }
@@ -53,11 +58,10 @@ void BioXASZebraOutputControl::setOutputValue(int newValue)
 	if (!outputValueControl_->withinTolerance(double(newValue)))
 		outputValueControl_->move(double(newValue));
 }
-#include <QDebug>
+
 void BioXASZebraOutputControl::setOutputValuePreference(int newValue)
 {
 	if (outputValuePreference_ != newValue || !outputValuePreferenceSet_) {
-		qDebug() << "Setting value preference for control" << name() << "," << newValue;
 		outputValuePreferenceSet_ = true;
 		outputValuePreference_ = newValue;
 		updateOutputValueControl();
@@ -86,9 +90,7 @@ void BioXASZebraOutputControl::onOutputStatusChanged()
 
 void BioXASZebraOutputControl::updateOutputValueControl()
 {
-	if (outputValuePreferenceSet_) {
-		qDebug() << "Updating output value" << name();
+	if (outputValuePreferenceSet_)
 		setOutputValue(outputValuePreference_);
-	}
 }
 

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.h
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.h
@@ -29,7 +29,9 @@ public:
 	/// Returns the output value string.
 	QString outputValueString() const;
 	/// Returns the output status value.
-	bool outputStatusValue() const;
+	double outputStatusValue() const;
+	/// Returns true if the output status value is high, false otherwise.
+	bool isOutputStateHigh() const;
 
 	/// Returns the output value control.
 	AMPVControl* outputValueControl() const { return outputValueControl_; }
@@ -44,7 +46,7 @@ signals:
 	/// Notifier that the output value string has changed.
 	void outputValueStringChanged(const QString &);
 	/// Notifier that the output status has changed.
-	void outputStatusChanged(bool);
+	void outputStatusChanged(double);
 
 	/// Notifier that the output value preference has changed.
 	void outputValuePreferenceChanged(int);

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.h
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.h
@@ -3,24 +3,26 @@
 
 #include <QObject>
 
+#include "beamline/AMControl.h"
+
 class AMPVControl;
 class AMReadOnlyPVControl;
 class AMControlSet;
 
-class BioXASZebraOutputControl : public QObject
+class BioXASZebraOutputControl : public AMControl
 {
 	Q_OBJECT
 
 public:
 	/// Constructor.
-	explicit BioXASZebraOutputControl(const QString &baseName, QObject *parent = 0);
+	explicit BioXASZebraOutputControl(const QString &name, const QString &baseName, QObject *parent = 0);
 	/// Destructor.
 	virtual ~BioXASZebraOutputControl();
 
 	/// Returns the name of the output control.
 	QString name() const { return name_; }
 	/// Returns the connected state.
-	bool isConnected() const;
+	virtual bool isConnected() const;
 
 	/// Returns the output value.
 	int outputValue() const;

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.h
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.h
@@ -1,0 +1,84 @@
+#ifndef BIOXASZEBRAOUTPUTCONTROL_H
+#define BIOXASZEBRAOUTPUTCONTROL_H
+
+#include <QObject>
+
+class AMPVControl;
+class AMReadOnlyPVControl;
+class AMControlSet;
+
+class BioXASZebraOutputControl : public QObject
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit BioXASZebraOutputControl(const QString &baseName, QObject *parent = 0);
+	/// Destructor.
+	virtual ~BioXASZebraOutputControl();
+
+	/// Returns the name of the output control.
+	QString name() const { return name_; }
+	/// Returns the connected state.
+	bool isConnected() const;
+
+	/// Returns the output value.
+	int outputValue() const;
+	/// Returns the output value string.
+	QString outputValueString() const;
+	/// Returns the output status value.
+	bool outputStatusValue() const;
+
+	/// Returns the output value control.
+	AMPVControl* outputValueControl() const { return outputValueControl_; }
+	/// Returns the output status control.
+	AMReadOnlyPVControl* outputStatusControl() const { return outputStatusControl_; }
+
+signals:
+	/// Notifier that the connected state has changed.
+	void connectedChanged(bool);
+	/// Notifier that the output value has changed.
+	void outputValueChanged(int);
+	/// Notifier that the output value string has changed.
+	void outputValueStringChanged(const QString &);
+	/// Notifier that the output status has changed.
+	void outputStatusChanged(bool);
+
+	/// Notifier that the output value preference has changed.
+	void outputValuePreferenceChanged(int);
+
+public slots:
+	/// Sets the output value.
+	void setOutputValue(int newValue);
+	/// Sets the output value preference.
+	void setOutputValuePreference(int newValue);
+
+protected slots:
+	/// Handles emitting the appropriate signals when the connected state has changed.
+	void onControlSetConnectedChanged();
+	/// Handles emitting the appropriate signals when the output value has changed.
+	void onOutputValueChanged();
+	/// Handles emitting the appropriate signals when the output status has changed.
+	void onOutputStatusChanged();
+
+	/// Updates the output value control with the output value preference.
+	void updateOutputValueControl();
+
+protected:
+	/// The name of the output control.
+	QString name_;
+
+	/// The set of all sub controls.
+	AMControlSet *allControls_;
+	/// The output value control.
+	AMPVControl *outputValueControl_;
+	/// The output status control.
+	AMReadOnlyPVControl* outputStatusControl_;
+
+	/// The flag indicating whether an output value preference has been set.
+	bool outputValuePreferenceSet_;
+	/// The output value preference.
+	int outputValuePreference_;
+};
+
+#endif // BIOXASZEBRAOUTPUTCONTROL_H

--- a/source/beamline/BioXAS/BioXASZebraPulseControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraPulseControl.cpp
@@ -230,7 +230,7 @@ void BioXASZebraPulseControl::setEdgeTriggerPreference(int value)
 
 void BioXASZebraPulseControl::setInputValuePreference(int value)
 {
-	if (inputValuePreference_ != value) {
+	if (inputValuePreference_ != value || !inputValuePreferenceSet_) {
 		inputValuePreferenceSet_ = true;
 		inputValuePreference_ = value;
 		updateInputControl();

--- a/source/ui/BioXAS/BioXASZebraOutputControlView.cpp
+++ b/source/ui/BioXAS/BioXASZebraOutputControlView.cpp
@@ -1,0 +1,83 @@
+#include "BioXASZebraOutputControlView.h"
+
+BioXASZebraOutputControlView::BioXASZebraOutputControlView(BioXASZebraOutputControl *outputControl, QWidget *parent) :
+	QWidget(parent)
+{
+	// Initialize class variables.
+
+	outputControl_ = 0;
+
+	// Create UI elements.
+
+	nameLabel_ = new QLabel();
+
+	outputValueBox_ = new QSpinBox();
+
+	outputValueLabel_ = new QLabel();
+
+	outputStatusLabel_ = new QLabel();
+
+	// Create and set main layout.
+
+	QHBoxLayout *layout = new QHBoxLayout();
+	layout->setMargin(0);
+	layout->addWidget(nameLabel_);
+	layout->addWidget(outputValueBox_);
+	layout->addWidget(outputValueLabel_);
+	layout->addWidget(outputStatusLabel_);
+
+	setLayout(layout);
+
+	// Current settings.
+
+	setOutputControl(outputControl);
+
+	refresh();
+}
+
+BioXASZebraOutputControlView::~BioXASZebraOutputControlView()
+{
+
+}
+
+void BioXASZebraOutputControlView::refresh()
+{
+	// Clear UI elements.
+
+	nameLabel_->clear();
+	outputValueBox_->clear();
+	outputValueLabel_->clear();
+	outputStatusLabel_->setPixmap(QPixmap(":/32x32/greenLEDOff.png"));
+
+	// Update elements.
+
+	if (outputControl_) {
+		nameLabel_->setText(outputControl_->name());
+		outputValueBox_->setMinimum(0);
+		outputValueBox_->setMaximum(63);
+		outputValueBox_->setValue(outputControl_->outputValue());
+		outputValueLabel_->setText(outputControl_->outputValueString());
+		outputStatusLabel_->setPixmap(outputControl_->outputStatusValue() ? QPixmap(":/32x32/greenLEDOn.png") : QPixmap(":/32x32/greenLEDOff.png"));
+	}
+}
+
+void BioXASZebraOutputControlView::setOutputControl(BioXASZebraOutputControl *newControl)
+{
+	if (outputControl_ != newControl) {
+
+		if (outputControl_)
+			disconnect( outputControl_, 0, this, 0 );
+
+		outputControl_ = newControl;
+
+		if (outputControl_) {
+			connect( outputControl_, SIGNAL(outputValueChanged(int)), this, SLOT(refresh()) );
+			connect( outputControl_, SIGNAL(outputStatusChanged(bool)), this, SLOT(refresh()) );
+		}
+
+		refresh();
+
+		emit outputControlChanged(outputControl_);
+	}
+}
+

--- a/source/ui/BioXAS/BioXASZebraOutputControlView.cpp
+++ b/source/ui/BioXAS/BioXASZebraOutputControlView.cpp
@@ -63,7 +63,7 @@ void BioXASZebraOutputControlView::refresh()
 		outputValueBox_->setMaximum(63);
 		outputValueBox_->setValue(outputControl_->outputValue());
 		outputValueLabel_->setText(outputControl_->outputValueString());
-		outputStatusLabel_->setPixmap(QIcon(outputControl_->outputStatusValue() ? ":/22x22/greenLEDOn.png" : ":/32x32/greenLEDOff.png").pixmap(22));
+		outputStatusLabel_->setPixmap(QIcon(outputControl_->isOutputStateHigh() ? ":/22x22/greenLEDOn.png" : ":/32x32/greenLEDOff.png").pixmap(22));
 	}
 }
 
@@ -78,7 +78,7 @@ void BioXASZebraOutputControlView::setOutputControl(BioXASZebraOutputControl *ne
 
 		if (outputControl_) {
 			connect( outputControl_, SIGNAL(outputValueChanged(int)), this, SLOT(refresh()) );
-			connect( outputControl_, SIGNAL(outputStatusChanged(bool)), this, SLOT(refresh()) );
+			connect( outputControl_, SIGNAL(outputStatusChanged(double)), this, SLOT(refresh()) );
 		}
 
 		refresh();

--- a/source/ui/BioXAS/BioXASZebraOutputControlView.cpp
+++ b/source/ui/BioXAS/BioXASZebraOutputControlView.cpp
@@ -10,10 +10,14 @@ BioXASZebraOutputControlView::BioXASZebraOutputControlView(BioXASZebraOutputCont
 	// Create UI elements.
 
 	nameLabel_ = new QLabel();
+	nameLabel_->setMinimumWidth(100);
 
 	outputValueBox_ = new QSpinBox();
+	outputValueBox_->setMinimumWidth(100);
+	connect( outputValueBox_, SIGNAL(valueChanged(int)), this, SLOT(onOutputValueBoxChanged()) );
 
 	outputValueLabel_ = new QLabel();
+	outputValueLabel_->setMinimumWidth(100);
 
 	outputStatusLabel_ = new QLabel();
 
@@ -46,18 +50,20 @@ void BioXASZebraOutputControlView::refresh()
 
 	nameLabel_->clear();
 	outputValueBox_->clear();
+	outputValueBox_->setEnabled(false);
 	outputValueLabel_->clear();
-	outputStatusLabel_->setPixmap(QPixmap(":/32x32/greenLEDOff.png"));
+	outputStatusLabel_->setPixmap(QIcon(":/22x22/greenLEDOff.png").pixmap(22));
 
 	// Update elements.
 
 	if (outputControl_) {
 		nameLabel_->setText(outputControl_->name());
+		outputValueBox_->setEnabled(true);
 		outputValueBox_->setMinimum(0);
 		outputValueBox_->setMaximum(63);
 		outputValueBox_->setValue(outputControl_->outputValue());
 		outputValueLabel_->setText(outputControl_->outputValueString());
-		outputStatusLabel_->setPixmap(outputControl_->outputStatusValue() ? QPixmap(":/32x32/greenLEDOn.png") : QPixmap(":/32x32/greenLEDOff.png"));
+		outputStatusLabel_->setPixmap(QIcon(outputControl_->outputStatusValue() ? ":/22x22/greenLEDOn.png" : ":/32x32/greenLEDOff.png").pixmap(22));
 	}
 }
 
@@ -79,5 +85,11 @@ void BioXASZebraOutputControlView::setOutputControl(BioXASZebraOutputControl *ne
 
 		emit outputControlChanged(outputControl_);
 	}
+}
+
+void BioXASZebraOutputControlView::onOutputValueBoxChanged()
+{
+	if (outputControl_)
+		outputControl_->setOutputValue(outputValueBox_->value());
 }
 

--- a/source/ui/BioXAS/BioXASZebraOutputControlView.h
+++ b/source/ui/BioXAS/BioXASZebraOutputControlView.h
@@ -31,6 +31,10 @@ public slots:
 	/// Sets the output control being viewed.
 	void setOutputControl(BioXASZebraOutputControl *newControl);
 
+protected slots:
+	/// Handles updating the output control with changes to the output value box.
+	void onOutputValueBoxChanged();
+
 protected:
 	/// The output control being viewed.
 	BioXASZebraOutputControl *outputControl_;

--- a/source/ui/BioXAS/BioXASZebraOutputControlView.h
+++ b/source/ui/BioXAS/BioXASZebraOutputControlView.h
@@ -1,0 +1,48 @@
+#ifndef BIOXASZEBRAOUTPUTCONTROLVIEW_H
+#define BIOXASZEBRAOUTPUTCONTROLVIEW_H
+
+#include <QLabel>
+#include <QSpinBox>
+#include <QLayout>
+
+#include "beamline/BioXAS/BioXASZebraOutputControl.h"
+
+class BioXASZebraOutputControlView : public QWidget
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	explicit BioXASZebraOutputControlView(BioXASZebraOutputControl *outputControl, QWidget *parent = 0);
+	/// Destructor.
+	virtual ~BioXASZebraOutputControlView();
+
+	/// Returns the output control being viewed.
+	BioXASZebraOutputControl* outputControl() const { return outputControl_; }
+
+signals:
+	/// Notifier that the output control being viewed has changed.
+	void outputControlChanged(BioXASZebraOutputControl *newControl);
+
+public slots:
+	/// Refreshes the view.
+	void refresh();
+
+	/// Sets the output control being viewed.
+	void setOutputControl(BioXASZebraOutputControl *newControl);
+
+protected:
+	/// The output control being viewed.
+	BioXASZebraOutputControl *outputControl_;
+
+	/// The output name label.
+	QLabel *nameLabel_;
+	/// The output control value spinbox.
+	QSpinBox *outputValueBox_;
+	/// The output control value label.
+	QLabel *outputValueLabel_;
+	/// The output status light.
+	QLabel *outputStatusLabel_;
+};
+
+#endif // BIOXASZEBRAOUTPUTCONTROLVIEW_H

--- a/source/ui/BioXAS/BioXASZebraView.cpp
+++ b/source/ui/BioXAS/BioXASZebraView.cpp
@@ -6,7 +6,7 @@
 #include "ui/BioXAS/BioXASZebraOutputControlView.h"
 
 #include <QGridLayout>
-#include <QDebug>
+
 BioXASZebraView::BioXASZebraView(BioXASZebra *zebra, QWidget *parent)
 	: QTabWidget(parent)
 {

--- a/source/ui/BioXAS/BioXASZebraView.cpp
+++ b/source/ui/BioXAS/BioXASZebraView.cpp
@@ -3,9 +3,10 @@
 #include "ui/BioXAS/BioXASZebraPulseControlView.h"
 #include "ui/beamline/AMExtendedControlEditor.h"
 #include "ui/BioXAS/BioXASZebraLogicBlockView.h"
+#include "ui/BioXAS/BioXASZebraOutputControlView.h"
 
 #include <QGridLayout>
-
+#include <QDebug>
 BioXASZebraView::BioXASZebraView(BioXASZebra *zebra, QWidget *parent)
 	: QTabWidget(parent)
 {
@@ -89,6 +90,29 @@ BioXASZebraView::BioXASZebraView(BioXASZebra *zebra, QWidget *parent)
 	orBlocksBox->setLayout(orBlocksLayout);
 
 	addTab(orBlocksBox, "OR blocks");
+
+	// The SYS panel--outputs.
+
+	QList<BioXASZebraOutputControl*> outputControls = zebra_->outputControls();
+
+	QVBoxLayout *outputViewsLayout = new QVBoxLayout();
+
+	foreach (BioXASZebraOutputControl* outputControl, outputControls) {
+		QHBoxLayout *outputViewLayout = new QHBoxLayout();
+		outputViewLayout->setMargin(0);
+		outputViewLayout->addStretch();
+		outputViewLayout->addWidget(new BioXASZebraOutputControlView(outputControl));
+		outputViewLayout->addStretch();
+
+		outputViewsLayout->addLayout(outputViewLayout);
+	}
+
+	outputViewsLayout->addStretch();
+
+	QWidget *outputViewsBox = new QWidget();
+	outputViewsBox->setLayout(outputViewsLayout);
+
+	addTab(outputViewsBox, "Outputs");
 }
 
 BioXASZebraView::~BioXASZebraView()


### PR DESCRIPTION
- Created new class BioXASZebraOutputControl, contains PV controls for the output value and status.
- Created new class BioXASZebraOutputControlView, a visualization for the output control.
- Created new class BioXASSideZebra and added to BioXASSideBeamline. This class has the output controls used on Side.
- Created new class BioXASMainZebra and added to BioXASMainBeamline. This class has the output controls used on Main, different from Side.
- Modified BioXASSide- and BioXASMainBeamlines to include the preferred values for the output controls, set on startup and enforced when the connected state of the control changes.