### PR TITLE
Pull Request for Issue2285: adding dead time buttons for disabled detector elements.

### DIFF
--- a/source/beamline/AMXRFDetector.cpp
+++ b/source/beamline/AMXRFDetector.cpp
@@ -417,9 +417,14 @@ bool AMXRFDetector::isElementEnabled(int index) const
 	return enabledElements_.contains(index);
 }
 
+bool AMXRFDetector::isElementDisabled(int index) const
+{
+	return !isElementEnabled(index);
+}
+
 void AMXRFDetector::enableElement(int elementId)
 {
-	if (!enabledElements_.contains(elementId)){
+	if (canEnableElement(elementId) && !enabledElements_.contains(elementId)){
 
 		enabledElements_.append(elementId);
 		updatePrimarySpectrumSources();
@@ -429,7 +434,7 @@ void AMXRFDetector::enableElement(int elementId)
 
 void AMXRFDetector::disableElement(int elementId)
 {
-	if (enabledElements_.contains(elementId)){
+	if (canDisableElement(elementId) && enabledElements_.contains(elementId)){
 
 		enabledElements_.removeAll(elementId);
 		updatePrimarySpectrumSources();

--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -85,6 +85,12 @@ public:
 	virtual double deadTimeAt(int index) const;
 	/// Returns whether the element is enabled or not.  Elements are zero indexed.
 	bool isElementEnabled(int index) const;
+	/// Returns true if the element at the given index is disabled. Elements are zero indexed.
+	bool isElementDisabled(int index) const;
+	/// Returns whether the element can be enabled. Elements are zero indexed.
+	virtual bool canEnableElement(int index) const { Q_UNUSED(index) return true; }
+	/// Returns whether the element can be disabled. Elements are zero indexed.
+	virtual bool canDisableElement(int index) const { Q_UNUSED(index) return true; }
 
 	// Returns the list of spectra controls.
 	QList<AMReadOnlyPVControl*> spectraControls() const { return spectraControls_; }

--- a/source/beamline/BioXAS/BioXAS32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXAS32ElementGeDetector.cpp
@@ -16,6 +16,12 @@ BioXAS32ElementGeDetector::~BioXAS32ElementGeDetector()
 
 }
 
+bool BioXAS32ElementGeDetector::canDisableElement(int index) const
+{
+	// All valid elements can technically be disabled.
+	return (AMXspress3XRFDetector::canDisableElement(index) && index >= 0 && index < 32);
+}
+
 bool BioXAS32ElementGeDetector::setAcquisitionTime(double seconds)
 {
 	if(!isConnected())

--- a/source/beamline/BioXAS/BioXAS32ElementGeDetector.h
+++ b/source/beamline/BioXAS/BioXAS32ElementGeDetector.h
@@ -19,6 +19,9 @@ public:
 	/// Returns the type of the detector
 	virtual int type() { return BioXAS::Ge13ElementDetector; }
 
+	/// Returns true if the element at the given index can be disabled, false otherwise.
+	virtual bool canDisableElement(int index) const;
+
 public slots:
 	/// Set the acquisition dwell time for triggered (RequestRead) detectors
 	virtual bool setAcquisitionTime(double seconds);

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -414,26 +414,36 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 
 		addSynchronizedXRFDetector(newDetector);
 
-		// Add each detector spectrum control.
+		// Add each enabled detector spectrum control.
 
-		foreach (AMControl *spectra, newDetector->spectraControls()) {
-			AM1DControlDetectorEmulator *element = new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 4096, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
-			element->setAccessAsDouble(true);
-			element->setAxisInfo(newDetector->axes().first());
-			addDetectorElement(newDetector, element);
+		for (int i = 0, count = newDetector->spectraControls().count(); i < count; i++) {
+
+			if (newDetector->isElementEnabled(i)) {
+				AMControl *spectra = newDetector->spectraControls().at(i);
+
+				if (spectra) {
+					AM1DControlDetectorEmulator *element = new AM1DControlDetectorEmulator(spectra->name(), spectra->description(), 4096, spectra, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+					element->setAccessAsDouble(true);
+					element->setAxisInfo(newDetector->axes().first());
+					addDetectorElement(newDetector, element);
+				}
+			}
 		}
 
-		// Add each detector ICR control.
+		// Add each enabled detector ICR control.
 
 		for (int i = 0, count = newDetector->icrControls().count(); i < count; i++) {
-			AMControl *icrControl = newDetector->icrControlAt(i);
 
-			if (icrControl) {
-				AMBasicControlDetectorEmulator *icrDetector = new AMBasicControlDetectorEmulator(QString("ICR %1").arg(i+1), QString("ICR %1").arg(i+1), icrControl, 0, 0, 0, AMDetectorDefinitions::ImmediateRead);
-				icrDetector->setHiddenFromUsers(false);
-				icrDetector->setIsVisible(true);
+			if (newDetector->isElementEnabled(i)) {
+				AMControl *icrControl = newDetector->icrControlAt(i);
 
-				addDetectorICR(newDetector, icrDetector);
+				if (icrControl) {
+					AMBasicControlDetectorEmulator *icrDetector = new AMBasicControlDetectorEmulator(QString("ICR %1").arg(i+1), QString("ICR %1").arg(i+1), icrControl, 0, 0, 0, AMDetectorDefinitions::ImmediateRead);
+					icrDetector->setHiddenFromUsers(false);
+					icrDetector->setIsVisible(true);
+
+					addDetectorICR(newDetector, icrDetector);
+				}
 			}
 		}
 

--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
@@ -26,7 +26,7 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 	// Elements are enabled by default. Disable elements that can't be enabled here.
 
 	for (int i = 0; i < 32; i++)
-		if (canDisableElement(i))
+		if (!canEnableElement(i))
 			disableElement(i);
 }
 

--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
@@ -8,12 +8,10 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 	acquisitionStatusControl_ = new AMReadOnlyPVControl("Status", "PDTR1607-7-I21-01:DetectorState_RBV", this);
 
 	for (int i = 0; i < 32; i++) {
-		if (i != 2 && i != 4 && i != 10 && i != 15 && i != 21 && i != 26) { // Elements 3, 5, 11, 16, 22, and 27 (start 1) are disabled for this detector.
-			channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
-			spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("PDTR1607-7-I21-01:ARR%1:ArrayData").arg(i+1), this));
-			thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));
-			icrControls_.append(new AMReadOnlyPVControl(QString("ICR %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4:Value_RBV").arg(i+1), this));
-		}
+		channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
+		spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("PDTR1607-7-I21-01:ARR%1:ArrayData").arg(i+1), this));
+		thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));
+		icrControls_.append(new AMReadOnlyPVControl(QString("ICR %1").arg(i+1), QString("PDTR1607-7-I21-01:C%1_SCA4:Value_RBV").arg(i+1), this));
 	}
 
 	initializationControl_ = new AMSinglePVControl("Initialization", "PDTR1607-7-I21-01:Acquire", this, 0.1);
