### PR TITLE
Pull Request for Issue2264: Adding limits to select motors on Side

### DIFF
--- a/source/beamline/AMPVControl.cpp
+++ b/source/beamline/AMPVControl.cpp
@@ -37,6 +37,9 @@ AMReadOnlyPVControl::AMReadOnlyPVControl(const QString& name, const QString& rea
 	lowLimitPV_ = 0;
 	highLimitPV_ = 0;
 
+	allowLowLimitValuePVUpdates_ = true;
+	allowHighLimitValuePVUpdates_ = true;
+
 	lowLimitValue_ = -1;
 	highLimitValue_ = -1;
 
@@ -63,23 +66,11 @@ void AMReadOnlyPVControl::enableLimitMonitoring()
 	lowLimitPV_ = new AMProcessVariable(QString("%1.LOPR").arg(readPV_->pvName()), true, this);
 	highLimitPV_ = new AMProcessVariable(QString("%1.HOPR").arg(readPV_->pvName()), true, this);
 
-	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVInitialized()));
-	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setLowLimitValue(double)));
+	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVValueChanged()));
+	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onLowLimitPVValueChanged()));
 
-	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVInitialized()));
-	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setHighLimitValue(double)));
-}
-
-void AMReadOnlyPVControl::setLowLimitValue(double newLowLimit)
-{
-	lowLimitValue_ = newLowLimit;
-	emit minimumValueChanged(lowLimitValue_);
-}
-
-void AMReadOnlyPVControl::setHighLimitValue(double newHighLimit)
-{
-	highLimitValue_ = newHighLimit;
-	emit maximumValueChanged(highLimitValue_);
+	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVValueChanged()));
+	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onHighLimitPVValueChanged()));
 }
 
 // This will work for subclasses with more PVs, since it checks virtual isConnected(). Subclasses should reimplement isConnected() to specify what counts as connected.
@@ -104,23 +95,51 @@ void AMReadOnlyPVControl::onReadPVError(int errorCode) {
 	}
 }
 
+void AMReadOnlyPVControl::setMinimumValue(double newValue)
+{
+	setLowLimitValue(newValue);
+	allowLowLimitValuePVUpdates_ = false;
+}
+
+void AMReadOnlyPVControl::setMaximumValue(double newValue)
+{
+	setHighLimitValue(newValue);
+	allowHighLimitValuePVUpdates_ = false;
+}
+
+void AMReadOnlyPVControl::setLowLimitValue(double newLowLimit)
+{
+	lowLimitValue_ = newLowLimit;
+	emit minimumValueChanged(lowLimitValue_);
+}
+
+void AMReadOnlyPVControl::setHighLimitValue(double newHighLimit)
+{
+	highLimitValue_ = newHighLimit;
+	emit maximumValueChanged(highLimitValue_);
+}
+
 void AMReadOnlyPVControl::onReadPVInitialized() {
 	setUnits(readPV_->units());	// copy over the new unit string
 	setEnumStates(readPV_->enumStrings());
 	setDisplayPrecision(readPV_->displayPrecision());
-	setLowLimitValue(readPV_->lowerGraphicalLimit());
-	setHighLimitValue(readPV_->upperGraphicalLimit());
+
+	if (allowLowLimitValuePVUpdates_)
+		setLowLimitValue(readPV_->lowerGraphicalLimit());
+
+	if (allowHighLimitValuePVUpdates_)
+		setHighLimitValue(readPV_->upperGraphicalLimit());
 }
 
-void AMReadOnlyPVControl::onLowLimitPVInitialized()
+void AMReadOnlyPVControl::onLowLimitPVValueChanged()
 {
-	if (lowLimitPV_ && lowLimitPV_->isInitialized())
+	if (lowLimitPV_ && lowLimitPV_->isInitialized() && allowLowLimitValuePVUpdates_)
 		setLowLimitValue(lowLimitPV_->getDouble());
 }
 
-void AMReadOnlyPVControl::onHighLimitPVInitialized()
+void AMReadOnlyPVControl::onHighLimitPVValueChanged()
 {
-	if (highLimitPV_ && highLimitPV_->isInitialized())
+	if (highLimitPV_ && highLimitPV_->isInitialized() && allowHighLimitValuePVUpdates_)
 		setHighLimitValue(highLimitPV_->getDouble());
 }
 
@@ -183,11 +202,11 @@ void AMPVControl::enableLimitMonitoring()
 	lowLimitPV_ = new AMProcessVariable(QString("%1.DRVL").arg(writePV_->pvName()), true, this);
 	highLimitPV_ = new AMProcessVariable(QString("%1.DRVH").arg(writePV_->pvName()), true, this);
 
-	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVInitialized()));
-	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setLowLimitValue(double)));
+	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVValueChanged()));
+	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onLowLimitPVValueChanged()));
 
-	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVInitialized()));
-	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setHighLimitValue(double)));
+	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVValueChanged()));
+	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onHighLimitPVValueChanged()));
 }
 
 void AMPVControl::onSetpointChanged(double newVal)
@@ -205,8 +224,12 @@ void AMPVControl::onReadPVInitialized()
 }
 
 void AMPVControl::onWritePVInitialized() {
-	setLowLimitValue(writePV_->lowerControlLimit());
-	setHighLimitValue(writePV_->upperControlLimit());
+	if (allowLowLimitValuePVUpdates_)
+		setLowLimitValue(writePV_->lowerControlLimit());
+
+	if (allowHighLimitValuePVUpdates_)
+		setHighLimitValue(writePV_->upperControlLimit());
+
 	setMoveEnumStates(writePV_->enumStrings());
 }
 
