### PR TITLE
Pull Request for Issue2074: Increasing scan view tool precision.

### DIFF
--- a/source/ui/dataman/AMScanViewPlotToolView.cpp
+++ b/source/ui/dataman/AMScanViewPlotToolView.cpp
@@ -99,30 +99,26 @@ void AMDataPositionToolView::refresh()
 	update();
 }
 
-QString AMDataPositionToolView::positionToString(double value, const QString &units)
+QString AMDataPositionToolView::positionToString(double value, const QString &units) const
 {
-	QString text = QString::number(value, 'f', 2);
-	if (!units.isEmpty())
-		text += " " + units;
+	QString result = QString("%1").arg(value);
 
-	return text;
+	if (!units.isEmpty() && units != " ")
+		result.append(QString(" %1").arg(units));
+
+	return result;
 }
 
-QString AMDataPositionToolView::positionToString(const QPointF &values, const QStringList &units)
+QString AMDataPositionToolView::positionToString(const QPointF &values, const QStringList &units) const
 {
-	QString text;
+	QString result;
 
-	QString x = QString::number(values.x(), 'f', 2);
-	if (units.size() > 0)
-		x += " " + units.at(0);
+	QString xString = positionToString(values.x(), units.size() > 0 ? units.at(0) : "");
+	QString yString = positionToString(values.y(), units.size() > 1 ? units.at(1) : "");
 
-	QString y = QString::number(values.y(), 'f', 2);
-	if (units.size() > 1)
-		y += " " + units.at(1);
+	result = QString("(%1, %2)").arg(xString).arg(yString);
 
-	text = "(" + x + ", " + y + ")";
-
-	return text;
+	return result;
 }
 
 
@@ -149,11 +145,13 @@ AMDataPositionCursorToolView::AMDataPositionCursorToolView(MPlotDataPositionCurs
 	xPositionBox_ = new QDoubleSpinBox();
 	xPositionBox_->setMinimum(-1000000);
 	xPositionBox_->setMaximum(1000000);
+	xPositionBox_->setDecimals(AMDATAPOSITIONCURSORTOOLVIEW_POSITION_PRECISION);
 	xPositionBox_->setValue(0);
 
 	yPositionBox_ = new QDoubleSpinBox();
 	yPositionBox_->setMinimum(-1000000);
 	yPositionBox_->setMaximum(1000000);
+	yPositionBox_->setDecimals(AMDATAPOSITIONCURSORTOOLVIEW_POSITION_PRECISION);
 	yPositionBox_->setValue(0);
 
 	markerComboBox_ = new AMPlotMarkerComboBox(QList<MPlotMarkerShape::Shape>() << MPlotMarkerShape::VerticalBeam << MPlotMarkerShape::HorizontalBeam << MPlotMarkerShape::Cross);

--- a/source/ui/dataman/AMScanViewPlotToolView.h
+++ b/source/ui/dataman/AMScanViewPlotToolView.h
@@ -42,9 +42,9 @@ public slots:
 
 protected:
 	/// Returns a string representation of the given 1D position.
-	static QString positionToString(double value, const QString &units);
+	QString positionToString(double value, const QString &units) const;
 	/// Returns a string representation of the given 2D position.
-	static QString positionToString(const QPointF &values, const QStringList &units);
+	QString positionToString(const QPointF &values, const QStringList &units) const;
 
 protected:
 	/// The tool being viewed.
@@ -65,6 +65,8 @@ protected:
 #include <QDoubleSpinBox>
 #include "ui/dataman/AMColorPickerButton.h"
 #include "ui/AMPlotMarkerComboBox.h"
+
+#define AMDATAPOSITIONCURSORTOOLVIEW_POSITION_PRECISION 3
 
 class AMDataPositionCursorToolView : public QWidget
 {


### PR DESCRIPTION
Increased the precision of the x and y position boxes in AMDataPositionCursorToolView from 2 (default) to requested 3. Noticed a couple of small things that could be fixed in this class -- eg. using QStringBuilder and removing static keywords.