@@ -29,4 +27,10 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 BioXASMainInboard32ElementGeDetector::~BioXASMainInboard32ElementGeDetector()
 {
 
+}
+
+bool BioXASMainInboard32ElementGeDetector::canEnableElement(int index) const
+{
+	// Elements 3, 5, 11, 16, 22, and 27 (start 1) are disabled for this detector.
+	return (index != 2 && index != 4 && index != 10 && index != 15 && index != 21 && index != 26);
 }

--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
@@ -26,7 +26,7 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 	// Elements are enabled by default. Disable elements that can't be enabled here.
 
 	for (int i = 0; i < 32; i++)
-		if (!canEnableElement(i))
+		if (canDisableElement(i))
 			disableElement(i);
 }
 

--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.cpp
@@ -22,6 +22,12 @@ BioXASMainInboard32ElementGeDetector::BioXASMainInboard32ElementGeDetector(const
 	framesPerAcquisitionControl_ = new AMPVControl("FramesPerAcquisition", "PDTR1607-7-I21-01:NumImages_RBV", "PDTR1607-7-I21-01:NumImages", QString(), this, 0.5);
 
 	makeConnections();
+
+	// Elements are enabled by default. Disable elements that can't be enabled here.
+
+	for (int i = 0; i < 32; i++)
+		if (!canEnableElement(i))
+			disableElement(i);
 }
 
 BioXASMainInboard32ElementGeDetector::~BioXASMainInboard32ElementGeDetector()

