### PR TITLE
PullRequest for Issue2253: when adding ROI, XRFDetector create a copy instead of the original instance

### DIFF
--- a/source/acquaman/AMGenericContinuousScanController.cpp
+++ b/source/acquaman/AMGenericContinuousScanController.cpp
@@ -111,7 +111,7 @@ void AMGenericContinuousScanController::buildScanControllerImplementation()
 				scan_->addAnalyzedDataSource(newRegion, true, false);
 			}
 			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 		}
 
 		if (configuration_->hasI0()){

--- a/source/acquaman/AMGenericContinuousScanController.cpp
+++ b/source/acquaman/AMGenericContinuousScanController.cpp
@@ -101,6 +101,9 @@ void AMGenericContinuousScanController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
+			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
+			detector->addRegionOfInterest(region);
+
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 
 			for(int x = 0, size = spectrumSources.count(); x < size; x++){
@@ -110,8 +113,6 @@ void AMGenericContinuousScanController::buildScanControllerImplementation()
 
 				scan_->addAnalyzedDataSource(newRegion, true, false);
 			}
-			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
-			detector->addRegionOfInterest(region->createCopy());
 		}
 
 		if (configuration_->hasI0()){

--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -118,6 +118,9 @@ void AMGenericStepScanController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
+			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
+			detector->addRegionOfInterest(region);
+
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
@@ -126,8 +129,6 @@ void AMGenericStepScanController::buildScanControllerImplementation()
 
 			scan_->addAnalyzedDataSource(newRegion, true, false);
 			newRegions << newRegion;
-			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
-			detector->addRegionOfInterest(region->createCopy());
 		}
 	}
 

--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -127,7 +127,7 @@ void AMGenericStepScanController::buildScanControllerImplementation()
 			scan_->addAnalyzedDataSource(newRegion, true, false);
 			newRegions << newRegion;
 			// This is sufficient to add a region of interest on all detectors as they should by synchronized via AMBeamline::synchronizeXRFDetectors.
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 		}
 	}
 

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -343,7 +343,7 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 
 			foreach (AMRegionOfInterest *region, bioXASConfiguration_->regionsOfInterest()){
 
-				ge32Detector->addRegionOfInterest(region->createCopy());
+				ge32Detector->addRegionOfInterest(region);
 
 				AMAnalysisBlock *newRegion = createRegionOfInterestAB(region->name().remove(' '), region, spectraSource);
 

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -343,7 +343,7 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 
 			foreach (AMRegionOfInterest *region, bioXASConfiguration_->regionsOfInterest()){
 
-				ge32Detector->addRegionOfInterest(region);
+				ge32Detector->addRegionOfInterest(region->createCopy());
 
 				AMAnalysisBlock *newRegion = createRegionOfInterestAB(region->name().remove(' '), region, spectraSource);
 

--- a/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
@@ -106,14 +106,7 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
     transmissionAB->setNormalizationName("Sample");
     scan_->addAnalyzedDataSource(transmissionAB);
 
-    AMXRFDetector *detector = 0;
-
-	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
-
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
-
+	AMXRFDetector *detector = IDEASBeamline::ideas()->xrfDetector(configuration_->fluorescenceDetector());
 	if (detector){
 
 		detector->removeAllRegionsOfInterest();
@@ -122,12 +115,13 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
+			detector->addRegionOfInterest(region->createCopy());
+
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, true, false);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
@@ -127,7 +127,7 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, true, false);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEAS2DScanActionController.cpp
@@ -115,7 +115,7 @@ void IDEAS2DScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			detector->addRegionOfInterest(region->createCopy());
+			detector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
@@ -163,7 +163,7 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			detector->addRegionOfInterest(region->createCopy());
+			detector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
@@ -175,7 +175,7 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << scan_->dataSourceAt(scan_->indexOfDataSource(detector->name())));
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DCalibrationAB* normalizedRegion = new AM1DCalibrationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setDescription(QString("Norm%1").arg(newRegion->name()));

--- a/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
+++ b/source/acquaman/IDEAS/IDEASXASScanActionController.cpp
@@ -145,14 +145,7 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 		scan_->addAnalyzedDataSource(normRef);
 	}
 