@@ -457,11 +480,11 @@ void AMPVwStatusControl::enableLimitMonitoring()
 	lowLimitPV_ = new AMProcessVariable(QString("%1.DRVL").arg(writePV_->pvName()), true, this);
 	highLimitPV_ = new AMProcessVariable(QString("%1.DRVH").arg(writePV_->pvName()), true, this);
 
-	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVInitialized()));
-	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setLowLimitValue(double)));
+	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVValueChanged()));
+	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onLowLimitPVValueChanged()));
 
-	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVInitialized()));
-	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setLowLimitValue(double)));
+	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVValueChanged()));
+	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onHighLimitPVValueChanged()));
 }
 
 void AMPVwStatusControl::onSetpointChanged(double newVal)
@@ -479,8 +502,12 @@ void AMPVwStatusControl::onReadPVInitialized()
 }
 
 void AMPVwStatusControl::onWritePVInitialized() {
-	setLowLimitValue(writePV_->lowerControlLimit());
-	setHighLimitValue(writePV_->upperControlLimit());
+	if (allowLowLimitValuePVUpdates_)
+		setLowLimitValue(writePV_->lowerControlLimit());
+
+	if (allowLowLimitValuePVUpdates_)
+		setHighLimitValue(writePV_->upperControlLimit());
+
 	setMoveEnumStates(writePV_->enumStrings());
 }
 
@@ -709,6 +736,16 @@ AMPVwStatusAndUnitConversionControl::AMPVwStatusAndUnitConversionControl(const Q
 
 }
 
+void AMPVwStatusAndUnitConversionControl::onReadPVValueChanged(double newValue)
+{
+	emit valueChanged(readUnitConverter()->convertFromRaw(newValue));
+}
+
+void AMPVwStatusAndUnitConversionControl::onWritePVValueChanged(double newValue)
+{
+	emit setpointChanged(writeUnitConverter()->convertFromRaw(newValue));
+}
+
 void AMPVwStatusAndUnitConversionControl::setLowLimitValue(double newLowLimit)
 {
 	lowLimitValue_ = writeUnitConverter()->convertFromRaw(newLowLimit);
@@ -721,27 +758,17 @@ void AMPVwStatusAndUnitConversionControl::setHighLimitValue(double newHighLimit)
 	emit maximumValueChanged(highLimitValue_);
 }
 
-void AMPVwStatusAndUnitConversionControl::onReadPVValueChanged(double newValue)
-{
-	emit valueChanged(readUnitConverter()->convertFromRaw(newValue));
-}
-
-void AMPVwStatusAndUnitConversionControl::onWritePVValueChanged(double newValue)
-{
-	emit setpointChanged(writeUnitConverter()->convertFromRaw(newValue));
-}
-
 void AMPVwStatusAndUnitConversionControl::enableLimitMonitoring()
 {
 	// AMPVwStatusControl uses the control limits (ie DRVL and DRVH)
 	lowLimitPV_ = new AMProcessVariable(QString("%1.DRVL").arg(writePV_->pvName()), true, this);
 	highLimitPV_ = new AMProcessVariable(QString("%1.DRVH").arg(writePV_->pvName()), true, this);
 
-	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVInitialized()));
-	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setLowLimitValue(double)));
+	connect(lowLimitPV_, SIGNAL(initialized()), this, SLOT(onLowLimitPVValueChanged()));
+	connect(lowLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onLowLimitPVValueChanged()));
 
-	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVInitialized()));
-	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setHighLimitValue(double)));
+	connect(highLimitPV_, SIGNAL(initialized()), this, SLOT(onHighLimitPVValueChanged()));
+	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(onHighLimitPVValueChanged()));
 }
 
 void AMPVwStatusAndUnitConversionControl::setUnitConverters(AMAbstractUnitConverter *readUnitConverter, AMAbstractUnitConverter* writeUnitConverter)

--- a/source/beamline/AMPVControl.cpp
+++ b/source/beamline/AMPVControl.cpp
@@ -70,6 +70,18 @@ void AMReadOnlyPVControl::enableLimitMonitoring()
 	connect(highLimitPV_, SIGNAL(valueChanged(double)), this, SLOT(setHighLimitValue(double)));
 }
 
+void AMReadOnlyPVControl::setLowLimitValue(double newLowLimit)
+{
+	lowLimitValue_ = newLowLimit;
+	emit minimumValueChanged(lowLimitValue_);
+}
+
+void AMReadOnlyPVControl::setHighLimitValue(double newHighLimit)
+{
+	highLimitValue_ = newHighLimit;
+	emit maximumValueChanged(highLimitValue_);
+}
+
 // This will work for subclasses with more PVs, since it checks virtual isConnected(). Subclasses should reimplement isConnected() to specify what counts as connected.
 void AMReadOnlyPVControl::onPVConnected(bool) {
 
@@ -90,18 +102,6 @@ void AMReadOnlyPVControl::onReadPVError(int errorCode) {
 			AMErrorMon::debug(this, AMPVCONTROL_READ_PROCESS_VARIABLE_ERROR, QString("AMReadOnlyPVControl: Read Process Variable error %1: code %2.").arg(source->pvName()).arg(errorCode));
 		}
 	}
