### PR TITLE
Pull Request for Issue2287: Add control information to XAS scan header

### DIFF
--- a/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
@@ -6,8 +6,6 @@ BioXASGenericStepScanController::BioXASGenericStepScanController(BioXASGenericSt
 {
 	useFeedback_ = true;
 
-	scan_->setNotes(BioXASBeamline::bioXAS()->scanNotes());
-
 	// Add the Ge detectors spectra, if a Ge detector is being used.
 
 	AMDetectorSet *geDetectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -28,8 +28,6 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 
 	useFeedback_ = true;
 
-	scan_->setNotes(BioXASBeamline::bioXAS()->scanNotes());
-
 	if (bioXASConfiguration_) {
 
 		AMExporterOptionXDIFormat *bioXASDefaultXAS = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", bioXASConfiguration_->edge().split(" ").first(), bioXASConfiguration_->edge().split(" ").last(), true);
@@ -92,6 +90,10 @@ void BioXASXASScanActionController::createScanAssembler()
 
 void BioXASXASScanActionController::buildScanControllerImplementation()
 {
+	// Identify current beamline settings.
+
+	scan_->setScanInitialConditions(BioXASBeamline::bioXAS()->defaultXASScanControlInfos());
+
 	// Identify exporter option.
 
 	AMExporterOptionXDIFormat *exportXDI = 0;

--- a/source/application/BioXAS/BioXAS.h
+++ b/source/application/BioXAS/BioXAS.h
@@ -25,7 +25,20 @@ namespace BioXAS
 
 		xasDefault->setName(name);
 		xasDefault->setFileName("$name_$number.dat");
-		xasDefault->setHeaderText("Scan: $name #$number\nDate: $dateTime\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
+		xasDefault->setHeaderText("Scan: $name #$number\n"
+								  "Date: $dateTime\n"
+								  "Facility: $facilityDescription\n"
+								  "\n"
+								  "SR1 current: $control[Ring Current]\n"
+								  "Settling time: $control[settlingTime]\n"
+								  "I0 amplifier gain: $control[I0Gain]\n"
+								  "I1 amplifier gain: $control[I1Gain]\n"
+								  "I2 amplifier gain: $control[I2Gain]\n"
+								  "\n"
+								  "$scanConfiguration[header]\n"
+								  "\n"
+								  "Notes:\n$notes\n"
+								  "\n");
 		xasDefault->setHeaderIncluded(true);
 		xasDefault->setColumnHeader("$dataSetName $dataSetInfoDescription");
 		xasDefault->setColumnHeaderIncluded(true);

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -90,9 +90,6 @@ public:
 	/// Creates and returna an action that cleans up the beamline after a scan.
 	virtual AMAction3* createScanCleanupAction(AMGenericStepScanConfiguration *configuration);
 
-	/// Returns a string representation of the beamline settings to include in the scan notes.
-	virtual QString scanNotes() const;
-
 	/// Returns the beam status.
 	virtual BioXASBeamStatus* beamStatus() const { return beamStatus_; }
 
@@ -165,10 +162,16 @@ public:
 
 	/// Returns the scaler.
 	virtual CLSSIS3820Scaler* scaler() const { return 0; }
+	/// Returns the I0 Keithley amplifier.
+	virtual CLSKeithley428* i0Keithley() const { return 0; }
 	/// Returns the I0 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i0Detector() const { return 0; }
+	/// Returns the I1 Keithley amplifier.
+	virtual CLSKeithley428* i1Keithley() const { return 0; }
 	/// Returns the I1 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i1Detector() const { return 0; }
+	/// Returns the I2 Keithley amplifier.
+	virtual CLSKeithley428* i2Keithley() const { return 0; }
 	/// Returns the I2 scaler channel detector.
 	virtual CLSBasicScalerChannelDetector* i2Detector() const { return 0; }
 	/// Returns true if this beamline can use a diode detector.
@@ -208,6 +211,8 @@ public:
 	AMDetectorSet* defaultXASScanDetectors() const { return defaultXASScanDetectors_; }
 	/// Returns the set of detectors to use as options in XAS scans.
 	AMDetectorSet* defaultXASScanDetectorOptions() const { return defaultXASScanDetectorOptions_; }
+	/// Returns the default list of infos for controls that are of interest in XAS scans.
+	AMControlInfoList defaultXASScanControlInfos() const;
 
 	/// Returns the set of default detectors added to generic scans, a subset of defaultGenericScanDetectorOptions.
 	AMDetectorSet* defaultGenericScanDetectors() const { return defaultGenericScanDetectors_; }

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -87,11 +87,11 @@ public:
 	/// Returns the scaler.
 	virtual BioXASSIS3820Scaler* scaler() const { return scaler_; }
 	/// Returns the I0 amplifier.
-	CLSKeithley428* i0Keithley() const { return i0Keithley_; }
+	virtual CLSKeithley428* i0Keithley() const { return i0Keithley_; }
 	/// Returns the IT amplifier.
-	CLSKeithley428* i1Keithley() const { return i1Keithley_; }
+	virtual CLSKeithley428* i1Keithley() const { return i1Keithley_; }
 	/// Returns the I2 amplifier.
-	CLSKeithley428* i2Keithley() const { return i2Keithley_; }
+	virtual CLSKeithley428* i2Keithley() const { return i2Keithley_; }
 	/// Returns the 'misc' Keithley 428 amplifier.
 	CLSKeithley428* miscKeithley() const { return miscKeithley_; }
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -97,13 +97,13 @@ public:
 	/// Returns the scaler.
 	virtual CLSSIS3820Scaler* scaler() const { return scaler_; }
 	/// Returns the I0 Keithley428 amplifier.
-	CLSKeithley428* i0Keithley() const { return i0Keithley_; }
+	virtual CLSKeithley428* i0Keithley() const { return i0Keithley_; }
 	/// Returns the IT Keithley428 amplifier.
-	CLSKeithley428* i1Keithley() const { return i1Keithley_; }
+	virtual CLSKeithley428* i1Keithley() const { return i1Keithley_; }
 	/// Returns the I2 Keithley 428 amplifier.
-	CLSKeithley428* i2Keithley() const { return i2Keithley_; }
+	virtual CLSKeithley428* i2Keithley() const { return i2Keithley_; }
 	/// Returns the 'misc' Keithley 428 amplifier.
-	CLSKeithley428* miscKeithley() const { return miscKeithley_; }
+	virtual CLSKeithley428* miscKeithley() const { return miscKeithley_; }
 
 	/// Returns the lateral detector stage motor.
 	virtual CLSMAXvMotor* detectorStageLateralMotor() const { return detectorStageLateral_; }


### PR DESCRIPTION
Modified BioXASBeamline: added virtual getters for the I0, I1, I2 Keithley amplifiers, and new getter for the list of control infos that would be useful to know about for scans (storage ring current, settling time, I0 gain, I1, gain, I2 gain). Removed the scanNotes() getter from BioXASBeamline--this functionality is now with the new control info getter. Modified BioXAS.h so that the exporter option now includes relevant control info information in the scan header.