-	AMXRFDetector *detector = 0;
-
-	if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("KETEK"));
-
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("13-el Ge"));
-
+	AMXRFDetector *detector = IDEASBeamline::ideas()->xrfDetector(configuration_->fluorescenceDetector());
 	if (detector){
 
 		detector->removeAllRegionsOfInterest();
@@ -170,12 +163,13 @@ void IDEASXASScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
+			detector->addRegionOfInterest(region->createCopy());
+
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << scan_->dataSourceAt(scan_->indexOfDataSource(detector->name())));
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DCalibrationAB* normalizedRegion = new AM1DCalibrationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setDescription(QString("Norm%1").arg(newRegion->name()));

--- a/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
@@ -98,7 +98,7 @@ void SXRMB2DScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
@@ -92,13 +92,13 @@ void SXRMB2DScanActionController::buildScanControllerImplementation()
 		AMDataSource *spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(detector->name()));
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
+			detector->addRegionOfInterest(region->createCopy());
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMB2DScanActionController.cpp
@@ -92,7 +92,7 @@ void SXRMB2DScanActionController::buildScanControllerImplementation()
 		AMDataSource *spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(detector->name()));
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
-			detector->addRegionOfInterest(region->createCopy());
+			detector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/SXRMB/SXRMBEXAFSScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMBEXAFSScanActionController.cpp
@@ -228,7 +228,7 @@ void SXRMBEXAFSScanActionController::buildXRFAnalysisBlock(const QList<AMDataSou
 			QString edgeSymbol = configuration_->edge().split(" ").first();
 
 			foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
-				xrfDetector->addRegionOfInterest(region->createCopy());
+				xrfDetector->addRegionOfInterest(region);
 
 				AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 				AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/SXRMB/SXRMBEXAFSScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMBEXAFSScanActionController.cpp
@@ -206,13 +206,7 @@ void SXRMBEXAFSScanActionController::buildXRFAnalysisBlock(const QList<AMDataSou
 {
 	SXRMB::FluorescenceDetectors xrfDetectorConfig = configuration_->fluorescenceDetector();
 
-	AMXRFDetector *xrfDetector = 0;
-	if (xrfDetectorConfig.testFlag(SXRMB::BrukerDetector)){
-		xrfDetector = SXRMBBeamline::sxrmb()->brukerDetector();
-	} else if (xrfDetectorConfig.testFlag(SXRMB::FourElementDetector)) {
-		xrfDetector = SXRMBBeamline::sxrmb()->fourElementVortexDetector();
-	}
-
+	AMXRFDetector *xrfDetector = SXRMBBeamline::sxrmb()->xrfDetector(xrfDetectorConfig);
 	if (xrfDetector) {
 		xrfDetector->removeAllRegionsOfInterest();
 

--- a/source/acquaman/SXRMB/SXRMBEXAFSScanActionController.cpp
+++ b/source/acquaman/SXRMB/SXRMBEXAFSScanActionController.cpp
@@ -234,7 +234,7 @@ void SXRMBEXAFSScanActionController::buildXRFAnalysisBlock(const QList<AMDataSou
 			QString edgeSymbol = configuration_->edge().split(" ").first();
 
 			foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
-				xrfDetector->addRegionOfInterest(region);
+				xrfDetector->addRegionOfInterest(region->createCopy());
 
 				AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 				AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
@@ -226,21 +226,12 @@ VESPERS2DScanActionController::VESPERS2DScanActionController(VESPERS2DScanConfig
 
 void VESPERS2DScanActionController::buildScanControllerImplementation()
 {
-	VESPERS::FluorescenceDetectors xrfDetector = configuration_->fluorescenceDetector();
-	AMXRFDetector *detector = 0;
+	VESPERS::FluorescenceDetectors xrfDetectorConfig = configuration_->fluorescenceDetector();
 
-	if (xrfDetector.testFlag(VESPERS::SingleElement))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("SingleElementVortex"));
+	AMXRFDetector *xrfDetector = VESPERSBeamline::vespers()->xrfDetector(xrfDetectorConfig);
+	if (xrfDetector){
 
-	else if (xrfDetector.testFlag(VESPERS::FourElement))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("FourElementVortex"));
-
-	else if (xrfDetector.testFlag(VESPERS::Ge13Element))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("Ge13El"));
-
-	if (detector){
-
-		detector->removeAllRegionsOfInterest();
+		xrfDetector->removeAllRegionsOfInterest();
 
 		QList<AMDataSource *> i0Sources = QList<AMDataSource *>()
 				<< scan_->dataSourceAt(scan_->indexOfDataSource("SplitIonChamber"))
@@ -249,7 +240,7 @@ void VESPERS2DScanActionController::buildScanControllerImplementation()
 
 		AMDataSource *spectraSource = 0;
 
-		if (xrfDetector.testFlag(VESPERS::SingleElement) && xrfDetector.testFlag(VESPERS::FourElement)){
+		if (xrfDetectorConfig.testFlag(VESPERS::SingleElement) && xrfDetectorConfig.testFlag(VESPERS::FourElement)){
 
 			AM3DAdditionAB *sumSpectra = new AM3DAdditionAB("SingleAndFourSpectra");
 			sumSpectra->setInputDataSources(QList<AMDataSource *>() << scan_->dataSourceAt(scan_->indexOfDataSource("SingleElementVortex")) << scan_->dataSourceAt(scan_->indexOfDataSource("FourElementVortex")));
@@ -258,16 +249,17 @@ void VESPERS2DScanActionController::buildScanControllerImplementation()
 		}
 
 		else
-			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(detector->name()));
+			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(xrfDetector->name()));
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
+
+			xrfDetector->addRegionOfInterest(region->createCopy());
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
@@ -253,7 +253,7 @@ void VESPERS2DScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			xrfDetector->addRegionOfInterest(region->createCopy());
+			xrfDetector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS2DScanActionController.cpp
@@ -267,7 +267,7 @@ void VESPERS2DScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
@@ -98,7 +98,7 @@ void VESPERS3DScanActionController::buildScanControllerImplementation()
 		source->setHiddenFromUsers(true);
 	}
 
-	AMXRFDetector *detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("SingleElementVortex"));
+	AMXRFDetector *detector = VESPERSBeamline::vespers()->vespersSingleElementVortexDetector();
 	detector->removeAllRegionsOfInterest();
 
 	QList<AMDataSource *> i0Sources = QList<AMDataSource *>()
@@ -111,12 +111,13 @@ void VESPERS3DScanActionController::buildScanControllerImplementation()
 
 	foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
+		detector->addRegionOfInterest(region->createCopy());
+
 		AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 		AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 		newRegion->setBinningRange(regionAB->binningRange());
 		newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 		scan_->addAnalyzedDataSource(newRegion, false, true);
-		detector->addRegionOfInterest(region->createCopy());
 
 		AM3DNormalizationAB *normalizedRegion = new AM3DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 		normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
@@ -116,7 +116,7 @@ void VESPERS3DScanActionController::buildScanControllerImplementation()
 		newRegion->setBinningRange(regionAB->binningRange());
 		newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 		scan_->addAnalyzedDataSource(newRegion, false, true);
-		detector->addRegionOfInterest(region);
+		detector->addRegionOfInterest(region->createCopy());
 
 		AM3DNormalizationAB *normalizedRegion = new AM3DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 		normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERS3DScanActionController.cpp
@@ -111,7 +111,7 @@ void VESPERS3DScanActionController::buildScanControllerImplementation()
 
 	foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-		detector->addRegionOfInterest(region->createCopy());
+		detector->addRegionOfInterest(region);
 
 		AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 		AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
@@ -264,21 +264,12 @@ VESPERSSpatialLineScanActionController::VESPERSSpatialLineScanActionController(V
 
 void VESPERSSpatialLineScanActionController::buildScanControllerImplementation()
 {
-	VESPERS::FluorescenceDetectors xrfDetector = configuration_->fluorescenceDetector();
-	AMXRFDetector *detector = 0;
+	VESPERS::FluorescenceDetectors xrfDetectorConfig = configuration_->fluorescenceDetector();
 
-	if (xrfDetector.testFlag(VESPERS::SingleElement))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("SingleElementVortex"));
+	AMXRFDetector *xrfDetector = VESPERSBeamline::vespers()->xrfDetector(xrfDetectorConfig);
+	if (xrfDetector){
 
-	else if (xrfDetector.testFlag(VESPERS::FourElement))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("FourElementVortex"));
-
-	else if (xrfDetector.testFlag(VESPERS::Ge13Element))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("Ge13El"));
-
-	if (detector){
-
-		detector->removeAllRegionsOfInterest();
+		xrfDetector->removeAllRegionsOfInterest();
 
 		QList<AMDataSource *> i0Sources = QList<AMDataSource *>()
 				<< scan_->dataSourceAt(scan_->indexOfDataSource("SplitIonChamber"))
@@ -287,7 +278,7 @@ void VESPERSSpatialLineScanActionController::buildScanControllerImplementation()
 
 		AMDataSource *spectraSource = 0;
 
-		if (xrfDetector.testFlag(VESPERS::SingleElement) && xrfDetector.testFlag(VESPERS::FourElement)){
+		if (xrfDetectorConfig.testFlag(VESPERS::SingleElement) && xrfDetectorConfig.testFlag(VESPERS::FourElement)){
 
 			AM2DAdditionAB *sumSpectra = new AM2DAdditionAB("SingleAndFourSpectra");
 			sumSpectra->setInputDataSources(QList<AMDataSource *>() << scan_->dataSourceAt(scan_->indexOfDataSource("SingleElementVortex")) << scan_->dataSourceAt(scan_->indexOfDataSource("FourElementVortex")));
@@ -296,16 +287,17 @@ void VESPERSSpatialLineScanActionController::buildScanControllerImplementation()
 		}
 
 		else
-			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(detector->name()));
+			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(xrfDetector->name()));
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
+
+			xrfDetector->addRegionOfInterest(region->createCopy());
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DNormalizationAB *normalizedRegion = new AM1DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
@@ -291,7 +291,7 @@ void VESPERSSpatialLineScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			xrfDetector->addRegionOfInterest(region->createCopy());
+			xrfDetector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSSpatialLineScanActionController.cpp
@@ -305,7 +305,7 @@ void VESPERSSpatialLineScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DNormalizationAB *normalizedRegion = new AM1DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERSTimeScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSTimeScanActionController.cpp
@@ -171,7 +171,7 @@ void VESPERSTimeScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			xrfDetector->addRegionOfInterest(region->createCopy());
+			xrfDetector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERSTimeScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSTimeScanActionController.cpp
@@ -185,7 +185,7 @@ void VESPERSTimeScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DNormalizationAB *normalizedRegion = new AM1DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
@@ -2,6 +2,7 @@
 
 #include "acquaman/VESPERS/VESPERSTimedLineScanActionControllerAssembler.h"
 #include "beamline/AMBeamline.h"
+#include "beamline/VESPERS/VESPERSBeamline.h"
 #include "dataman/datastore/AMCDFDataStore.h"
 #include "dataman/datastore/AMInMemoryDataStore.h"
 #include "analysis/AM3DAdditionAB.h"
@@ -196,21 +197,12 @@ void VESPERSTimedLineScanActionController::buildScanController()
 
 void VESPERSTimedLineScanActionController::buildScanControllerImplementation()
 {
-	VESPERS::FluorescenceDetectors xrfDetector = configuration_->fluorescenceDetector();
-	AMXRFDetector *detector = 0;
+	VESPERS::FluorescenceDetectors xrfDetectorConfig = configuration_->fluorescenceDetector();
 
-	if (xrfDetector.testFlag(VESPERS::SingleElement))
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("SingleElementVortex"));
+	AMXRFDetector *xrfDetector = VESPERSBeamline::vespers()->xrfDetector(xrfDetectorConfig);
+	if (xrfDetector){
 
-	else if (xrfDetector.testFlag(VESPERS::FourElement))
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("FourElementVortex"));
-
-	else if (xrfDetector.testFlag(VESPERS::Ge13Element))
-		detector = qobject_cast<AMXRFDetector *>(AMBeamline::bl()->exposedDetectorByName("Ge13El"));
-
-	if (detector){
-
-		detector->removeAllRegionsOfInterest();
+		xrfDetector->removeAllRegionsOfInterest();
 
 		QList<AMDataSource *> i0Sources = QList<AMDataSource *>()
 				<< scan_->dataSourceAt(scan_->indexOfDataSource("SplitIonChamber"))
@@ -219,7 +211,7 @@ void VESPERSTimedLineScanActionController::buildScanControllerImplementation()
 
 		AMDataSource *spectraSource = 0;
 
-		if (xrfDetector.testFlag(VESPERS::SingleElement) && xrfDetector.testFlag(VESPERS::FourElement)){
+		if (xrfDetectorConfig.testFlag(VESPERS::SingleElement) && xrfDetectorConfig.testFlag(VESPERS::FourElement)){
 
 			AM3DAdditionAB *sumSpectra = new AM3DAdditionAB("SingleAndFourSpectra");
 			sumSpectra->setInputDataSources(QList<AMDataSource *>() << scan_->dataSourceAt(scan_->indexOfDataSource("SingleElementVortex")) << scan_->dataSourceAt(scan_->indexOfDataSource("FourElementVortex")));
@@ -228,16 +220,17 @@ void VESPERSTimedLineScanActionController::buildScanControllerImplementation()
 		}
 
 		else
-			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(detector->name()));
+			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(xrfDetector->name()));
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
+
+			xrfDetector->addRegionOfInterest(region->createCopy());
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
@@ -237,7 +237,7 @@ void VESPERSTimedLineScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM2DNormalizationAB *normalizedRegion = new AM2DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSTimedLineScanActionController.cpp
@@ -224,7 +224,7 @@ void VESPERSTimedLineScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			xrfDetector->addRegionOfInterest(region->createCopy());
+			xrfDetector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
@@ -195,7 +195,7 @@ void VESPERSXASScanActionController::buildScanControllerImplementation()
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region);
+			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DNormalizationAB *normalizedRegion = new AM1DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
@@ -181,7 +181,7 @@ void VESPERSXASScanActionController::buildScanControllerImplementation()
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
 
-			xrfDetector->addRegionOfInterest(region->createCopy());
+			xrfDetector->addRegionOfInterest(region);
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));