-}
-
-void AMReadOnlyPVControl::setLowLimitValue(double newLowLimit)
-{
-	lowLimitValue_ = newLowLimit;
-	emit minimumValueChanged(lowLimitValue_);
-}
-
-void AMReadOnlyPVControl::setHighLimitValue(double newHighLimit)
-{
-	highLimitValue_ = newHighLimit;
-	emit maximumValueChanged(highLimitValue_);
 }
 
 void AMReadOnlyPVControl::onReadPVInitialized() {
@@ -709,16 +709,6 @@ AMPVwStatusAndUnitConversionControl::AMPVwStatusAndUnitConversionControl(const Q
 
 }
 
-void AMPVwStatusAndUnitConversionControl::onReadPVValueChanged(double newValue)
-{
-	emit valueChanged(readUnitConverter()->convertFromRaw(newValue));
-}
-
-void AMPVwStatusAndUnitConversionControl::onWritePVValueChanged(double newValue)
-{
-	emit setpointChanged(writeUnitConverter()->convertFromRaw(newValue));
-}
-
 void AMPVwStatusAndUnitConversionControl::setLowLimitValue(double newLowLimit)
 {
 	lowLimitValue_ = writeUnitConverter()->convertFromRaw(newLowLimit);
@@ -729,6 +719,16 @@ void AMPVwStatusAndUnitConversionControl::setHighLimitValue(double newHighLimit)
 {
 	highLimitValue_ = writeUnitConverter()->convertFromRaw(newHighLimit);
 	emit maximumValueChanged(highLimitValue_);
+}
+
+void AMPVwStatusAndUnitConversionControl::onReadPVValueChanged(double newValue)
+{
+	emit valueChanged(readUnitConverter()->convertFromRaw(newValue));
+}
+
+void AMPVwStatusAndUnitConversionControl::onWritePVValueChanged(double newValue)
+{
+	emit setpointChanged(writeUnitConverter()->convertFromRaw(newValue));
 }
 
 void AMPVwStatusAndUnitConversionControl::enableLimitMonitoring()

--- a/source/beamline/AMPVControl.cpp
+++ b/source/beamline/AMPVControl.cpp
@@ -95,13 +95,13 @@ void AMReadOnlyPVControl::onReadPVError(int errorCode) {
 	}
 }
 
-void AMReadOnlyPVControl::setMinimumValue(double newValue)
+void AMReadOnlyPVControl::setMinimumValueOverride(double newValue)
 {
 	setLowLimitValue(newValue);
 	allowLowLimitValuePVUpdates_ = false;
 }
 
-void AMReadOnlyPVControl::setMaximumValue(double newValue)
+void AMReadOnlyPVControl::setMaximumValueOverride(double newValue)
 {
 	setHighLimitValue(newValue);
 	allowHighLimitValuePVUpdates_ = false;

--- a/source/beamline/AMPVControl.h
+++ b/source/beamline/AMPVControl.h
@@ -115,10 +115,10 @@ signals:
 	void readConnectionTimeoutOccurred();
 
 public slots:
-	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setLowLimitValue(double newLowLimit);
-	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setHighLimitValue(double newHighLimit);
+	/// Sets the minimum value.
+	void setMinimumValue(double newValue);
+	/// Sets the maximum value.
+	void setMaximumValue(double newValue);
 
 protected:
 
@@ -130,19 +130,28 @@ protected:
 	AMProcessVariable* highLimitPV_;
 	/// Used for change-detection of isConnected() for the connected() signal
 	bool wasConnected_;
+	/// Flag indicating whether we use the cached low limit value as the minimum value, prevents the low limit PV from updating the value.
+	bool allowLowLimitValuePVUpdates_;
 	/// Cached low limit value, to ensure that the correct value is returned when monitoring.
 	double lowLimitValue_;
+	/// Flag indicating whether we use the cached low limit value as the minimum value, prevents the low limit PV from updating the value.
+	bool allowHighLimitValuePVUpdates_;
 	/// Cached high limit value, to ensure that the correct value is returned when monitoring.
 	double highLimitValue_;
 
 
 protected slots:
+	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setLowLimitValue(double newLowLimit);
+	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setHighLimitValue(double newHighLimit);
+
 	/// This is called when reading the PV's control information completes successfully.
 	virtual void onReadPVInitialized();
-	/// Handles updating the low limit value when the low limit pv is initialized.
-	virtual void onLowLimitPVInitialized();
-	/// Handles updating the high limit value when the high limit pv is initialized.
-	virtual void onHighLimitPVInitialized();
+	/// Handles updating the low limit value when the low limit pv value changes.
+	virtual void onLowLimitPVValueChanged();
+	/// Handles updating the high limit value when the high limit pv value changes.
+	virtual void onHighLimitPVValueChanged();
 
 	/// You can also monitor the readConnectionTimeoutOccurred() signal.
 	void onConnectionTimeout() { setUnits("?"); emit connected(false); emit error(AMControl::CannotConnectError); }
@@ -802,17 +811,16 @@ public:
 	/// Overloaded to convert the units.
 	virtual double writePVValue() const { return writeUnitConverter()->convertFromRaw(AMPVwStatusControl::writePVValue()); }
 
-public slots:
-	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setLowLimitValue(double newLowLimit);
-	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setHighLimitValue(double newHighLimit);
 
 protected slots:
 	/// Instead of forwarding the readPV valueChanged() signal directly as valueChanged(), we need to do a conversion
 	void onReadPVValueChanged(double newValue);
 	/// Instead of forwarding the writePV valueChanged() signal directly as setpointChanged(), we need to do a conversion
 	void onWritePVValueChanged(double newValue);
+	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setLowLimitValue(double newLowLimit);
+	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setHighLimitValue(double newHighLimit);
 
 protected:
 

--- a/source/beamline/AMPVControl.h
+++ b/source/beamline/AMPVControl.h
@@ -116,9 +116,9 @@ signals:
 
 public slots:
 	/// Sets the minimum value.
-	void setMinimumValue(double newValue);
+	void setMinimumValueOverride(double newValue);
 	/// Sets the maximum value.
-	void setMaximumValue(double newValue);
+	void setMaximumValueOverride(double newValue);
 
 protected:
 

--- a/source/beamline/AMPVControl.h
+++ b/source/beamline/AMPVControl.h
@@ -114,6 +114,12 @@ signals:
 	///  This extra signal is specialized to report on PV channel connection status.  You should be free to ignore it and use the signals defined in AMControl.
 	void readConnectionTimeoutOccurred();
 
+public slots:
+	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setLowLimitValue(double newLowLimit);
+	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setHighLimitValue(double newHighLimit);
+
 protected:
 
 	/// Pointer to ProcessVariable used to read feedback value
@@ -131,11 +137,6 @@ protected:
 
 
 protected slots:
-	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setLowLimitValue(double newLowLimit);
-	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setHighLimitValue(double newHighLimit);
-
 	/// This is called when reading the PV's control information completes successfully.
 	virtual void onReadPVInitialized();
 	/// Handles updating the low limit value when the low limit pv is initialized.
@@ -801,16 +802,17 @@ public:
 	/// Overloaded to convert the units.
 	virtual double writePVValue() const { return writeUnitConverter()->convertFromRaw(AMPVwStatusControl::writePVValue()); }
 
+public slots:
+	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setLowLimitValue(double newLowLimit);
+	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
+	virtual void setHighLimitValue(double newHighLimit);
 
 protected slots:
 	/// Instead of forwarding the readPV valueChanged() signal directly as valueChanged(), we need to do a conversion
 	void onReadPVValueChanged(double newValue);
 	/// Instead of forwarding the writePV valueChanged() signal directly as setpointChanged(), we need to do a conversion
 	void onWritePVValueChanged(double newValue);
-	/// Handles the low limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setLowLimitValue(double newLowLimit);
-	/// Handles the high limit PV changing. Converts the limit before forwarding the signal on.
-	virtual void setHighLimitValue(double newHighLimit);
 
 protected:
 

--- a/source/beamline/AMPseudoMotorControl.cpp
+++ b/source/beamline/AMPseudoMotorControl.cpp
@@ -299,6 +299,22 @@ AMControl::FailureExplanation AMPseudoMotorControl::calibrate(double oldValue, d
 	return AMControl::NoFailure;
 }
 
+void AMPseudoMotorControl::setMinimumValue(double newValue)
+{
+	if (minimumValue_ != newValue) {
+		minimumValue_ = newValue;
+		emit minimumValueChanged(minimumValue_);
+	}
+}
+
+void AMPseudoMotorControl::setMaximumValue(double newValue)
+{
+	if (maximumValue_ != newValue) {
+		maximumValue_ = newValue;
+		emit maximumValueChanged(maximumValue_);
+	}
+}
+
 void AMPseudoMotorControl::setEnumStates(const QStringList &enumStateNames)
 {
 	AMControl::setEnumStates(enumStateNames);
@@ -343,22 +359,6 @@ void AMPseudoMotorControl::setIsMoving(bool isMoving)
 	if (isMoving_ != isMoving) {
 		isMoving_ = isMoving;
 		emit movingChanged(isMoving_);
-	}
-}
-
-void AMPseudoMotorControl::setMinimumValue(double newValue)
-{
-	if (minimumValue_ != newValue) {
-		minimumValue_ = newValue;
-		emit minimumValueChanged(minimumValue_);
-	}
-}
-
-void AMPseudoMotorControl::setMaximumValue(double newValue)
-{
-	if (maximumValue_ != newValue) {
-		maximumValue_ = newValue;
-		emit maximumValueChanged(maximumValue_);
 	}
 }
 

--- a/source/beamline/AMPseudoMotorControl.h
+++ b/source/beamline/AMPseudoMotorControl.h
@@ -72,6 +72,11 @@ public slots:
 	/// Calibrates the control such that the old value becomes the new value. Fails if calibration has not been implemented for this control.
 	virtual FailureExplanation calibrate(double oldValue, double newValue);
 
+	/// Sets the minimum value.
+	void setMinimumValue(double newValue);
+	/// Sets the maximum value.
+	void setMaximumValue(double newValue);
+
 protected slots:
 	/// Sets the enum states.
 	void setEnumStates(const QStringList &enumStateNames);
@@ -83,10 +88,6 @@ protected slots:
 	void setMoveInProgress(bool isMoving);
 	/// Sets the 'is moving' state.
 	void setIsMoving(bool isMoving);
-	/// Sets the minimum value.
-	void setMinimumValue(double newValue);
-	/// Sets the maximum value.
-	void setMaximumValue(double newValue);
 	/// Sets the 'calibration in progress' state.
 	void setCalibrationInProgress(bool isCalibrating);
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -307,8 +307,8 @@ void BioXASSideBeamline::setupComponents()
 	// Be window.
 
 	beWindow_ = new CLSMAXvMotor("SMTR1607-6-I22-01", "SMTR1607-6-I22-01", "SMTR1607-6-I22-01", true, 0.01, 2.0, this);
-	beWindow_->setMinimumValue(-12.5);
-	beWindow_->setMaximumValue(2.5);
+	beWindow_->setMinimumValueOverride(-12.5);
+	beWindow_->setMaximumValueOverride(2.5);
 	connect( beWindow_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// JJ slits.

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -307,6 +307,8 @@ void BioXASSideBeamline::setupComponents()
 	// Be window.
 
 	beWindow_ = new CLSMAXvMotor("SMTR1607-6-I22-01", "SMTR1607-6-I22-01", "SMTR1607-6-I22-01", true, 0.01, 2.0, this);
+	beWindow_->setMinimumValue(-12.5);
+	beWindow_->setMaximumValue(2.5);
 	connect( beWindow_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// JJ slits.

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -22,11 +22,31 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 
-	setPitch(new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this));
-	setRoll(new BioXASMirrorRollControl(name()+"RollControl", "deg", this));
-	setHeight(new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this));
-	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
-	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
+	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
+	pitchControl->setMinimumValue(0.1);
+	pitchControl->setMaximumValue(0.225);
+	setPitch(pitchControl);
+
+	BioXASMirrorRollControl *rollControl = new BioXASMirrorRollControl(name()+"RollControl", "deg", this);
+	rollControl->setMinimumValue(-0.1);
+	rollControl->setMaximumValue(0.1);
+	setRoll(rollControl);
+
+	BioXASMirrorHeightControl *heightControl = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
+	heightControl->setMinimumValue(-22);
+	heightControl->setMaximumValue(2);
+	setHeight(heightControl);
+
+	BioXASMirrorLateralControl *lateralControl = new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this);
+	lateralControl->setMinimumValue(-3);
+	lateralControl->setMaximumValue(3);
+	setLateral(lateralControl);
+
+	BioXASMirrorYawControl *yawControl = new BioXASMirrorYawControl(name()+"YawControl", "deg", this);
+	yawControl->setMinimumValue(-0.05);
+	yawControl->setMaximumValue(0.05);
+	setYaw(yawControl);
+
 	setBend(new BioXASSideM1MirrorBendControl(name()+"BendControl", "m", this));
 
 	setDownstreamBladeCurrent(new AMReadOnlyPVControl(QString("%1%2").arg(name()).arg("DownstreamBladeCurrent"), QString("A1607-5-03:A:fbk"), this));

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -10,6 +10,9 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setDownstreamLength(543.68);
 
 	CLSMAXvMotor *upperSlitBladeMotor = new CLSMAXvMotor(QString("SMTR1607-5-I22-08 UPPER SLIT"), QString("SMTR1607-5-I22-08"), QString("SMTR1607-5-I22-08 UPPER SLIT"), true, 0.05, 2.0, this, QString(":mm"));
+	upperSlitBladeMotor->setLowLimitValue(0);
+	upperSlitBladeMotor->setHighLimitValue(3.4);
+
 	BioXASM1MirrorMask *mask = new BioXASM1MirrorMask(name()+"Mask", this);
 	mask->setUpperSlitBlade(upperSlitBladeMotor);
 	setMask(mask);
@@ -19,8 +22,16 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-03"), QString("SMTR1607-5-I22-03 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
 	setStripeSelectMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-04 STRIPE SELECT"), QString("SMTR1607-5-I22-04"), QString("SMTR1607-5-I22-04 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
 	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-05 YAW"), QString("SMTR1607-5-I22-05"), QString("SMTR1607-5-I22-05 YAW"), true, 0.05, 2.0, this, QString(":mm")));
-	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
-	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
+
+	CLSMAXvMotor *upstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
+	upstreamBender->setLowLimitValue(0);
+	upstreamBender->setHighLimitValue(10);
+	setUpstreamBenderMotor(upstreamBender);
+
+	CLSMAXvMotor *downstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
+	downstreamBender->setLowLimitValue(0);
+	downstreamBender->setHighLimitValue(10);
+	setDownstreamBenderMotor(downstreamBender);
 
 	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
 	pitchControl->setMinimumValue(0.1);

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -33,7 +33,7 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setRoll(rollControl);
 
 	BioXASMirrorHeightControl *heightControl = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
-	heightControl->setMinimumValue(-22);
+	heightControl->setMinimumValue(-2);
 	heightControl->setMaximumValue(2);
 	setHeight(heightControl);
 

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -10,8 +10,8 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setDownstreamLength(543.68);
 
 	CLSMAXvMotor *upperSlitBladeMotor = new CLSMAXvMotor(QString("SMTR1607-5-I22-08 UPPER SLIT"), QString("SMTR1607-5-I22-08"), QString("SMTR1607-5-I22-08 UPPER SLIT"), true, 0.05, 2.0, this, QString(":mm"));
-	upperSlitBladeMotor->setLowLimitValue(0);
-	upperSlitBladeMotor->setHighLimitValue(3.4);
+	upperSlitBladeMotor->setMinimumValue(0);
+	upperSlitBladeMotor->setMaximumValue(3.4);
 
 	BioXASM1MirrorMask *mask = new BioXASM1MirrorMask(name()+"Mask", this);
 	mask->setUpperSlitBlade(upperSlitBladeMotor);
@@ -24,13 +24,13 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-05 YAW"), QString("SMTR1607-5-I22-05"), QString("SMTR1607-5-I22-05 YAW"), true, 0.05, 2.0, this, QString(":mm")));
 
 	CLSMAXvMotor *upstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	upstreamBender->setLowLimitValue(0);
-	upstreamBender->setHighLimitValue(10);
+	upstreamBender->setMinimumValue(0);
+	upstreamBender->setMaximumValue(10);
 	setUpstreamBenderMotor(upstreamBender);
 
 	CLSMAXvMotor *downstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	downstreamBender->setLowLimitValue(0);
-	downstreamBender->setHighLimitValue(10);
+	downstreamBender->setMinimumValue(0);
+	downstreamBender->setMaximumValue(10);
 	setDownstreamBenderMotor(downstreamBender);
 
 	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);

