### PR TITLE
Pull Request for Export Issue 2106: XRF button bring up unpopulated scan browser

### DIFF
--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -534,8 +534,8 @@ void AMXRFDetailedDetectorView::onSaveButtonClicked()
 		connect(chooseScanDialog_, SIGNAL(accepted()), this, SLOT(exportScan()));
 	}
 
-	chooseScanDialog_->setFilterKeyColumn(4);
-	chooseScanDialog_->setFilterRegExp("X(|-)Ray Fluorescence Scan");
+	chooseScanDialog_->setFilterKeyColumn(1);
+	chooseScanDialog_->setFilterRegExp(QString("XRF Scan - %1").arg(detector_->name()));
 	chooseScanDialog_->show();
 }
 


### PR DESCRIPTION
Changed AMXRFDetailedDetectorView::onSaveButtonClicked() so that RegEx filters on scan name instead of type and only shows XRF scans with the default name "XRF Scan - <detector>" (i.e. unexported
scans)