--- a/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
+++ b/source/acquaman/VESPERS/VESPERSXASScanActionController.cpp
@@ -152,30 +152,21 @@ void VESPERSXASScanActionController::buildScanControllerImplementation()
 	kCalculator->setInputDataSources(QList<AMDataSource *>() << scan_->rawDataSources()->at(scan_->indexOfDataSource("EnergyFeedback")));
 	scan_->addAnalyzedDataSource(kCalculator, false, true);
 
-	VESPERS::FluorescenceDetectors xrfDetector = configuration_->fluorescenceDetector();
-	AMXRFDetector *detector = 0;
-
-	if (xrfDetector.testFlag(VESPERS::SingleElement))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("SingleElementVortex"));
-
-	else if (xrfDetector.testFlag(VESPERS::FourElement))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("FourElementVortex"));
-
-	else if (xrfDetector.testFlag(VESPERS::Ge13Element))
-		detector = qobject_cast<AMXRFDetector *>(VESPERSBeamline::vespers()->exposedDetectorByName("Ge13El"));
-
 	QList<AMDataSource *> i0Sources = QList<AMDataSource *>()
 			<< scan_->dataSourceAt(scan_->indexOfDataSource("SplitIonChamber"))
 			   << scan_->dataSourceAt(scan_->indexOfDataSource("PreKBIonChamber"))
 				  << scan_->dataSourceAt(scan_->indexOfDataSource("MiniIonChamber"));
 