--- a/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM1Mirror.cpp
@@ -10,8 +10,8 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setDownstreamLength(543.68);
 
 	CLSMAXvMotor *upperSlitBladeMotor = new CLSMAXvMotor(QString("SMTR1607-5-I22-08 UPPER SLIT"), QString("SMTR1607-5-I22-08"), QString("SMTR1607-5-I22-08 UPPER SLIT"), true, 0.05, 2.0, this, QString(":mm"));
-	upperSlitBladeMotor->setMinimumValue(0);
-	upperSlitBladeMotor->setMaximumValue(3.4);
+	upperSlitBladeMotor->setMinimumValueOverride(0);
+	upperSlitBladeMotor->setMaximumValueOverride(3.4);
 
 	BioXASM1MirrorMask *mask = new BioXASM1MirrorMask(name()+"Mask", this);
 	mask->setUpperSlitBlade(upperSlitBladeMotor);
@@ -24,13 +24,13 @@ BioXASSideM1Mirror::BioXASSideM1Mirror(QObject *parent) :
 	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-05 YAW"), QString("SMTR1607-5-I22-05"), QString("SMTR1607-5-I22-05 YAW"), true, 0.05, 2.0, this, QString(":mm")));
 
 	CLSMAXvMotor *upstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-06"), QString("SMTR1607-5-I22-06 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	upstreamBender->setMinimumValue(0);
