### PR TITLE
Pull Request for Issue 2242: Rename move method in SGMEnergyCoordinator

### DIFF
--- a/source/beamline/SGM/SGMEnergyCoordinator.cpp
+++ b/source/beamline/SGM/SGMEnergyCoordinator.cpp
@@ -648,7 +648,7 @@ void SGMEnergyCoordinator::onEnergyTrajectoryStartPVChanged(double /*value*/)
 		double target = newEnergyControls_->energyTrajectoryTarget()->value();
 		double time = newEnergyControls_->energyTrajectoryTime()->value();
 
-		if(energyControlCoordinator_->move(target, time) == AMControl::NoFailure) {
+		if(energyControlCoordinator_->coordinatedMove(target, time) == AMControl::NoFailure) {
 			qDebug() << "Moving energy to" << target << "in" << time << "s";
 		}
 	}

--- a/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.cpp
+++ b/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.cpp
@@ -163,7 +163,7 @@ AMControl *SGMEnergyCoordinatorControl::exitSlitPositionControl() const
 	return exitSlitPositionControl_;
 }
 
-AMControl::FailureExplanation SGMEnergyCoordinatorControl::move(double targetSetpoint, double time)
+AMControl::FailureExplanation SGMEnergyCoordinatorControl::coordinatedMove(double targetSetpoint, double time)
 {
 	// Check that this control is connected and able to move before proceeding.
 

--- a/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.h
+++ b/source/beamline/SGM/energy/SGMEnergyCoordinatorControl.h
@@ -149,7 +149,7 @@ public slots:
 	  * \param targetSetpoint ~ The position which the energy will move to.
 	  * \param time ~ The time for the motion to take
 	  */
-	virtual FailureExplanation move(double targetSetpoint, double time);
+	virtual FailureExplanation coordinatedMove(double targetSetpoint, double time);
 
 	/*!
 	 * Sets the undulator harmonic to use in calculating the control positions.

--- a/source/tests/SGM/SGMEnergyControlTestView.cpp
+++ b/source/tests/SGM/SGMEnergyControlTestView.cpp
@@ -109,7 +109,7 @@ void SGMEnergyControlTestView::onStartTrajectoryButtonPushed()
 		double endEnergy = endEnergySpinBox_->value();
 
 		double velocity = qAbs(endEnergy - startEnergy) / timeTakenSpinBox_->value();
-		energyCoordinatorControl_->move(endEnergy, velocity);
+		energyCoordinatorControl_->coordinatedMove(endEnergy, velocity);
 	}
 }
 


### PR DESCRIPTION
Renamed move(double, double) function added into SGMEnergyCoordinatorControl to coordinatedMove(double, double) so as to remove warnings about ambiguous overloading