### PR TITLE
Pull Request for Issue2267: Use kill for stopping Ge detector stages.

### DIFF
--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -360,6 +360,7 @@ void BioXASSideBeamline::setupComponents()
 	// Detector stage.
 
 	detectorStageLateral_ = new CLSMAXvMotor("SMTR1607-6-I22-16", "SMTR1607-6-I22-16", "SMTR1607-6-I22-16", true, 0.05, 2.0, this, ":mm");
+	detectorStageLateral_->setUsingKill(true);
 	addDetectorStageLateralMotor(detectorStageLateral_);
 
 	// Cryostat stage.


### PR DESCRIPTION
Changes:
- Modified the Side detector stage motor, set the usingKill status to true.