-	upstreamBender->setMaximumValue(10);
+	upstreamBender->setMinimumValueOverride(0);
+	upstreamBender->setMaximumValueOverride(10);
 	setUpstreamBenderMotor(upstreamBender);
 
 	CLSMAXvMotor *downstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-07"), QString("SMTR1607-5-I22-07 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	downstreamBender->setMinimumValue(0);
-	downstreamBender->setMaximumValue(10);
+	downstreamBender->setMinimumValueOverride(0);
+	downstreamBender->setMaximumValueOverride(10);
 	setDownstreamBenderMotor(downstreamBender);
 
 	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);

--- a/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
@@ -13,8 +13,16 @@ BioXASSideM2Mirror::BioXASSideM2Mirror(QObject *parent) :
 	setDownstreamMotor(new BioXASMirrorMotor(QString("SMTR1607-5-I22-17 VERT (DOWNSTREAM)"), QString("SMTR1607-5-I22-17"), QString("SMTR1607-5-I22-17 VERT (DOWNSTREAM)"), true, 619.125, 0, 0.05, 2.0, this, QString(":mm")));
 	setStripeSelectMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-18 STRIPE SELECT"), QString("SMTR1607-5-I22-18"), QString("SMTR1607-5-I22-18 STRIPE SELECT"), true, 0.05, 2.0, this, QString(":mm")));
 	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-19 YAW"), QString("SMTR1607-5-I22-19"), QString("SMTR1607-5-I22-19 YAW"), true, 0.05, 2.0, this, QString(":mm")));