--- a/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.h
+++ b/source/beamline/BioXAS/BioXASMainInboard32ElementGeDetector.h
@@ -13,6 +13,8 @@ public:
 	/// Destructor.
 	virtual ~BioXASMainInboard32ElementGeDetector();
 
+	/// Returns whether the element can be enabled. Elements are zero indexed.
+	virtual bool canEnableElement(int index) const;
 };
 
 #endif // BIOXASMAININBOARD32ELEMENTGEDETECTOR_H

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -26,7 +26,7 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 	// Elements are enabled by default. Disable elements that can't be enabled here.
 
 	for (int i = 0; i < 32; i++)
-		if (canDisableElement(i))
+		if (!canEnableElement(i))
 			disableElement(i);
 }
 

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -22,6 +22,12 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 	framesPerAcquisitionControl_ = new AMPVControl("FramesPerAcquisition", "DXP1607-I22-01:NumImages_RBV", "DXP1607-I22-01:NumImages", QString(), this, 0.5);
 
 	makeConnections();
+
+	// Elements are enabled by default. Disable elements that can't be enabled here.
+
+	for (int i = 0; i < 32; i++)
+		if (!canEnableElement(i))
+			disableElement(i);
 }
 
 BioXASSide32ElementGeDetector::~BioXASSide32ElementGeDetector()

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -26,7 +26,7 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 	// Elements are enabled by default. Disable elements that can't be enabled here.
 
 	for (int i = 0; i < 32; i++)
-		if (!canDisableElement(i))
+		if (canDisableElement(i))
 			disableElement(i);
 }
 

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -26,7 +26,7 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 	// Elements are enabled by default. Disable elements that can't be enabled here.
 
 	for (int i = 0; i < 32; i++)
-		if (!canEnableElement(i))
+		if (!canDisableElement(i))
 			disableElement(i);
 }
 

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.cpp
@@ -7,7 +7,7 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 
 	acquisitionStatusControl_ = new AMReadOnlyPVControl("Status", "DXP1607-I22-01:DetectorState_RBV", this);
 
