### PR TITLE
Pull Request for Issue2148: generic scan configuration to show detectors already added.

### DIFF
--- a/source/acquaman/AMGenericContinuousScanConfiguration.cpp
+++ b/source/acquaman/AMGenericContinuousScanConfiguration.cpp
@@ -76,7 +76,7 @@ QString AMGenericContinuousScanConfiguration::detailedDescription() const
 
 bool AMGenericContinuousScanConfiguration::hasI0() const
 {
-	return i0_.name() != "Invalid Detector";
+	return i0_.isValid();
 }
 
 void AMGenericContinuousScanConfiguration::addRegion(int scanAxisIndex, int regionIndex, AMScanAxisRegion *region)
@@ -282,10 +282,11 @@ void AMGenericContinuousScanConfiguration::setI0(const AMDetectorInfo &info)
 		if (info.name() == detectorConfigurations_.at(i).name())
 			nameInDetectorList = true;
 
-	if (nameInDetectorList){
-
+	if ((info.isValid() && nameInDetectorList) || !info.isValid()){
 		i0_ = info;
 		setModified(true);
+
+		emit i0DetectorChanged();
 	}
 }
 

--- a/source/acquaman/AMGenericContinuousScanConfiguration.h
+++ b/source/acquaman/AMGenericContinuousScanConfiguration.h
@@ -52,6 +52,8 @@ public:
 signals:
 	/// Notifier that the total time estimate has changed.
 	void totalTimeChanged(double);
+	/// Notifier that the I0 detector has changed.
+	void i0DetectorChanged();
 
 public slots:
 	/// Sets a controlInfo to an axis.  If the axis has no control associated with it yet, then it will add it to the list, otherwise it will replace it.