-	if (detector){
+	VESPERS::FluorescenceDetectors xrfDetectorConfig = configuration_->fluorescenceDetector();
 
-		detector->removeAllRegionsOfInterest();
+	AMXRFDetector *xrfDetector = VESPERSBeamline::vespers()->xrfDetector(xrfDetectorConfig);
+	if (xrfDetector){
+
+		xrfDetector->removeAllRegionsOfInterest();
 
 		AMDataSource *spectraSource = 0;
 
-		if (xrfDetector.testFlag(VESPERS::SingleElement) && xrfDetector.testFlag(VESPERS::FourElement)){
+		if (xrfDetectorConfig.testFlag(VESPERS::SingleElement) && xrfDetectorConfig.testFlag(VESPERS::FourElement)){
 
 			AM2DAdditionAB *sumSpectra = new AM2DAdditionAB("SingleAndFourSpectra");
 			sumSpectra->setInputDataSources(QList<AMDataSource *>() << scan_->dataSourceAt(scan_->indexOfDataSource("SingleElementVortex")) << scan_->dataSourceAt(scan_->indexOfDataSource("FourElementVortex")));
@@ -184,18 +175,19 @@ void VESPERSXASScanActionController::buildScanControllerImplementation()
 		}
 
 		else
-			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(detector->name()));
+			spectraSource = scan_->dataSourceAt(scan_->indexOfDataSource(xrfDetector->name()));
 
 		QString edgeSymbol = configuration_->edge().split(" ").first();
 
 		foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
+
+			xrfDetector->addRegionOfInterest(region->createCopy());
 
 			AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
 			AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(regionAB->name().remove(' '));
 			newRegion->setBinningRange(regionAB->binningRange());
 			newRegion->setInputDataSources(QList<AMDataSource *>() << spectraSource);
 			scan_->addAnalyzedDataSource(newRegion, false, true);
-			detector->addRegionOfInterest(region->createCopy());
 
 			AM1DNormalizationAB *normalizedRegion = new AM1DNormalizationAB(QString("norm_%1").arg(newRegion->name()));
 			normalizedRegion->setInputDataSources(QList<AMDataSource *>() << newRegion << i0Sources);

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -81,7 +81,7 @@ void BioXASAppController::onUserConfigurationLoadedFromDb()
 
 				foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 					if (!containsRegionOfInterest(geDetector->regionsOfInterest(), region)) {
-						geDetector->addRegionOfInterest(region->createCopy());
+						geDetector->addRegionOfInterest(region);
 						onRegionOfInterestAdded(region);
 					}
 				}

--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -347,7 +347,7 @@ void IDEASAppController::onUserConfigurationLoadedFromDb()
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 
-		detector->addRegionOfInterest(region->createCopy());
+		detector->addRegionOfInterest(region);
 		mapScanConfiguration_->addRegionOfInterest(region);
 		xasScanConfiguration_->addRegionOfInterest(region);
 		genericConfiguration_->addRegionOfInterest(region);

--- a/source/application/IDEAS/IDEASAppController.cpp
+++ b/source/application/IDEAS/IDEASAppController.cpp
@@ -347,8 +347,7 @@ void IDEASAppController::onUserConfigurationLoadedFromDb()
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 
-		AMRegionOfInterest *newRegion = region->createCopy();
-		detector->addRegionOfInterest(newRegion);
+		detector->addRegionOfInterest(region->createCopy());
 		mapScanConfiguration_->addRegionOfInterest(region);
 		xasScanConfiguration_->addRegionOfInterest(region);
 		genericConfiguration_->addRegionOfInterest(region);

--- a/source/application/SGM/SGMAppController.cpp
+++ b/source/application/SGM/SGMAppController.cpp
@@ -145,7 +145,7 @@ void SGMAppController::onUserConfigurationLoadedFromDb()
 	AMXRFDetector *detector = SGMBeamline::sgm()->amptekSDD1();
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
-		detector->addRegionOfInterest(region->createCopy());
+		detector->addRegionOfInterest(region);
 		xasScanConfiguration_->addRegionOfInterest(region);
 		lineScanConfiguration_->addRegionOfInterest(region);
 		mapScanConfiguration_->addRegionOfInterest(region);

--- a/source/application/SXRMB/SXRMBAppController.cpp
+++ b/source/application/SXRMB/SXRMBAppController.cpp
@@ -461,7 +461,7 @@ void SXRMBAppController::onUserConfigurationLoadedFromDb()
 	AMXRFDetector *detector = SXRMBBeamline::sxrmb()->brukerDetector();
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
-		detector->addRegionOfInterest(region->createCopy());
+		detector->addRegionOfInterest(region);
 		microProbe2DScanConfiguration_->addRegionOfInterest(region);
 		exafsScanConfiguration_->addRegionOfInterest(region);
 		microProbe2DOxidationScanConfiguration_->addRegionOfInterest(region);

--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -908,8 +908,7 @@ void VESPERSAppController::onUserConfigurationLoadedFromDb()
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 
-		AMRegionOfInterest *newRegion = region->createCopy();
-		detector->addRegionOfInterest(newRegion);
+		detector->addRegionOfInterest(region->createCopy());
 		mapScanConfiguration_->addRegionOfInterest(region);
 		map3DScanConfiguration_->addRegionOfInterest(region);
 		exafsScanConfiguration_->addRegionOfInterest(region);

--- a/source/application/VESPERS/VESPERSAppController.cpp
+++ b/source/application/VESPERS/VESPERSAppController.cpp
@@ -908,7 +908,7 @@ void VESPERSAppController::onUserConfigurationLoadedFromDb()
 
 	foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
 
-		detector->addRegionOfInterest(region->createCopy());
+		detector->addRegionOfInterest(region);
 		mapScanConfiguration_->addRegionOfInterest(region);
 		map3DScanConfiguration_->addRegionOfInterest(region);
 		exafsScanConfiguration_->addRegionOfInterest(region);

--- a/source/beamline/AMBeamline.cpp
+++ b/source/beamline/AMBeamline.cpp
@@ -158,7 +158,7 @@ void AMBeamline::onRegionOfInterestAdded(AMRegionOfInterest *newRegion)
 				regionNeedsToBeAdded = false;
 
 		if (regionNeedsToBeAdded)
-			detector->addRegionOfInterest(newRegion->createCopy());
+			detector->addRegionOfInterest(newRegion);
 	}
 }
 