-	for (int i = 0; i < 20; i++) { // Elements 21-32 (start 1) are disabled for this detector.
+	for (int i = 0; i < 32; i++) {
 		channelEnableControls_.append(new AMSinglePVControl(QString("Channel Enable %1").arg(i+1), QString("DXP1607-I22-01:C%1_PluginControlVal").arg(i+1), this, 0.1));
 		spectraControls_.append(new AMReadOnlyPVControl(QString("Raw Spectrum %1").arg(i+1), QString("DXP1607-I22-01:ARR%1:ArrayData").arg(i+1), this, QString("spectra%1").arg(i+1)));
 		thresholdControls_.append(new AMPVControl(QString("Threshold %1").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4_THRESHOLD_RBV").arg(i+1), QString("DXP1607-I22-01:C%1_SCA4_THRESHOLD").arg(i+1), QString(), this, 0.5));
@@ -27,4 +27,10 @@ BioXASSide32ElementGeDetector::BioXASSide32ElementGeDetector(const QString &name
 BioXASSide32ElementGeDetector::~BioXASSide32ElementGeDetector()
 {
 
+}
+
+bool BioXASSide32ElementGeDetector::canEnableElement(int index) const
+{
+	// Elements 21 - 32 (start 1) are disabled for this detector.
+	return (BioXAS32ElementGeDetector::canEnableElement(index) && index >= 0 && index < 20);
 }

--- a/source/beamline/BioXAS/BioXASSide32ElementGeDetector.h
+++ b/source/beamline/BioXAS/BioXASSide32ElementGeDetector.h
@@ -12,6 +12,9 @@ public:
 	BioXASSide32ElementGeDetector(const QString &name, const QString &description, AMPVControl *triggerControl, BioXASZebraPulseControl *pulseControl, QObject *parent = 0);
 	/// Destructor.
 	virtual ~BioXASSide32ElementGeDetector();
+
+	/// Returns whether the element can be enabled. Elements are zero indexed.
+	virtual bool canEnableElement(int index) const;
 };
 
 #endif // BIOXASSIDE32ELEMENTGEDETECTOR_H

--- a/source/stylesheets/AMDeadTimeButton.qss
+++ b/source/stylesheets/AMDeadTimeButton.qss
@@ -28,13 +28,3 @@ background-color: #a0a0a4;
 AMDeadTimeButton[colorState = "3"]:!enabled {
 background-color: #000000;
 }
-
-/* Styling for colorState = Disregard. */
-
-AMDeadTimeButton[colorState="4"]:checked {
-background-color: #000000;
-}
-
-AMDeadTimeButton[colorState = "4"]:!enabled {
-background-color: #000000;
-}

--- a/source/stylesheets/AMDeadTimeButton.qss
+++ b/source/stylesheets/AMDeadTimeButton.qss
@@ -5,10 +5,18 @@ AMDeadTimeButton[colorState="1"]:checked {
 background-color: #a0a0a4;
 }
 
+AMDeadTimeButton[colorState = "1"]:!enabled {
+background-color: #000000;
+}
+
 /* Styling for colorState = Bad. */
 
 AMDeadTimeButton[colorState="2"]:checked {
 background-color: #a0a0a4;
+}
+
+AMDeadTimeButton[colorState = "2"]:!enabled {
+background-color: #000000;
 }
 
 /* Styling for colorState = Neutral. */
@@ -17,8 +25,16 @@ AMDeadTimeButton[colorState="3"]:checked {
 background-color: #a0a0a4;
 }
 
+AMDeadTimeButton[colorState = "3"]:!enabled {
+background-color: #000000;
+}
+
 /* Styling for colorState = Disregard. */
 
 AMDeadTimeButton[colorState="4"]:checked {
+background-color: #000000;
+}
+
+AMDeadTimeButton[colorState = "4"]:!enabled {
 background-color: #000000;
 }

--- a/source/stylesheets/AMToolButton.qss
+++ b/source/stylesheets/AMToolButton.qss
@@ -64,18 +64,4 @@ AMToolButton[colorState="3"]:checked {
 background-color: #808000;
 }
 
-/* Styling for colorState = Disregard. */
-
-AMToolButton[colorState="4"] {
-background-color: #000000;
-}
-
-AMToolButton[colorState="4"]:pressed {
-background-color: #000000;
-}
-
-AMToolButton[colorState="4"]:checked {
-background-color: #000000;
-}
-
 QToolTip { }

--- a/source/ui/AMToolButton.cpp
+++ b/source/ui/AMToolButton.cpp
@@ -1,4 +1,5 @@
 #include "AMToolButton.h"
+#include <QStyle>
 
 AMToolButton::AMToolButton(QWidget *parent) :
 	QToolButton(parent)
@@ -15,6 +16,10 @@ void AMToolButton::setColorState(AMToolButton::ColorState newState)
 {
 	if (colorState_ != newState) {
 		colorState_ = newState;
+
+		style()->unpolish(this);
+		style()->polish(this);
+
 		emit colorStateChanged(colorState_);
 	}
 }

--- a/source/ui/AMToolButton.cpp
+++ b/source/ui/AMToolButton.cpp
@@ -1,5 +1,4 @@
 #include "AMToolButton.h"
-#include <QStyle>
 
 AMToolButton::AMToolButton(QWidget *parent) :
 	QToolButton(parent)
@@ -16,10 +15,6 @@ void AMToolButton::setColorState(AMToolButton::ColorState newState)
 {
 	if (colorState_ != newState) {
 		colorState_ = newState;
-
-		style()->unpolish(this);
-		style()->polish(this);
-
 		emit colorStateChanged(colorState_);
 	}
 }

--- a/source/ui/AMToolButton.h
+++ b/source/ui/AMToolButton.h
@@ -12,7 +12,7 @@ class AMToolButton : public QToolButton
 
 public:
 	/// Enumeration of different button color states.
-	enum ColorState { None = 0, Good = 1, Bad = 2, Neutral = 3, Disregard = 4 };
+	enum ColorState { None = 0, Good = 1, Bad = 2, Neutral = 3 };
 
 	/// Constructor.
 	AMToolButton(QWidget *parent = 0);

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -48,24 +48,6 @@ AMDeadTimeButton::~AMDeadTimeButton()
 
 }
 
-void AMDeadTimeButton::setGoodReferencePoint(double newReference)
-{
-	goodReferencePoint_ = newReference;
-	updateColorState();
-}
-
-void AMDeadTimeButton::setBadReferencePoint(double newReference)
-{
-	badReferencePoint_ = newReference;
-	updateColorState();
-}
-
-void AMDeadTimeButton::setDisplayAsPercent(bool showPercent)
-{
-	displayPercent_ = showPercent;
-	updateToolTip();
-}
-
 void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMDataSource *outputCountSource)
 {
 	if (inputCountSource_) {
@@ -92,6 +74,24 @@ void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMData
 	}
 
 	updateColorState();
+	updateToolTip();
+}
+
+void AMDeadTimeButton::setGoodReferencePoint(double newReference)
+{
+	goodReferencePoint_ = newReference;
+	updateColorState();
+}
+
+void AMDeadTimeButton::setBadReferencePoint(double newReference)
+{
+	badReferencePoint_ = newReference;
+	updateColorState();
+}
+
+void AMDeadTimeButton::setDisplayAsPercent(bool showPercent)
+{
+	displayPercent_ = showPercent;
 	updateToolTip();
 }
 

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -120,7 +120,6 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 
 			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), detector_->outputCountSourceAt(i), 30.0, 50.0);
 			deadTimeButton->setCheckable(true);