-	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-20"), QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
-	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-21"), QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
+
+	CLSMAXvMotor *upstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-20"), QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
+	upstreamBender->setMinimumValue(0);
+	upstreamBender->setMaximumValue(17);
+	setUpstreamBenderMotor(upstreamBender);
+
+	CLSMAXvMotor *downstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-21"), QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
+	downstreamBender->setMinimumValue(0);
+	downstreamBender->setMaximumValue(17);
+	setDownstreamBenderMotor(downstreamBender);
 
 	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
 	pitchControl->setMinimumValue(0.125);

--- a/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
@@ -15,13 +15,13 @@ BioXASSideM2Mirror::BioXASSideM2Mirror(QObject *parent) :
 	setYawMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-19 YAW"), QString("SMTR1607-5-I22-19"), QString("SMTR1607-5-I22-19 YAW"), true, 0.05, 2.0, this, QString(":mm")));
 
 	CLSMAXvMotor *upstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-20"), QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	upstreamBender->setMinimumValue(0);
-	upstreamBender->setMaximumValue(17);
+	upstreamBender->setMinimumValueOverride(0);
+	upstreamBender->setMaximumValueOverride(17);
 	setUpstreamBenderMotor(upstreamBender);
 
 	CLSMAXvMotor *downstreamBender = new CLSMAXvMotor(QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-21"), QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs"));
-	downstreamBender->setMinimumValue(0);
-	downstreamBender->setMaximumValue(17);
+	downstreamBender->setMinimumValueOverride(0);
+	downstreamBender->setMaximumValueOverride(17);
 	setDownstreamBenderMotor(downstreamBender);
 
 	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);

