### PR TITLE
Pull Request for Issue2188: Problem setting values in AMGenericStepScanConfigurationView

### DIFF
--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
@@ -474,10 +474,10 @@ void AMGenericStepScanConfigurationView::onScanAxisAdded(AMScanAxis *axis)
 {
 	if (configuration_->scanAxes().size() == 1){
 
-		connect(axisStart1_, SIGNAL(valueChanged(double)), this, SLOT(onStart1Changed()));
-		connect(axisStep1_, SIGNAL(valueChanged(double)), this, SLOT(onStep1Changed()));
-		connect(axisEnd1_, SIGNAL(valueChanged(double)), this, SLOT(onEnd1Changed()));
-		connect(dwellTime_, SIGNAL(valueChanged(double)), this, SLOT(onDwellTimeChanged()));
+		connect(axisStart1_, SIGNAL(editingFinished()), this, SLOT(onStart1Changed()));
+		connect(axisStep1_, SIGNAL(editingFinished()), this, SLOT(onStep1Changed()));
+		connect(axisEnd1_, SIGNAL(editingFinished()), this, SLOT(onEnd1Changed()));
+		connect(dwellTime_, SIGNAL(editingFinished()), this, SLOT(onDwellTimeChanged()));
 
 		connect(axis->regionAt(0), SIGNAL(regionStartChanged(AMNumber)), this, SLOT(setStart1(AMNumber)));
 		connect(axis->regionAt(0), SIGNAL(regionStepChanged(AMNumber)), this, SLOT(setStep1(AMNumber)));


### PR DESCRIPTION
- Altered the connection from the spinboxes to onXChanged() so that the editingFinished() signal is used instead of valueChanged(). Fixes the issue with the input being validated by the spin box while the user is still in the process of entering values.