-			deadTimeButton->setFixedSize(20, 20);
 			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
 			deadTimeButtons_->addButton(deadTimeButton, i);
 		}
@@ -132,7 +131,8 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 
 			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), 0, 300000, 1000000, false);
 			deadTimeButton->setCheckable(true);
-			deadTimeButton->setFixedSize(20, 20);
+			deadTimeButton->setChecked(detector_->isElementDisabled(i)); // Elements are disabled by checking the corresponding toolbutton.
+			deadTimeButton->setEnabled(detector_->canEnableElement(i)); // Elements that are not enabled initially will always be disabled (ie. permanently disabled elements).
 			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
 			deadTimeButtons_->addButton(deadTimeButton, i);
 		}
@@ -144,7 +144,6 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 
 			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton;
 			deadTimeButton->setCheckable(true);
-			deadTimeButton->setFixedSize(20, 20);
 			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
 			deadTimeButtons_->addButton(deadTimeButton, i);
 		}


### PR DESCRIPTION
Changes:
- Added styling for the 'disabled' state to AMDeadTimeButton.qss.
- Removed the 'Disregard' state from AMToolButton, AMToolButton.qss, AMDeadTimeButton.qss. Using the button's enabled/disabled state instead.
- Added virtual methods to AMXRFDetector: canEnabled/DisableElement(int). Reimplemented these methods in BioXAS-specific Ge detector subclasses to include info on which elements are permanently disabled for these detectors.
- Added checks to AMXRFDetailedDetectorView for the canEnableElement(int) state. If an element is disabled, the button is checked; if the element can't be enabled, the button is disabled.
- Added checks to BioXASBeamline for the canEnableElement(int) state. Detector emulators for the spectra and ICR controls are only created for elements that can be enabled.