--- a/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
+++ b/source/beamline/BioXAS/BioXASSideM2Mirror.cpp
@@ -16,11 +16,31 @@ BioXASSideM2Mirror::BioXASSideM2Mirror(QObject *parent) :
 	setUpstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), QString("SMTR1607-5-I22-20"), QString("SMTR1607-5-I22-20 BENDER (UPSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 	setDownstreamBenderMotor(new CLSMAXvMotor(QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), QString("SMTR1607-5-I22-21"), QString("SMTR1607-5-I22-21 BENDER (DOWNSTREAM)"), true, 0.3, 2.0, this, QString(":lbs")));
 
-	setPitch(new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this));
-	setRoll(new BioXASMirrorRollControl(name()+"RollControl", "deg", this));
-	setHeight(new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this));
-	setLateral(new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this));
-	setYaw(new BioXASMirrorYawControl(name()+"YawControl", "deg", this));
+	BioXASMirrorPitchControl *pitchControl = new BioXASMirrorPitchControl(name()+"PitchControl", "deg", this);
+	pitchControl->setMinimumValue(0.125);
+	pitchControl->setMaximumValue(0.27);
+	setPitch(pitchControl);
+
+	BioXASMirrorRollControl *rollControl = new BioXASMirrorRollControl(name()+"RollControl", "deg", this);
+	rollControl->setMinimumValue(-0.125);
+	rollControl->setMaximumValue(0.125);
+	setRoll(rollControl);
+
+	BioXASMirrorHeightControl *heightControl = new BioXASMirrorHeightControl(name()+"HeightControl", "mm", this);
+	heightControl->setMinimumValue(-2.5);
+	heightControl->setMaximumValue(12.5);
+	setHeight(heightControl);
+
+	BioXASMirrorLateralControl *lateralControl = new BioXASMirrorLateralControl(name()+"LateralControl", "mm", this);
+	lateralControl->setMinimumValue(-3);
+	lateralControl->setMaximumValue(3);
+	setLateral(lateralControl);
+
+	BioXASMirrorYawControl *yawControl = new BioXASMirrorYawControl(name()+"YawControl", "deg", this);
+	yawControl->setMinimumValue(-0.05);
+	yawControl->setMaximumValue(0.05);
+	setYaw(yawControl);
+
 	setBend(new BioXASSideM2MirrorBendControl(name()+"BendControl", "m", this));
 
 	setScreen(new AMSinglePVControl(name()+"FluorescentScreen", "VSC1607-5-I22-02:InBeam", this));

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -14,7 +14,12 @@ BioXASSideMonochromator::BioXASSideMonochromator(const QString &deviceName, QObj
 	setCrystalChange(new CLSMAXvMotor(QString("SMTR1607-5-I22-22 XTAL XCHANGE"), QString("SMTR1607-5-I22-22"), QString("SMTR1607-5-I22-22 XTAL XCHAGE"), true, 0.05, 2.0, this));
 	setRegionAStatus(new AMReadOnlyPVControl(name()+"RegionAStatus", "BL1607-5-I22:Mono:Region:A", this));
 	setRegionBStatus(new AMReadOnlyPVControl(name()+"RegionBStatus", "BL1607-5-I22:Mono:Region:B", this));
-	setVertical(new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this));
+
+	CLSMAXvMotor *verticalMotor = new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this);
+	verticalMotor->setMinimumValue(1400);
+	verticalMotor->setMaximumValue(1420);
+	setVertical(verticalMotor);
+
 	setLateral(new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this));
 	setCrystal1Pitch(new CLSMAXvMotor(QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), QString("SMTR1607-5-I22-23"), QString("SMTR1607-5-I22-23 XTAL 1 PITCH"), true, 0.05, 2.0, this, QString(":V")));
 	setCrystal1Roll(new CLSMAXvMotor(QString("SMTR1607-5-I22-24 XTAL 1 ROLL"), QString("SMTR1607-5-I22-24"), QString("SMTR1607-5-I22-24 XTAL 1 ROLL"),   true, 0.05, 2.0, this, QString(":V")));