--- a/source/acquaman/AMGenericStepScanConfiguration.cpp
+++ b/source/acquaman/AMGenericStepScanConfiguration.cpp
@@ -283,16 +283,18 @@ void AMGenericStepScanConfiguration::setRegionOfInterestBoundingRange(AMRegionOf
 
 void AMGenericStepScanConfiguration::setI0(const AMDetectorInfo &info)
 {
+	bool validInfo = (info.name() != "Invalid detector");
 	bool nameInDetectorList = false;
 
 	for (int i = 0, size = detectorConfigurations_.count(); i < size && !nameInDetectorList; i++)
 		if (info.name() == detectorConfigurations_.at(i).name())
 			nameInDetectorList = true;
 
-	if (nameInDetectorList){
-
+	if ((validInfo && nameInDetectorList) || !validInfo) {
 		i0_ = info;
 		setModified(true);
+
+		emit i0DetectorChanged();
 	}
 }
 

--- a/source/acquaman/AMGenericStepScanConfiguration.cpp
+++ b/source/acquaman/AMGenericStepScanConfiguration.cpp
@@ -73,7 +73,7 @@ QString AMGenericStepScanConfiguration::detailedDescription() const
 
 bool AMGenericStepScanConfiguration::hasI0() const
 {
-	return i0_.name() != "Invalid Detector";
+	return i0_.isValid();
 }
 
 void AMGenericStepScanConfiguration::addRegion(int scanAxisIndex, int regionIndex, AMScanAxisRegion *region)
@@ -283,14 +283,13 @@ void AMGenericStepScanConfiguration::setRegionOfInterestBoundingRange(AMRegionOf
 
 void AMGenericStepScanConfiguration::setI0(const AMDetectorInfo &info)
 {
-	bool validInfo = (info.name() != "Invalid detector");
 	bool nameInDetectorList = false;
 
 	for (int i = 0, size = detectorConfigurations_.count(); i < size && !nameInDetectorList; i++)
 		if (info.name() == detectorConfigurations_.at(i).name())
 			nameInDetectorList = true;
 
-	if ((validInfo && nameInDetectorList) || !validInfo) {
+	if ((info.isValid() && nameInDetectorList) || !info.isValid()) {
 		i0_ = info;
 		setModified(true);
 

--- a/source/acquaman/AMGenericStepScanConfiguration.h
+++ b/source/acquaman/AMGenericStepScanConfiguration.h
@@ -62,6 +62,8 @@ signals:
 	void totalTimeChanged(double);
 	/// Notifier that the detectors have changed.
 	void detectorsChanged();
+	/// Notifier that the I0 detector has changed.
+	void i0DetectorChanged();
 
 public slots:
 	/// Sets a controlInfo to an axis.  If the axis has no control associated with it yet, then it will add it to the list, otherwise it will replace it.

--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -78,11 +78,9 @@ AMAction3 * AMGenericStepScanController::createCleanupActions()
 {
 	return AMBeamline::bl()->createScanCleanupAction(configuration_);
 }
-#include <QDebug>
+
 void AMGenericStepScanController::buildScanControllerImplementation()
 {
-	qDebug() << "\n\nAMGenericStepScanController::buildScanControllerImplementation()";
-
 	QList<AMXRFDetector *> xrfDetectors;
 	QList<AMDataSource *> spectrumSources;
 
@@ -147,8 +145,6 @@ void AMGenericStepScanController::buildScanControllerImplementation()
 				AMDataSource *source = scan_->dataSourceAt(sourceIndices.at(i));
 
 				if (source->name() != i0Source->name() && source->rank() == i0Source->rank()){
-
-					qDebug() << "\tAdding normalized source" << source->name();
 
 					AMNormalizationAB *normalizedSource = new AMNormalizationAB(QString("norm_%1").arg(source->name()));
 					normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << i0Source);

--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -78,9 +78,11 @@ AMAction3 * AMGenericStepScanController::createCleanupActions()
 {
 	return AMBeamline::bl()->createScanCleanupAction(configuration_);
 }
-
+#include <QDebug>
 void AMGenericStepScanController::buildScanControllerImplementation()
 {
+	qDebug() << "\n\nAMGenericStepScanController::buildScanControllerImplementation()";
+
 	QList<AMXRFDetector *> xrfDetectors;
 	QList<AMDataSource *> spectrumSources;
 
@@ -129,28 +131,30 @@ void AMGenericStepScanController::buildScanControllerImplementation()
 			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
 			detector->addRegionOfInterest(region);
 		}
+	}
 
-		if (configuration_->hasI0()){
+	if (configuration_->hasI0()){
 
-			int index = scan_->indexOfDataSource(configuration_->i0().name());
+		int index = scan_->indexOfDataSource(configuration_->i0().name());
 
-			if (index != -1){
+		if (index != -1){
 
-				AMDataSource *i0Source = scan_->dataSourceAt(index);
-				QVector<int> sourceIndices = scan_->nonHiddenDataSourceIndexes();
+			AMDataSource *i0Source = scan_->dataSourceAt(index);
+			QVector<int> sourceIndices = scan_->nonHiddenDataSourceIndexes();
 
-				for (int i = 0, size = sourceIndices.size(); i < size; i++){
+			for (int i = 0, size = sourceIndices.size(); i < size; i++){
 
-					AMDataSource *source = scan_->dataSourceAt(sourceIndices.at(i));
+				AMDataSource *source = scan_->dataSourceAt(sourceIndices.at(i));
 
-					if (source->name() != i0Source->name() && source->rank() == i0Source->rank()){
+				if (source->name() != i0Source->name() && source->rank() == i0Source->rank()){
 
-						AMNormalizationAB *normalizedSource = new AMNormalizationAB(QString("norm_%1").arg(source->name()));
-						normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << i0Source);
-						normalizedSource->setDataName(source->name());
-						normalizedSource->setNormalizationName(i0Source->name());
-						scan_->addAnalyzedDataSource(normalizedSource, true, false);
-					}
+					qDebug() << "\tAdding normalized source" << source->name();
+
+					AMNormalizationAB *normalizedSource = new AMNormalizationAB(QString("norm_%1").arg(source->name()));
+					normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << i0Source);
+					normalizedSource->setDataName(source->name());
+					normalizedSource->setNormalizationName(i0Source->name());
+					scan_->addAnalyzedDataSource(normalizedSource, true, false);
 				}
 			}
 		}

--- a/source/acquaman/BioXAS/BioXASGenericStepScanConfiguration.h
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanConfiguration.h
@@ -28,7 +28,7 @@ public:
 
 protected:
 	/// Returns a string containing scan header information.
-	virtual QString headerText() const { return QString("Here is some header text."); }
+	virtual QString headerText() const { return QString(); }
 };
 
 #endif // BIOXASGENERICSTEPSCANCONFIGURATION_H

--- a/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
@@ -1,4 +1,8 @@
 #include "BioXASGenericStepScanController.h"
+#include "application/AMAppControllerSupport.h"
+#include "dataman/export/AMExporterXDIFormat.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
+#include "application/BioXAS/BioXAS.h"
 #include "beamline/BioXAS/BioXASBeamline.h"
 
 BioXASGenericStepScanController::BioXASGenericStepScanController(BioXASGenericStepScanConfiguration *configuration, QObject *parent) :
@@ -42,6 +46,22 @@ void BioXASGenericStepScanController::buildScanControllerImplementation()
 {
 	AMGenericStepScanController::buildScanControllerImplementation();
 
+	// Identify exporter option.
+
+	AMExporterOptionXDIFormat *genericExporterOption = 0;
+
+	if (configuration_) {
+
+		genericExporterOption = BioXAS::buildStandardXDIFormatExporterOption("BioXAS Generic Step Scan (XDI Format)", "", "", true);
+
+		if (genericExporterOption->id() > 0)
+			AMAppControllerSupport::registerClass<BioXASGenericStepScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(genericExporterOption->id());
+
+		// Clear the option of any previous data sources.
+
+		genericExporterOption->clearDataSources();
+	}
+
 	// Identify and setup the zebra trigger source.
 
 	AMZebraDetectorTriggerSource *zebraTriggerSource = BioXASBeamline::bioXAS()->zebraTriggerSource();
@@ -73,4 +93,26 @@ void BioXASGenericStepScanController::buildScanControllerImplementation()
 			}
 		}
 	}
+
+	// Identify data sources for the scaler channels and add them to the exporter option.
+
+	AMDataSource *i0DetectorSource = BioXASBeamlineSupport::i0DetectorSource(scan_);
+
+	if (i0DetectorSource)
+		genericExporterOption->addDataSource(i0DetectorSource->name(), false);
+
+	AMDataSource *i1DetectorSource = BioXASBeamlineSupport::i1DetectorSource(scan_);
+
+	if (i1DetectorSource)
+		genericExporterOption->addDataSource(i1DetectorSource->name(), true);
+
+	AMDataSource *i2DetectorSource = BioXASBeamlineSupport::i2DetectorSource(scan_);
+
+	if (i2DetectorSource)
+		genericExporterOption->addDataSource(i2DetectorSource->name(), true);
+
+	// Save changes to the exporter option.
+
+	if (genericExporterOption)
+		genericExporterOption->storeToDb(AMDatabase::database("user"));
 }

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -98,7 +98,7 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 
 	if (bioXASConfiguration_) {
 
-		exportXDI = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", bioXASConfiguration_->edge().split(" ").first(), bioXASConfiguration_->edge().split(" ").last(), bioXASConfiguration_->canExportSpectra() && bioXASConfiguration_->exportSpectraPreference());
+		exportXDI = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", bioXASConfiguration_->edge().split(" ").first(), bioXASConfiguration_->edge().split(" ").last(), true);
 
 		if (exportXDI->id() > 0)
 			AMAppControllerSupport::registerClass<BioXASXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(exportXDI->id());

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -236,6 +236,7 @@ void BioXASAppController::updateGenericScanConfigurationDetectors()
 		AMDetector *i0Detector = BioXASBeamline::bioXAS()->i0Detector();
 
 		if (defaultDetectors && i0Detector) {
+
 			bool i0Found = false;
 
 			for (int i = 0, count = defaultDetectors->count(); i < count && !i0Found; i++) {

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -214,15 +214,12 @@ void BioXASAppController::updateScanConfigurationDetectors(AMGenericStepScanConf
 
 void BioXASAppController::updateXASScanConfigurationDetectors()
 {
-	qDebug() << "Updating XAS scan detectors.";
 	updateScanConfigurationDetectors(xasConfiguration_, BioXASBeamline::bioXAS()->defaultXASScanDetectors());
 	updateScanConfigurationDetectors(energyCalibrationConfiguration_, BioXASBeamline::bioXAS()->defaultXASScanDetectors());
 }
 
 void BioXASAppController::updateGenericScanConfigurationDetectors()
 {
-	qDebug() << "Updating generic scan detectors.";
-
 	AMDetectorSet *defaultDetectors = BioXASBeamline::bioXAS()->defaultGenericScanDetectors();
 
 	// Update the detectors added to the configuration by default.
@@ -270,10 +267,16 @@ void BioXASAppController::registerClasses()
 
 void BioXASAppController::setupExporterOptions()
 {
-	AMExporterOptionXDIFormat *bioXASDefaultXAS = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", "", "", true);
+	AMExporterOptionXDIFormat *xasExporterOption = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", "", "", true);
 
-	if (bioXASDefaultXAS->id() > 0)
-		AMAppControllerSupport::registerClass<BioXASXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(bioXASDefaultXAS->id());
+	if (xasExporterOption->id() > 0)
+		AMAppControllerSupport::registerClass<BioXASXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(xasExporterOption->id());
+
+	AMExporterOptionXDIFormat *genericExporterOption = BioXAS::buildStandardXDIFormatExporterOption("BioXAS Generic Step Scan (XDI Format)", "", "", true);
+
+	if (genericExporterOption->id() > 0)
+		AMAppControllerSupport::registerClass<BioXASGenericStepScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(genericExporterOption->id());
+
 }
 
 void BioXASAppController::setupUserConfiguration()

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -214,17 +214,18 @@ void BioXASAppController::updateScanConfigurationDetectors(AMGenericStepScanConf
 
 void BioXASAppController::updateXASScanConfigurationDetectors()
 {
+	qDebug() << "Updating XAS scan detectors.";
 	updateScanConfigurationDetectors(xasConfiguration_, BioXASBeamline::bioXAS()->defaultXASScanDetectors());
 	updateScanConfigurationDetectors(energyCalibrationConfiguration_, BioXASBeamline::bioXAS()->defaultXASScanDetectors());
 }
 
 void BioXASAppController::updateGenericScanConfigurationDetectors()
 {
+	qDebug() << "Updating generic scan detectors.";
+
 	AMDetectorSet *defaultDetectors = BioXASBeamline::bioXAS()->defaultGenericScanDetectors();
 
 	// Update the detectors added to the configuration by default.
-
-	genericConfiguration_->detectorConfigurations().clear();
 
 	updateScanConfigurationDetectors(genericConfiguration_, defaultDetectors);
 
@@ -238,7 +239,6 @@ void BioXASAppController::updateGenericScanConfigurationDetectors()
 		AMDetector *i0Detector = BioXASBeamline::bioXAS()->i0Detector();
 
 		if (defaultDetectors && i0Detector) {
-
 			bool i0Found = false;
 
 			for (int i = 0, count = defaultDetectors->count(); i < count && !i0Found; i++) {
@@ -813,11 +813,11 @@ void BioXASAppController::setupGenericStepScanConfiguration(AMGenericStepScanCon
 
 		// Set scan detectors.
 
-//		connect( BioXASBeamline::bioXAS()->defaultGenericScanDetectors(), SIGNAL(connected(bool)), this, SLOT(updateGenericScanConfigurationDetectors()) );
-//		connect( BioXASBeamline::bioXAS()->defaultGenericScanDetectors(), SIGNAL(detectorAdded(int)), this, SLOT(updateGenericScanConfigurationDetectors()) );
-//		connect( BioXASBeamline::bioXAS()->defaultGenericScanDetectors(), SIGNAL(detectorRemoved(int)), this, SLOT(updateGenericScanConfigurationDetectors()) );
+		connect( BioXASBeamline::bioXAS()->defaultGenericScanDetectors(), SIGNAL(connected(bool)), this, SLOT(updateGenericScanConfigurationDetectors()) );
+		connect( BioXASBeamline::bioXAS()->defaultGenericScanDetectors(), SIGNAL(detectorAdded(int)), this, SLOT(updateGenericScanConfigurationDetectors()) );
+		connect( BioXASBeamline::bioXAS()->defaultGenericScanDetectors(), SIGNAL(detectorRemoved(int)), this, SLOT(updateGenericScanConfigurationDetectors()) );
 
-//		updateGenericScanConfigurationDetectors();
+		updateGenericScanConfigurationDetectors();
 	}
 }
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -1038,6 +1038,7 @@ bool BioXASBeamline::clearDefaultXASScanDetectorOptions()
 
 bool BioXASBeamline::addDefaultGenericScanDetector(AMDetector *detector)
 {
+	qDebug() << "Adding detector" << detector->name() << "to default generic scan detectors.";
 	return defaultGenericScanDetectors_->addDetector(detector);
 }
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -826,8 +826,6 @@ bool BioXASBeamline::setScalerDwellTimeDetector(AMDetector *detector)
 			removeExposedDetector(scalerDwellTimeDetector_);
 			removeDefaultXASScanDetector(scalerDwellTimeDetector_);
 			removeDefaultXASScanDetectorOption(scalerDwellTimeDetector_);
-			removeDefaultGenericScanDetector(scalerDwellTimeDetector_);
-			removeDefaultGenericScanDetectorOption(scalerDwellTimeDetector_);
 		}
 
 		scalerDwellTimeDetector_ = detector;
@@ -838,8 +836,6 @@ bool BioXASBeamline::setScalerDwellTimeDetector(AMDetector *detector)
 			addExposedDetector(scalerDwellTimeDetector_);
 			addDefaultXASScanDetector(scalerDwellTimeDetector_);
 			addDefaultXASScanDetectorOption(scalerDwellTimeDetector_);
-			addDefaultGenericScanDetector(scalerDwellTimeDetector_);
-			addDefaultGenericScanDetectorOption(scalerDwellTimeDetector_);
 		}
 
 		result = true;
@@ -1038,7 +1034,6 @@ bool BioXASBeamline::clearDefaultXASScanDetectorOptions()
 
 bool BioXASBeamline::addDefaultGenericScanDetector(AMDetector *detector)
 {
-	qDebug() << "Adding detector" << detector->name() << "to default generic scan detectors.";
 	return defaultGenericScanDetectors_->addDetector(detector);
 }
 

--- a/source/dataman/info/AMDetectorInfo.h
+++ b/source/dataman/info/AMDetectorInfo.h
@@ -55,6 +55,8 @@ public:
  	virtual ~AMDetectorInfo();
 	Q_INVOKABLE AMDetectorInfo(const QString &name = "Invalid Detector", const QString &description = "", const QString &units = "N/A", double acquisitionTime = -1, AMDetectorDefinitions::ReadMode readMode = AMDetectorDefinitions::InvalidReadMode, QObject *parent = 0);
 
+	/// Returns true if the detector is valid, false otherwise.
+	bool isValid() const { return (name() != "Invalid Detector"); }
 	/// Returns the user readable name
 	QString description() const { return description_; }
 	/// Returns the units

--- a/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
@@ -161,8 +161,8 @@ void AMGenericStepScanConfigurationDetectorsView::refresh()
 
 				// Create new checkbox for the detector.
 
-				QString detectorText = (detector->description().isEmpty() ? detector->name() : detector->description());
-
+				//QString detectorText = (detector->description().isEmpty() ? detector->name() : detector->description());
+				QString detectorText = detector->name();
 				QCheckBox *checkBox = new QCheckBox(detectorText);
 				buttonGroup_->addButton(checkBox, detectorIndex);
 				layout_->addWidget(checkBox);

--- a/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
@@ -161,8 +161,7 @@ void AMGenericStepScanConfigurationDetectorsView::refresh()
 
 				// Create new checkbox for the detector.
 
-				//QString detectorText = (detector->description().isEmpty() ? detector->name() : detector->description());
-				QString detectorText = detector->name();
+				QString detectorText = (detector->description().isEmpty() ? detector->name() : detector->description());
 				QCheckBox *checkBox = new QCheckBox(detectorText);
 				buttonGroup_->addButton(checkBox, detectorIndex);
 				layout_->addWidget(checkBox);

--- a/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationDetectorsView.cpp
@@ -162,6 +162,7 @@ void AMGenericStepScanConfigurationDetectorsView::refresh()
 				// Create new checkbox for the detector.
 
 				QString detectorText = (detector->description().isEmpty() ? detector->name() : detector->description());
+
 				QCheckBox *checkBox = new QCheckBox(detectorText);
 				buttonGroup_->addButton(checkBox, detectorIndex);
 				layout_->addWidget(checkBox);

--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
@@ -493,13 +493,13 @@ void AMGenericStepScanConfigurationView::updateI0Box()
 		AMDetector *detector = detectors_->at(detectorIndex);
 
 		if (detector && configuration_ && configuration_->detectorConfigurations().contains(detector->name()) && detector->isConnected())
-			i0ComboBox_->addItem(detector->name());
+			i0ComboBox_->addItem((detector->description().isEmpty() ? detector->name() : detector->description()), detector->name());
 	}
 
 	// Set current selection.
 
 	if (configuration_ && configuration_->hasI0())
-		i0ComboBox_->setCurrentIndex(i0ComboBox_->findText(configuration_->i0().name()));
+		i0ComboBox_->setCurrentIndex(i0ComboBox_->findData(configuration_->i0().name()));
 
 	i0ComboBox_->blockSignals(false);
 }
@@ -511,8 +511,12 @@ void AMGenericStepScanConfigurationView::updateDetectorsView()
 
 void AMGenericStepScanConfigurationView::onI0ChoiceChanged(int index)
 {
-	if (index <= 0)
-		configuration_->setI0(AMDetectorInfo());
-	else
-		configuration_->setI0(configuration_->detectorConfigurations().at(configuration_->detectorConfigurations().indexOf(i0ComboBox_->itemText(index))));
+	if (configuration_) {
+		int configurationIndex = configuration_->detectorConfigurations().indexOf(i0ComboBox_->itemData(index).toString());
+
+		if (configurationIndex >= 0 && configurationIndex < configuration_->detectorConfigurations().count())
+			configuration_->setI0(configuration_->detectorConfigurations().at(configurationIndex));
+		else
+			configuration_->setI0(AMDetectorInfo());
+	}
 }

--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.cpp
@@ -103,31 +103,36 @@ AMGenericStepScanConfigurationView::AMGenericStepScanConfigurationView(AMGeneric
 		onAxisControlChoice2Changed();
 	}
 
-	QScrollArea *detectorScrollArea = new QScrollArea;
-	QGroupBox *detectorGroupBox = new QGroupBox("Detectors");
-	detectorGroupBox->setFlat(true);
-	detectorGroup_ = new QButtonGroup;
-	detectorGroup_->setExclusive(false);
-	detectorLayout_ = new QVBoxLayout;
+	// Create I0 box and detectors view.
 
 	i0ComboBox_ = new QComboBox;
+	connect( configuration_, SIGNAL(i0DetectorChanged()), this, SLOT(updateI0Box()) );
+	connect(i0ComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onI0ChoiceChanged(int)));
 
 	QHBoxLayout *i0Layout = new QHBoxLayout;
 	i0Layout->addWidget(new QLabel("I0:"));
 	i0Layout->addWidget(i0ComboBox_);
 
+	detectorsView_ = new AMGenericStepScanConfigurationDetectorsView(configuration_, 0);
+
 	setDetectors(detectors);
 
-	connect(detectorGroup_, SIGNAL(buttonClicked(QAbstractButton*)), this, SLOT(onDetectorSelectionChanged(QAbstractButton*)));
-	connect(i0ComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onI0ChoiceChanged(int)));
+	QVBoxLayout *detectorsBoxLayout = new QVBoxLayout();
+	detectorsBoxLayout->addWidget(detectorsView_);
 
-	detectorGroupBox->setLayout(detectorLayout_);
-	detectorScrollArea->setWidget(detectorGroupBox);
+	QGroupBox *detectorsBox = new QGroupBox("Detectors");
+	detectorsBox->setFlat(true);
+	detectorsBox->setLayout(detectorsBoxLayout);
+
+	QScrollArea *detectorScrollArea = new QScrollArea;
+	detectorScrollArea->setWidget(detectorsBox);
 	detectorScrollArea->setFrameStyle(QFrame::NoFrame);
 
 	QVBoxLayout *detectorsAndI0Layout = new QVBoxLayout;
 	detectorsAndI0Layout->addLayout(i0Layout);
 	detectorsAndI0Layout->addWidget(detectorScrollArea);
+
+	// Create and set main layouts.
 
 	QVBoxLayout *layout = new QVBoxLayout;
 	layout->addWidget(positionsBox);
@@ -146,7 +151,6 @@ AMGenericStepScanConfigurationView::AMGenericStepScanConfigurationView(AMGeneric
 	configViewLayout->addStretch();
 
 	setLayout(configViewLayout);
-
 }
 
 void AMGenericStepScanConfigurationView::setControls(AMControlSet *newControls)
@@ -198,50 +202,20 @@ void AMGenericStepScanConfigurationView::setDetectors(AMDetectorSet *newDetector
 {
 	if (detectors_ != newDetectors) {
 
-		// Clear previously displayed detectors.
-
-		for (int buttonIndex = 0, buttonCount = detectorGroup_->buttons().count(); buttonIndex < buttonCount; buttonIndex++) {
-			QAbstractButton *button = detectorGroup_->button(buttonIndex);
-			detectorLayout_->removeWidget(button);
-			detectorGroup_->removeButton(button);
-			button->deleteLater();
-		}
-
-		detectorButtonMap_.clear();
-		i0ComboBox_->clear();
-
-		// Set new detectors.
+		if (detectors_)
+			disconnect( detectors_, 0, this, 0 );
 
 		detectors_ = newDetectors;
 
-		// Add new detectors.
-
-		i0ComboBox_->addItem("None");
-
-		for (int detectorIndex = 0, detectorCount = detectors_->count(); detectorIndex < detectorCount; detectorIndex++) {
-			AMDetector *detector = detectors_->at(detectorIndex);
-
-			if (detector) {
-				QCheckBox *checkBox = new QCheckBox(detector->name());
-				detectorGroup_->addButton(checkBox);
-				detectorLayout_->addWidget(checkBox);
-
-				detectorButtonMap_.insert(detector, checkBox);
-
-				// Update current selection.
-
-				if (configuration_ && configuration_->detectorConfigurations().contains(detector->name())) {
-					checkBox->blockSignals(true);
-					checkBox->setChecked(true);
-					i0ComboBox_->addItem(detector->name());
-					checkBox->blockSignals(false);
-				}
-
-			}
+		if (detectors_) {
+			connect( detectors_, SIGNAL(detectorConnectedChanged(bool,AMDetector*)), this, SLOT(updateI0Box()) );
+			connect( detectors_, SIGNAL(connected(bool)), this, SLOT(updateI0Box()) );
+			connect( detectors_, SIGNAL(detectorAdded(int)), this, SLOT(updateI0Box()) );
+			connect( detectors_, SIGNAL(detectorRemoved(int)), this, SLOT(updateI0Box()) );
 		}
 
-		if (configuration_ && configuration_->i0().name() != "Invalid Detector")
-			i0ComboBox_->setCurrentIndex(i0ComboBox_->findText(configuration_->i0().name()));
+		updateI0Box();
+		updateDetectorsView();
 	}
 }
 
@@ -503,36 +477,42 @@ void AMGenericStepScanConfigurationView::onScanAxisAdded(AMScanAxis *axis)
 	}
 }
 
-void AMGenericStepScanConfigurationView::onDetectorSelectionChanged(QAbstractButton *button)
+void AMGenericStepScanConfigurationView::updateI0Box()
 {
-	if (button) {
-		AMDetector *detector = detectorButtonMap_.key(button, 0);
+	i0ComboBox_->blockSignals(true);
 
-		if (detector) {
-			if (button->isChecked()){
+	// Clear the i0 box.
 
-				configuration_->addDetector(detector->toInfo());
-				i0ComboBox_->addItem(detector->name());
-			}
+	i0ComboBox_->clear();
 
-			else {
+	// Populate with detector options.
 
-				configuration_->removeDetector(detector->toInfo());
+	i0ComboBox_->addItem("None");
 
-				if (i0ComboBox_->currentText() == detector->name())
-					i0ComboBox_->setCurrentIndex(i0ComboBox_->findText("None"));
+	for (int detectorIndex = 0, detectorCount = detectors_->count(); detectorIndex < detectorCount; detectorIndex++) {
+		AMDetector *detector = detectors_->at(detectorIndex);
 
-				i0ComboBox_->removeItem(i0ComboBox_->findText(detector->name()));
-			}
-		}
+		if (detector && configuration_ && configuration_->detectorConfigurations().contains(detector->name()) && detector->isConnected())
+			i0ComboBox_->addItem(detector->name());
 	}
+
+	// Set current selection.
+
+	if (configuration_ && configuration_->hasI0())
+		i0ComboBox_->setCurrentIndex(i0ComboBox_->findText(configuration_->i0().name()));
+
+	i0ComboBox_->blockSignals(false);
+}
+
+void AMGenericStepScanConfigurationView::updateDetectorsView()
+{
+	detectorsView_->setDetectors(detectors_);
 }
 
 void AMGenericStepScanConfigurationView::onI0ChoiceChanged(int index)
 {
-	if (i0ComboBox_->currentText() == "None")
+	if (index <= 0)
 		configuration_->setI0(AMDetectorInfo());
-
 	else
 		configuration_->setI0(configuration_->detectorConfigurations().at(configuration_->detectorConfigurations().indexOf(i0ComboBox_->itemText(index))));
 }

--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.h
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.h
@@ -2,9 +2,11 @@
 #define AMGENERICSTEPSCANCONFIGURATIONVIEW_H
 
 #include "ui/acquaman/AMScanConfigurationView.h"
+#include "ui/acquaman/AMGenericStepScanConfigurationDetectorsView.h"
 #include "acquaman/AMGenericStepScanConfiguration.h"
 #include "beamline/AMControlSet.h"
 #include "beamline/AMDetectorSet.h"
+
 
 #include <QLabel>
 #include <QLineEdit>
@@ -78,13 +80,16 @@ protected slots:
 	void onAxisControlChoice1Changed();
 	/// Handles setting the configurations axis 2 control info.
 	void onAxisControlChoice2Changed();
-	/// Handles updating the configurations detector infos.
-	void onDetectorSelectionChanged(QAbstractButton *button);
 	/// Handles updating the I0 for the configuration.
 	void onI0ChoiceChanged(int index);
 
 	/// Handles doing some connections when an scan axis has been added or removed.
 	void onScanAxisAdded(AMScanAxis *axis);
+
+	/// Handles updating the i0 combo box to reflect the current detector options and configuration i0 selection.
+	void updateI0Box();
+	/// Handles updating the detectors view to reflect the current detector options and configuration detectors.
+	void updateDetectorsView();
 
 protected:
 	/// Method that updates the map info label based on the current values of the start, end, and step size.
@@ -127,14 +132,10 @@ protected:
 
 	/// The detectors being displayed.
 	AMDetectorSet *detectors_;
-	/// The detectors button group.
-	QButtonGroup *detectorGroup_;
-	/// The detectors widget layout.
-	QVBoxLayout *detectorLayout_;
-	/// The mapping between detector and detector button.
-	QMap<AMDetector*, QAbstractButton*> detectorButtonMap_;
 	/// The combo box holding the detector that should be I0.
 	QComboBox *i0ComboBox_;
+	/// The detectors view.
+	AMGenericStepScanConfigurationDetectorsView *detectorsView_;
 };
 
 #endif // AMGENERICSTEPSCANCONFIGURATIONVIEW_H

--- a/source/ui/acquaman/AMGenericStepScanConfigurationView.h
+++ b/source/ui/acquaman/AMGenericStepScanConfigurationView.h
@@ -7,7 +7,6 @@
 #include "beamline/AMControlSet.h"
 #include "beamline/AMDetectorSet.h"
 
-
 #include <QLabel>
 #include <QLineEdit>
 #include <QComboBox>


### PR DESCRIPTION
Basic changes:
- Modified the generic step scan configuration to use the existing generic step scan configuration detectors view. This view handles disabling detector options if they are not connected, checking them if they are already added, etc.
- Uncommented calls in BioXASAppController to use existing methods to update generic configurations.
- Modified the detectors view to show the detector descriptions instead of names, if they are available.

During testing, I ran into a couple of unrelated problems that I fixed in this pull request:
- The changes in #2194 meant that only sources that are explicitly added to the exporter option are actually exported. Sources were specified for XAS scans but not for BioXAS generic scans--no data sources were being exported. Modified the BioXAS generic scans to export raw I0, I1, I2 values if they are available.
- Previously, the generic scan controller only added the I0-normalized data to a scan if there was an XRF detector added to the scan. Moved this code out of the XRF detector if-check so that normalized values are provided whenever I0 is provided.