--- a/source/beamline/AMXRFDetector.cpp
+++ b/source/beamline/AMXRFDetector.cpp
@@ -333,10 +333,13 @@ void AMXRFDetector::addRegionOfInterest(const AMEmissionLine &emissionLine)
 	AMRegionOfInterest *region = new AMRegionOfInterest(emissionLine.name(), energy, AMRange(energy*(1-halfWidth), energy*(1+halfWidth)), this);
 
 	addRegionOfInterest(region);
+	region->deleteLater();
 }
 
-void AMXRFDetector::addRegionOfInterest(AMRegionOfInterest *newRegionOfInterest)
+void AMXRFDetector::addRegionOfInterest(AMRegionOfInterest *regionOfInterest)
 {
+	AMRegionOfInterest *newRegionOfInterest = regionOfInterest->createCopy();
+
 	connect(newRegionOfInterest, SIGNAL(boundingRangeChanged(AMRange)), regionOfInterestSignalMapper_, SLOT(map()));
 	regionOfInterestSignalMapper_->setMapping(newRegionOfInterest, newRegionOfInterest);
 	regionsOfInterest_.append(newRegionOfInterest);

--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -134,8 +134,8 @@ public slots:
 
 	/// Adds a region of interest.  Does the work of creating the region and the data source associated with it.  Builds the region off of an AMEmissionLine.
 	void addRegionOfInterest(const AMEmissionLine &emissionLine);
-	/// Overloaded.  Adds a region of interest.  Does the work of creating the region and the data source associated with it.  The provided region is expected to be valid.
-	void addRegionOfInterest(AMRegionOfInterest *newRegionOfInterest);
+	/// Overloaded.  Adds a region of interest (make a copy of the regionOfInterest instance).  Does the work of creating the region and the data source associated with it.  The provided region is expected to be valid.
+	void addRegionOfInterest(AMRegionOfInterest *regionOfInterest);
 	/// Removes a region of interest.  Does the work of ensuring the region and the data source associated with it is properly removed.  Knows which region to remove based on the provided AMEmissionLine.
 	void removeRegionOfInterest(const AMEmissionLine &emissionLine);
 	/// Removes a region of interest.  Does the work of ensuring the region and the data source associated with it is properly removed.

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -300,10 +300,10 @@ AMXRFDetector *IDEASBeamline::xrfDetector(IDEAS::FluorescenceDetectors detectorT
 	AMXRFDetector * XRFDetector = 0;
 
 	if (detectorType.testFlag(IDEAS::Ketek))
-		XRFDetector = IDEASBeamline::ideas()->ketek();
+		XRFDetector = ketek();
 
 	else if (detectorType.testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
-		XRFDetector = IDEASBeamline::ideas()->ge13Element();
+		XRFDetector = ge13Element();
 
 	return XRFDetector;
 }

--- a/source/beamline/SXRMB/SXRMBBeamline.cpp
+++ b/source/beamline/SXRMB/SXRMBBeamline.cpp
@@ -450,6 +450,19 @@ SXRMBFourElementVortexDetector *SXRMBBeamline::fourElementVortexDetector() const
 	return fourElementVortexDetector_;
 }
 
+AMXRFDetector *SXRMBBeamline::xrfDetector(SXRMB::FluorescenceDetectors detectorType) const
+{
+	AMXRFDetector * XRFDetector = 0;
+
+	if (detectorType.testFlag(SXRMB::BrukerDetector)){
+		XRFDetector = brukerDetector();
+	} else if (detectorType.testFlag(SXRMB::FourElementDetector)) {
+		XRFDetector = fourElementVortexDetector();
+	}
+
+	return XRFDetector;
+}
+
 AMControlSet *SXRMBBeamline::beamlineHVControlSet() const
 {
 	return beamlineHVControlSet_;

--- a/source/beamline/SXRMB/SXRMBBeamline.cpp
+++ b/source/beamline/SXRMB/SXRMBBeamline.cpp
@@ -621,7 +621,7 @@ void SXRMBBeamline::setupComponents()
 	jjSlits_->setHorizontalSlitClosedGapValue(0);
 
 	//energy_ = new AMPVwStatusControl("Energy", "BL1606-B1-1:Energy:fbk", "BL1606-B1-1:Energy", "BL1606-B1-1:Energy:status", QString(), this, 0.1, 2.0, new AMControlStatusCheckerCLSMAXv());
-	energy_ = new AMPVwStatusControl("Energy", "BL1606-B1-1:AddOns:Energy:fbk", "BL1606-B1-1:AddOns:Energy", "BL1606-B1-1:AddOns:Energy:status", "BL1606-B1-1:AddOns:Energy:stop", this, 0.001, 2.0, new CLSMAXvControlStatusChecker());
+	energy_ = new AMPVwStatusControl("Energy", "BL1606-B1-1:AddOns:Energy:fbk", "BL1606-B1-1:AddOns:Energy", "BL1606-B1-1:AddOns:Energy:status", "BL1606-B1-1:AddOns:Energy:stop", this, 0.05, 2.0, new CLSMAXvControlStatusChecker());
 
 	CLSSR570 *tempSR570;
 	scaler_ = new CLSSIS3820Scaler("BL1606-B1-1:mcs", this);

--- a/source/beamline/SXRMB/SXRMBBeamline.h
+++ b/source/beamline/SXRMB/SXRMBBeamline.h
@@ -162,6 +162,8 @@ public:
 	SXRMBBrukerDetector *brukerDetector() const;
 	/// Returns the four element vortex detector.
 	SXRMBFourElementVortexDetector *fourElementVortexDetector() const;
+	/// Returns the XRF detector with given detector type.
+	AMXRFDetector *xrfDetector(SXRMB::FluorescenceDetectors detectorType) const;
 
 	/// Returns the control set of the HV controls
 	AMControlSet *beamlineHVControlSet() const;

--- a/source/beamline/VESPERS/VESPERSBeamline.cpp
+++ b/source/beamline/VESPERS/VESPERSBeamline.cpp
@@ -1278,6 +1278,22 @@ QString VESPERSBeamline::details() const
 	return notes;
 }
 
+AMXRFDetector *VESPERSBeamline::xrfDetector(VESPERS::FluorescenceDetectors detectorType) const
+{
+	AMXRFDetector *detector = 0;
+
+	if (detectorType.testFlag(VESPERS::SingleElement))
+		detector = vespersSingleElementVortexDetector();
+
+	else if (detectorType.testFlag(VESPERS::FourElement))
+		detector = vespersFourElementVortexDetector();
+
+	else if (detectorType.testFlag(VESPERS::Ge13Element))
+		detector = vespersGe13ElementDetector();
+
+	return detector;
+}
+
 bool VESPERSBeamline::allValvesOpen() const
 {
 	bool result = false;

--- a/source/beamline/VESPERS/VESPERSBeamline.h
+++ b/source/beamline/VESPERS/VESPERSBeamline.h
@@ -113,6 +113,9 @@ public:
 	AMDetector *ge13ElementDetector() const { return ge13ElementDetector_; }
 	/// Returns the 13 element germanium detector as its full type.
 	VESPERS13ElementGeDetector *vespersGe13ElementDetector() const { return ge13ElementDetector_; }
+	/// Returns the XRF detector with given type
+	AMXRFDetector *xrfDetector(VESPERS::FluorescenceDetectors detectorType) const;
+
 
 	// Accessing control elements:
 	/// Returns the monochromator abstraction for the VESPERS beamline.

--- a/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
+++ b/source/ui/IDEAS/IDEASXASScanConfigurationView.cpp
@@ -365,18 +365,12 @@ void IDEASXASScanConfigurationView::onEstimatedTimeChanged()
 
 void IDEASXASScanConfigurationView::onROIChange()
 {
-	AMXRFDetector *detector = 0;
+	AMXRFDetector *detector = IDEASBeamline::ideas()->xrfDetector(configuration_->fluorescenceDetector());
+	if (!detector) {
 
-	if (configuration_->fluorescenceDetector().testFlag(IDEAS::NoXRF))
 		ROIsLabel_->setText("");
 
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ketek))
-		detector = IDEASBeamline::ideas()->ketek();
-
-	else if (configuration_->fluorescenceDetector().testFlag(IDEAS::Ge13Element) && IDEASBeamline::ideas()->ge13Element()->isConnected())
-		detector = IDEASBeamline::ideas()->ge13Element();
-
-	if (detector){
+	} else {
 
 		if (detector->regionsOfInterest().isEmpty())
 			ROIsLabel_->setText("No XRF detector regions of interest selected.");


### PR DESCRIPTION
Reported in Issue #2253, when we start to do a scan, we added the ROIs in the scan configuration to the XRFDetectors in function `buildScanControllerImplementation()`. Unfortunately, we are using the ROI instances of the current scan configuration.

Therefore, if the user removed ROIs from XRFDetectors when a scan is running, we deleted the ROI instance which is associated with the current scan configuration and will cause a crash when we are trying to export the scan.
 
====
Solution:
  - create a copy of ROI when adding the ROI to the XRFDetector
  - small code refactor for `buildScanControllerImplementation()`