--- a/source/beamline/BioXAS/BioXASSideMonochromator.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromator.cpp
@@ -16,8 +16,8 @@ BioXASSideMonochromator::BioXASSideMonochromator(const QString &deviceName, QObj
 	setRegionBStatus(new AMReadOnlyPVControl(name()+"RegionBStatus", "BL1607-5-I22:Mono:Region:B", this));
 
 	CLSMAXvMotor *verticalMotor = new CLSMAXvMotor(QString("SMTR1607-5-I22-13 VERTICAL"), QString("SMTR1607-5-I22-13"), QString("SMTR1607-5-I22-13 VERTICAL"), true, 0.05, 2.0, this);
-	verticalMotor->setMinimumValue(1400);
-	verticalMotor->setMaximumValue(1420);
+	verticalMotor->setMinimumValueOverride(1400);
+	verticalMotor->setMaximumValueOverride(1420);
 	setVertical(verticalMotor);
 
 	setLateral(new CLSMAXvMotor(QString("SMTR1607-5-I22-14 LATERAL"), QString("SMTR1607-5-I22-14"), QString("SMTR1607-5-I22-14 LATERAL"), true, 0.05, 2.0, this));

--- a/source/beamline/BioXAS/BioXASSideMonochromatorMask.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromatorMask.cpp
@@ -6,13 +6,13 @@ BioXASSideMonochromatorMask::BioXASSideMonochromatorMask(const QString &deviceNa
 	BioXASSSRLMonochromatorMask(deviceName, parent)
 {
 	CLSMAXvMotor *upperBlade = new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this);
-	upperBlade->setMinimumValue(0);
-	upperBlade->setMaximumValue(1);
+	upperBlade->setMinimumValueOverride(0);
+	upperBlade->setMaximumValueOverride(1);
 	setUpperBlade(upperBlade);
 
 	CLSMAXvMotor *lowerBlade = new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
-	lowerBlade->setMinimumValue(-4);
-	lowerBlade->setMaximumValue(0);
+	lowerBlade->setMinimumValueOverride(-4);
+	lowerBlade->setMaximumValueOverride(0);
 	setLowerBlade(lowerBlade);
 
 	setBladesState(new AMReadOnlyPVControl("BL1607-5-I22:Mono:SlitsClosed", "BL1607-5-I22:Mono:SlitsClosed", this));

--- a/source/beamline/BioXAS/BioXASSideMonochromatorMask.cpp
+++ b/source/beamline/BioXAS/BioXASSideMonochromatorMask.cpp
@@ -5,8 +5,16 @@
 BioXASSideMonochromatorMask::BioXASSideMonochromatorMask(const QString &deviceName, QObject *parent) :
 	BioXASSSRLMonochromatorMask(deviceName, parent)
 {
-	setUpperBlade(new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this));
-	setLowerBlade(new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this));
+	CLSMAXvMotor *upperBlade = new CLSMAXvMotor(QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), QString("SMTR1607-5-I22-09"), QString("SMTR1607-5-I22-09 VERT UPPER BLADE"), true, 0.1, 2.0, this);
+	upperBlade->setMinimumValue(0);
+	upperBlade->setMaximumValue(1);
+	setUpperBlade(upperBlade);
+
+	CLSMAXvMotor *lowerBlade = new CLSMAXvMotor(QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), QString("SMTR1607-5-I22-10"), QString("SMTR1607-5-I22-10 VERT LOWER BLADE"), true, 0.1, 2.0, this);
+	lowerBlade->setMinimumValue(-4);
+	lowerBlade->setMaximumValue(0);
+	setLowerBlade(lowerBlade);
+
 	setBladesState(new AMReadOnlyPVControl("BL1607-5-I22:Mono:SlitsClosed", "BL1607-5-I22:Mono:SlitsClosed", this));
 }
 

--- a/source/ui/beamline/AMControlView.cpp
+++ b/source/ui/beamline/AMControlView.cpp
@@ -147,7 +147,7 @@ void AMControlView::updateValueLabel()
 
 	valueLabel_->setText(value);
 }
-#include <QDebug>
+
 void AMControlView::updateMinimumLabel()
 {
 	QString minimum = "";
@@ -157,8 +157,6 @@ void AMControlView::updateMinimumLabel()
 
 		if (!control_->units().isEmpty())
 			minimum.append(QString(" %1").arg(control_->units()));
-
-		qDebug() << "\n\nUpdating minimum label for" << control_->name() << ":" << minimum;
 	}
 
 	valueMinimumLabel_->setText(minimum);

--- a/source/ui/beamline/AMControlView.cpp
+++ b/source/ui/beamline/AMControlView.cpp
@@ -94,6 +94,8 @@ void AMControlView::setControl(AMControl *newControl)
 			connect( control_, SIGNAL(connected(bool)), this, SLOT(updateConnectedLabel()) );
 			connect( control_, SIGNAL(valueChanged(double)), this, SLOT(updateValueLabel()) );
 			connect( control_, SIGNAL(enumChanged()), this, SLOT(updateValuesView()) );
+			connect( control_, SIGNAL(minimumValueChanged(double)), this, SLOT(updateMinimumLabel()) );
+			connect( control_, SIGNAL(maximumValueChanged(double)), this, SLOT(updateMaximumLabel()) );
 		}
 
 		refresh();
@@ -145,7 +147,7 @@ void AMControlView::updateValueLabel()
 
 	valueLabel_->setText(value);
 }
-
+#include <QDebug>
 void AMControlView::updateMinimumLabel()
 {
 	QString minimum = "";
@@ -155,6 +157,8 @@ void AMControlView::updateMinimumLabel()
 
 		if (!control_->units().isEmpty())
 			minimum.append(QString(" %1").arg(control_->units()));
+
+		qDebug() << "\n\nUpdating minimum label for" << control_->name() << ":" << minimum;
 	}
 
 	valueMinimumLabel_->setText(minimum);


### PR DESCRIPTION
Changes:
- Moved `AMPseudoMotorControl::setMinimum(...)` and `setMaximum(...)` methods to public slots, from protected slots.
- Added `AMReadOnlyPVControl::setMinimum(...)` and `setMaximum(...)` methods. These call the existing protected `setLowLimitValue(...)/setHighLimitValue(...)` slots, and additionally set a flag that causes limit updates from PVs to be rejected.
- Added limits.

Testing involved attempting to input values inside and outside the value ranges using editors. Control editors should reject input for values outside the desired range.
- [x] M1 mirror PV controls
- [x] M1 mirror pseudomotors
- [x] Mono PV controls
- [x] M2 mirror PV controls
- [x] M2 mirror pseudomotors