### PR TITLE
Pull request for Issue2069: Add scan serial number to AMScanThumbnailGridView scan items.

### DIFF
--- a/source/ui/dataman/AMScanThumbnailGridGeometryManager.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridGeometryManager.cpp
@@ -7,12 +7,23 @@ AMScanThumbnailGridGeometryManager::AMScanThumbnailGridGeometryManager(int width
 
 }
 
+QRect AMScanThumbnailGridGeometryManager::scanSerialRectangle(const QRect &contentRect) const
+{
+
+    int serialRectWidth = int(contentRect.width() * 0.2);
+    int serialRectHeight = int(contentRect.height() * 0.1);
+    int serialRectX = contentRect.x() + 10;
+    int serialRectY = contentRect.y() + 10;
+
+    return QRect(serialRectX, serialRectY, serialRectWidth, serialRectHeight);
+}
+
 QRect AMScanThumbnailGridGeometryManager::scanNameRectangle(const QRect &contentRect) const
 {
 
-	int nameRectWidth = int(contentRect.width() * 0.9);
+    int nameRectWidth = int(contentRect.width() * 0.8);
 	int nameRectHeight = int(contentRect.height() * 0.1);
-	int nameRectX = contentRect.x() + (contentRect.width() - nameRectWidth) /2;
+    int nameRectX = contentRect.x() + 50;
 	int nameRectY = contentRect.y() + 10;
 
 	return QRect(nameRectX, nameRectY, nameRectWidth, nameRectHeight);

--- a/source/ui/dataman/AMScanThumbnailGridGeometryManager.h
+++ b/source/ui/dataman/AMScanThumbnailGridGeometryManager.h
@@ -25,6 +25,14 @@ public:
 	 */
 	explicit AMScanThumbnailGridGeometryManager(int width);
 
+    /**
+     * The rectangle for displaying the serial number within the provided content
+     * rectangle
+     * @param contentRect::QRect ~ The rectangle which the serial number is to be
+     * displayed in
+     */
+    QRect scanSerialRectangle(const QRect& contentRect) const;
+
 	/**
 	 * The rectangle for displaying the scan name within the provided content
 	 * rectangle

--- a/source/ui/dataman/AMScanThumbnailGridView.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridView.cpp
@@ -4,423 +4,445 @@
 #include "ui/dataman/AMScanThumbnailGridInputManager.h"
 
 AMScanThumbnailGridView::AMScanThumbnailGridView(QWidget *parent) :
-	QAbstractItemView(parent)
+    QAbstractItemView(parent)
 {
-	geometryManager_ = new AMScanThumbnailGridGeometryManager(sizeHint().width());
-	// Wire up the input manager to this view
-	inputManager_ = new AMScanThumbnailGridInputManager();
-	connect(inputManager_, SIGNAL(itemSelected(int,QItemSelectionModel::SelectionFlags)), this, SLOT(onItemSelected(int,QItemSelectionModel::SelectionFlags)));
-	connect(inputManager_, SIGNAL(selectionExtended(int)), this, SLOT(onSelectionExtended(int)));
-	connect(inputManager_, SIGNAL(itemDoubleClicked(int)), this, SLOT(onItemDoubleClicked(int)));
-	connect(inputManager_, SIGNAL(dragBegun()), this, SLOT(onDragBegun()));
-	connect(inputManager_, SIGNAL(selectionRectangleChanged(QRect)), this, SLOT(onSelectionRectangleChanged(QRect)));
-	connect(inputManager_, SIGNAL(selectionRectangleEnded(QRect, QItemSelectionModel::SelectionFlags)), this, SLOT(onSelectionRectangleEnded(QRect, QItemSelectionModel::SelectionFlags)));
-	connect(inputManager_, SIGNAL(hoverMove(int, int, int)), this, SLOT(onHoverMove(int, int, int)));
+    geometryManager_ = new AMScanThumbnailGridGeometryManager(sizeHint().width());
+    // Wire up the input manager to this view
+    inputManager_ = new AMScanThumbnailGridInputManager();
+    connect(inputManager_, SIGNAL(itemSelected(int,QItemSelectionModel::SelectionFlags)), this, SLOT(onItemSelected(int,QItemSelectionModel::SelectionFlags)));
+    connect(inputManager_, SIGNAL(selectionExtended(int)), this, SLOT(onSelectionExtended(int)));
+    connect(inputManager_, SIGNAL(itemDoubleClicked(int)), this, SLOT(onItemDoubleClicked(int)));
+    connect(inputManager_, SIGNAL(dragBegun()), this, SLOT(onDragBegun()));
+    connect(inputManager_, SIGNAL(selectionRectangleChanged(QRect)), this, SLOT(onSelectionRectangleChanged(QRect)));
+    connect(inputManager_, SIGNAL(selectionRectangleEnded(QRect, QItemSelectionModel::SelectionFlags)), this, SLOT(onSelectionRectangleEnded(QRect, QItemSelectionModel::SelectionFlags)));
+    connect(inputManager_, SIGNAL(hoverMove(int, int, int)), this, SLOT(onHoverMove(int, int, int)));
 
-	// Have to set mouse tracking in order to receive events when no mouse button is held
-	setMouseTracking(true);
+    // Have to set mouse tracking in order to receive events when no mouse button is held
+    setMouseTracking(true);
 
-	setItemDelegate(new AMScanThumbnailGridViewItemDelegate(this));
-	horizontalScrollBar()->setVisible(false);
-	updateScrollBars();
-	rubberBand_ = new QRubberBand(QRubberBand::Rectangle, viewport());
-	rubberBand_->setVisible(false);
+    setItemDelegate(new AMScanThumbnailGridViewItemDelegate(this));
+    horizontalScrollBar()->setVisible(false);
+    updateScrollBars();
+    rubberBand_ = new QRubberBand(QRubberBand::Rectangle, viewport());
+    rubberBand_->setVisible(false);
 }
 
 AMScanThumbnailGridView::~AMScanThumbnailGridView()
 {
-	delete geometryManager_;
-	inputManager_->deleteLater();
+    delete geometryManager_;
+    inputManager_->deleteLater();
 }
 
 QModelIndex AMScanThumbnailGridView::indexAt(const QPoint &point) const
 {
-	if(!model())
-		return QModelIndex();
+    if(!model())
+        return QModelIndex();
 
-	QPoint adjustedPoint(point.x() + horizontalOffset(),
-						 point.y() + verticalOffset());
+    QPoint adjustedPoint(point.x() + horizontalOffset(),
+                         point.y() + verticalOffset());
 
-	int integerIndexAt = geometryManager_->contentIndexAt(adjustedPoint);
+    int integerIndexAt = geometryManager_->contentIndexAt(adjustedPoint);
 
-	if(integerIndexAt == -1)
-		return QModelIndex();
+    if(integerIndexAt == -1)
+        return QModelIndex();
 
-	return model()->index(integerIndexAt, 1, QModelIndex());
+    return model()->index(integerIndexAt, 1, QModelIndex());
 }
 
 QRect AMScanThumbnailGridView::visualRect(const QModelIndex &index) const
 {
 
-	QRect rowContentRect;
-
-	if(index.parent().isValid()) {
-		// is  a thumbnail
-		rowContentRect = geometryManager_->contentGeometryAt(index.parent().row(),
-															 horizontalOffset(),
-															 verticalOffset());
-	} else {
-		rowContentRect = geometryManager_->contentGeometryAt(index.row(),
-															 horizontalOffset(),
-															 verticalOffset());
-	}
-
+    QRect rowContentRect;
+    /*
     if(!index.isValid()){
-        return rowContentRect;
+        return rowContentRect ;
+    }
+    */
+    if(index.parent().isValid()) {
+        // is  a thumbnail
+        rowContentRect = geometryManager_->contentGeometryAt(index.parent().row(),
+                                                             horizontalOffset(),
+                                                             verticalOffset());
+    } else {
+        rowContentRect = geometryManager_->contentGeometryAt(index.row(),
+                                                             horizontalOffset(),
+                                                             verticalOffset());
     }
 
-	if(!index.parent().isValid()) {
-		// Is Scan
-		switch(index.column()) {
-		case 0:
+
+    if(!index.parent().isValid()) {
+        // Is Scan
+        switch(index.column()) {
+        case 0:
             return geometryManager_->scanSerialRectangle(rowContentRect);
         case 1:
             return geometryManager_->scanNameRectangle(rowContentRect);
-		case 3:
-			return geometryManager_->scanDateRectangle(rowContentRect);
-		case 4:
-			return geometryManager_->scanTechniqueRectangle(rowContentRect);
+        case 3:
+            return geometryManager_->scanDateRectangle(rowContentRect);
+        case 4:
+            return geometryManager_->scanTechniqueRectangle(rowContentRect);
 
-		default:
+        default:
             return QRect();
-		}
-	} else {
-		// Is Thumbnail
-		switch(index.column()) {
-		case 1:
-			return geometryManager_->thumbnailImageRectangle(rowContentRect);
-		case 2:
-			return geometryManager_->thumbnailTitleRectangle(rowContentRect);
+        }
+    } else {
+        // Is Thumbnail
+        switch(index.column()) {
+        case 1:
+            return geometryManager_->thumbnailImageRectangle(rowContentRect);
+        case 2:
+            return geometryManager_->thumbnailTitleRectangle(rowContentRect);
 
-		default:
-			return QRect();
-		}
-	}
+        default:
+            return QRect();
+        }
+    }
+
+}
+
+QRect AMScanThumbnailGridView::backgroundRect(const QModelIndex &index) const
+{
+
+    QRect rowContentRect;
+
+    rowContentRect = geometryManager_->contentGeometryAt(index.row(),
+                                                             horizontalOffset(),
+                                                             verticalOffset());
+    return rowContentRect;
 
 }
 
 void AMScanThumbnailGridView::scrollTo(const QModelIndex &index, QAbstractItemView::ScrollHint hint)
 {
-	// Note: currently ignores the scroll hint. Places the corresponding scan as close to the top of
-	// the view as is possible
-	Q_UNUSED(hint);
+    // Note: currently ignores the scroll hint. Places the corresponding scan as close to the top of
+    // the view as is possible
+    Q_UNUSED(hint);
 
-	if(!index.isValid())
-		return;
+    if(!index.isValid())
+        return;
 
-	// If the passed index refers to a thumbnail (i.e. its parent is valid) then we need to
-	// scrollTo the index of the parent scan
-	if(index.parent().isValid()) {
-		scrollTo(index.parent(), hint);
-		return;
-	}
+    // If the passed index refers to a thumbnail (i.e. its parent is valid) then we need to
+    // scrollTo the index of the parent scan
+    if(index.parent().isValid()) {
+        scrollTo(index.parent(), hint);
+        return;
+    }
 
-	// Obtian the geometry of the index
-	int itemCellIndex = index.row();
-	QRect indexCellGeometry = geometryManager_->cellGeometryAt(itemCellIndex, horizontalOffset(), verticalOffset());
+    // Obtian the geometry of the index
+    int itemCellIndex = index.row();
+    QRect indexCellGeometry = geometryManager_->cellGeometryAt(itemCellIndex, horizontalOffset(), verticalOffset());
 
-	verticalScrollBar()->setValue(indexCellGeometry.y());
-	horizontalScrollBar()->setValue(indexCellGeometry.x());
+    verticalScrollBar()->setValue(indexCellGeometry.y());
+    horizontalScrollBar()->setValue(indexCellGeometry.x());
 }
 
 void AMScanThumbnailGridView::onItemSelected(int itemIndex, QItemSelectionModel::SelectionFlags flags)
 {
-	if(itemIndex < 0)
-		return;
+    if(itemIndex < 0)
+        return;
 
-	QModelIndex selectedItemIndex = model()->index(itemIndex, 0, QModelIndex());
-	selectionModel()->select(selectedItemIndex, flags | QItemSelectionModel::Rows);
+    QModelIndex selectedItemIndex = model()->index(itemIndex, 0, QModelIndex());
+    selectionModel()->select(selectedItemIndex, flags | QItemSelectionModel::Rows);
 }
 
 void AMScanThumbnailGridView::onSelectionExtended(int itemIndex)
 {
-	QModelIndex extendToIndex = model()->index(itemIndex, 0, QModelIndex());
-	if(!extendToIndex.isValid())
-		return;
+    QModelIndex extendToIndex = model()->index(itemIndex, 0, QModelIndex());
+    if(!extendToIndex.isValid())
+        return;
 
-	// Get the lowest currently selected row index
-	int lowestSelectedRowIndex = 0;
-	int rowCount = model()->rowCount();
-	bool lowestSelectedRowIndexFound = false;
-	while(lowestSelectedRowIndex < rowCount && !lowestSelectedRowIndexFound) {
-		if(selectionModel()->isRowSelected(lowestSelectedRowIndex, QModelIndex())) {
-			lowestSelectedRowIndexFound = true;
-		} else {
-			++lowestSelectedRowIndex;
-		}
-	}
+    // Get the lowest currently selected row index
+    int lowestSelectedRowIndex = 0;
+    int rowCount = model()->rowCount();
+    bool lowestSelectedRowIndexFound = false;
+    while(lowestSelectedRowIndex < rowCount && !lowestSelectedRowIndexFound) {
+        if(selectionModel()->isRowSelected(lowestSelectedRowIndex, QModelIndex())) {
+            lowestSelectedRowIndexFound = true;
+        } else {
+            ++lowestSelectedRowIndex;
+        }
+    }
 
-	if(lowestSelectedRowIndexFound)	{
-		QModelIndex lowestSelectedModelIndex =
-				model()->index(lowestSelectedRowIndex, 1, QModelIndex());
+    if(lowestSelectedRowIndexFound)	{
+        QModelIndex lowestSelectedModelIndex =
+                model()->index(lowestSelectedRowIndex, 1, QModelIndex());
 
-		if(lowestSelectedModelIndex.isValid()) {
+        if(lowestSelectedModelIndex.isValid()) {
 
-			QItemSelection newSelectedItems;
+            QItemSelection newSelectedItems;
 
-			if(extendToIndex.row() < lowestSelectedModelIndex.row())
-				newSelectedItems.select(extendToIndex, lowestSelectedModelIndex);
-			else
-				newSelectedItems.select(lowestSelectedModelIndex, extendToIndex);
+            if(extendToIndex.row() < lowestSelectedModelIndex.row())
+                newSelectedItems.select(extendToIndex, lowestSelectedModelIndex);
+            else
+                newSelectedItems.select(lowestSelectedModelIndex, extendToIndex);
 
-			selectionModel()->select(newSelectedItems, QItemSelectionModel::Select | QItemSelectionModel::Rows);
-		}
-	}
+            selectionModel()->select(newSelectedItems, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+        }
+    }
 }
 
 void AMScanThumbnailGridView::onItemDoubleClicked(int itemIndex)
 {
-	QModelIndex doubleClickedItemIndex = model()->index(itemIndex, 0, QModelIndex());
-	emit doubleClicked(doubleClickedItemIndex);
+    QModelIndex doubleClickedItemIndex = model()->index(itemIndex, 0, QModelIndex());
+    emit doubleClicked(doubleClickedItemIndex);
 }
 
 void AMScanThumbnailGridView::onDragBegun()
 {
-	QDrag* drag = new QDrag(this);
-	QMimeData* mimeData = model()->mimeData(selectionModel()->selectedIndexes());
-	drag->setMimeData(mimeData);
-	drag->setHotSpot(QPoint(15,15));
-	drag->exec(Qt::CopyAction);
+    QDrag* drag = new QDrag(this);
+    QMimeData* mimeData = model()->mimeData(selectionModel()->selectedIndexes());
+    drag->setMimeData(mimeData);
+    drag->setHotSpot(QPoint(15,15));
+    drag->exec(Qt::CopyAction);
 }
 
 void AMScanThumbnailGridView::onSelectionRectangleChanged(const QRect &selectionRectangle)
 {
-	rubberBand_->setGeometry(selectionRectangle.normalized());
+    rubberBand_->setGeometry(selectionRectangle.normalized());
 
-	if(!rubberBand_->isVisible())
-		rubberBand_->setVisible(true);
+    if(!rubberBand_->isVisible())
+        rubberBand_->setVisible(true);
 }
 
 void AMScanThumbnailGridView::onSelectionRectangleEnded(const QRect& selectionRectangle, QItemSelectionModel::SelectionFlags flags)
 {
-	setSelection(selectionRectangle, flags);
-	rubberBand_->setVisible(false);
+    setSelection(selectionRectangle, flags);
+    rubberBand_->setVisible(false);
 }
 
 void AMScanThumbnailGridView::onHoverMove(int itemIndex, int positionX, int positionY)
 {
-	// get number of thumbnails
-	QModelIndex modelIndexOfItem = model()->index(itemIndex, 0, QModelIndex());
-	if(!modelIndexOfItem.isValid())
-		return;
+    // get number of thumbnails
+    QModelIndex modelIndexOfItem = model()->index(itemIndex, 0, QModelIndex());
+    if(!modelIndexOfItem.isValid())
+        return;
 
-	int thumbnailCount = model()->rowCount(modelIndexOfItem);
+    int thumbnailCount = model()->rowCount(modelIndexOfItem);
 
-	if(thumbnailCount == 0)
-		return;
+    if(thumbnailCount == 0)
+        return;
 
-	// get position of x within the content rectangle for itemIndex
-	QModelIndex modelThumbnailImageIndex = model()->index(0, 1, modelIndexOfItem);
-	QRect thumbnailImageRectangle = visualRect(modelThumbnailImageIndex);
-	QPoint posInsideRect(positionX - thumbnailImageRectangle.x(), positionY - thumbnailImageRectangle.y());
+    // get position of x within the content rectangle for itemIndex
+    QModelIndex modelThumbnailImageIndex = model()->index(0, 1, modelIndexOfItem);
+    QRect thumbnailImageRectangle = visualRect(modelThumbnailImageIndex);
+    QPoint posInsideRect(positionX - thumbnailImageRectangle.x(), positionY - thumbnailImageRectangle.y());
 
-	// calculate at what thumbnail index the thumbnail should be at given the
-	// position inside the thumbnail and the number of thumbnails
-	int widthOfEachThumbnailSegment = thumbnailImageRectangle.width() / thumbnailCount;
-	if(widthOfEachThumbnailSegment == 0)
-		return;
+    // calculate at what thumbnail index the thumbnail should be at given the
+    // position inside the thumbnail and the number of thumbnails
+    int widthOfEachThumbnailSegment = thumbnailImageRectangle.width() / thumbnailCount;
+    if(widthOfEachThumbnailSegment == 0)
+        return;
 
-	int currentThumbnailIndexToShow = 0;
+    int currentThumbnailIndexToShow = 0;
 
-	if (posInsideRect.x() > 0)
-		currentThumbnailIndexToShow = posInsideRect.x() / widthOfEachThumbnailSegment;
+    if (posInsideRect.x() > 0)
+        currentThumbnailIndexToShow = posInsideRect.x() / widthOfEachThumbnailSegment;
 
-	if(currentThumbnailIndexToShow+1 > thumbnailCount)
-		currentThumbnailIndexToShow = thumbnailCount - 1;
-	// check if the thumbnail map value for this index is already set to the
-	// correct thumbnail value
-	if(currentThumbnailIndexToShow != rowCurrentDisplayedThumbnailMap_.value(itemIndex)) {
-		// if it isn't set it to be the new calculated thumbnail index
-		rowCurrentDisplayedThumbnailMap_.remove(itemIndex);
-		rowCurrentDisplayedThumbnailMap_.insert(itemIndex, currentThumbnailIndexToShow);
+    if(currentThumbnailIndexToShow+1 > thumbnailCount)
+        currentThumbnailIndexToShow = thumbnailCount - 1;
+    // check if the thumbnail map value for this index is already set to the
+    // correct thumbnail value
+    if(currentThumbnailIndexToShow != rowCurrentDisplayedThumbnailMap_.value(itemIndex)) {
+        // if it isn't set it to be the new calculated thumbnail index
+        rowCurrentDisplayedThumbnailMap_.remove(itemIndex);
+        rowCurrentDisplayedThumbnailMap_.insert(itemIndex, currentThumbnailIndexToShow);
 
-		// refresh the thumbnail rectangle
-		QRegion regionForIndex(viewport()->rect());
+        // refresh the thumbnail rectangle
+        QRegion regionForIndex(viewport()->rect());
 
-		setDirtyRegion(regionForIndex);
-	}
+        setDirtyRegion(regionForIndex);
+    }
 }
 
 int AMScanThumbnailGridView::horizontalOffset() const
 {
-	return horizontalScrollBar()->value();
+    return horizontalScrollBar()->value();
 }
 
 bool AMScanThumbnailGridView::isIndexHidden(const QModelIndex &index) const
 {
-	Q_UNUSED(index)
-	return false;
+    Q_UNUSED(index)
+    return false;
 }
 
 QModelIndex AMScanThumbnailGridView::moveCursor(QAbstractItemView::CursorAction cursorAction,
-											Qt::KeyboardModifiers modifiers)
+                                            Qt::KeyboardModifiers modifiers)
 {
-	//STUB
-	Q_UNUSED(cursorAction)
-	Q_UNUSED(modifiers)
-	return QModelIndex();
+    //STUB
+    Q_UNUSED(cursorAction)
+    Q_UNUSED(modifiers)
+    return QModelIndex();
 }
 
 void AMScanThumbnailGridView::setSelection(const QRect &rect, QItemSelectionModel::SelectionFlags command)
 {
-	QList<int> containedCellIndices = geometryManager_->indicesWithin(rect, horizontalOffset(), verticalOffset());
+    QList<int> containedCellIndices = geometryManager_->indicesWithin(rect, horizontalOffset(), verticalOffset());
 
-	if(containedCellIndices.isEmpty())
-		return;
+    if(containedCellIndices.isEmpty())
+        return;
 
-	QItemSelection totalSelectedItems;
+    QItemSelection totalSelectedItems;
 
-	for(int iContainedCell = 0, containedCellCount = containedCellIndices.count();
-		iContainedCell < containedCellCount;
-		++iContainedCell) {
+    for(int iContainedCell = 0, containedCellCount = containedCellIndices.count();
+        iContainedCell < containedCellCount;
+        ++iContainedCell) {
 
-		QModelIndex indexToAdd = model()->index(containedCellIndices.at(iContainedCell),
-												1, QModelIndex());
+        QModelIndex indexToAdd = model()->index(containedCellIndices.at(iContainedCell),
+                                                1, QModelIndex());
 
-		totalSelectedItems.select(indexToAdd, indexToAdd);
-	}
+        totalSelectedItems.select(indexToAdd, indexToAdd);
+    }
 
-	selectionModel()->select(totalSelectedItems, command | QItemSelectionModel::Rows);
+    selectionModel()->select(totalSelectedItems, command | QItemSelectionModel::Rows);
 
 }
 
 int AMScanThumbnailGridView::verticalOffset() const
 {
-	return verticalScrollBar()->value();
+    return verticalScrollBar()->value();
 }
 
 QRegion AMScanThumbnailGridView::visualRegionForSelection(const QItemSelection &selection) const
 {
-	Q_UNUSED(selection)
-	return QRegion(viewport()->rect());
+    Q_UNUSED(selection)
+    return QRegion(viewport()->rect());
 }
 
 void AMScanThumbnailGridView::paintEvent(QPaintEvent *event)
 {
-	QAbstractItemView::paintEvent(event);
+    QAbstractItemView::paintEvent(event);
 
-	QPainter painter(viewport());
+    QPainter painter(viewport());
 
-	// Paint background
-	painter.fillRect(viewport()->rect(), palette().color(QPalette::Normal, QPalette::Window));
+    // Paint background
+    painter.fillRect(viewport()->rect(), palette().color(QPalette::Normal, QPalette::Window));
 
-	QStyleOptionViewItem option = viewOptions();
+    QStyleOptionViewItem option = viewOptions();
 
-	for(int iDataRow = 0; iDataRow < model()->rowCount(); iDataRow++) {
+    for(int iDataRow = 0; iDataRow < model()->rowCount(); iDataRow++) {
 
-		// Paint the scanSerialNumber (we've hijacked this column in the delegate to
-		// paint the background for this item
-		QModelIndex scanSerialIndex = model()->index(iDataRow, 0, QModelIndex());
-		bool isSelected = selectionModel()->isSelected(scanSerialIndex);
-		option.state = isSelected ? QStyle::State_Selected : QStyle::State_Enabled ;
+        // Paint the scanSerialNumber (we've hijacked this column in the delegate to
+        // paint the background for this item
+        QModelIndex scanSerialIndex = model()->index(iDataRow, 0, QModelIndex());
+        bool isSelected = selectionModel()->isSelected(scanSerialIndex);
+        option.state = isSelected ? QStyle::State_Selected : QStyle::State_Enabled ;
 
-        option.rect = visualRect(QModelIndex());
-        itemDelegate()->paint(&painter, option, QModelIndex());
-		int currentThumbnailIndex = 0;
+        //option.rect = visualRect(QModelIndex());
+        //itemDelegate()->paint(&painter, option, QModelIndex());
 
-		if(model()->rowCount(scanSerialIndex) > 0) {
-			currentThumbnailIndex = rowCurrentDisplayedThumbnailMap_.value(scanSerialIndex.row(), 0);
-		}
+        AMScanThumbnailGridViewItemDelegate* itemDelegate_ = qobject_cast<AMScanThumbnailGridViewItemDelegate*>(itemDelegate());
 
-		// Paint the thumbnail
-		QModelIndex scanThumbnailIndex = model()->index(currentThumbnailIndex, 1, scanSerialIndex);
-		option.rect = visualRect(scanThumbnailIndex);
-		itemDelegate()->paint(&painter, option, scanThumbnailIndex);
+        if(!itemDelegate_){
+            return;
+        }
+
+        option.rect = backgroundRect(scanSerialIndex);
+        itemDelegate_->paintItemBackground(&painter, option);
+        int currentThumbnailIndex = 0;
+
+        if(model()->rowCount(scanSerialIndex) > 0) {
+            currentThumbnailIndex = rowCurrentDisplayedThumbnailMap_.value(scanSerialIndex.row(), 0);
+        }
+
+        // Paint the thumbnail
+        QModelIndex scanThumbnailIndex = model()->index(currentThumbnailIndex, 1, scanSerialIndex);
+        option.rect = visualRect(scanThumbnailIndex);
+        itemDelegate()->paint(&painter, option, scanThumbnailIndex);
 
         // Paint the scan index
         QModelIndex scanIDIndex = model()->index(iDataRow, 0, QModelIndex());
         option.rect = visualRect(scanIDIndex);
         itemDelegate()->paint(&painter, option, scanIDIndex);
 
-		// Paint the scan name
+        // Paint the scan name
         QModelIndex scanNameIndex = model()->index(iDataRow, 1, QModelIndex());
         option.rect = visualRect(scanNameIndex);
         itemDelegate()->paint(&painter, option, scanNameIndex);
 
-		// Paint the scan date
-		QModelIndex scanDateIndex = model()->index(iDataRow, 3, QModelIndex());
-		option.rect = visualRect(scanDateIndex);
-		itemDelegate()->paint(&painter, option, scanDateIndex);
+        // Paint the scan date
+        QModelIndex scanDateIndex = model()->index(iDataRow, 3, QModelIndex());
+        option.rect = visualRect(scanDateIndex);
+        itemDelegate()->paint(&painter, option, scanDateIndex);
 
-		// Paint the scan type
-		QModelIndex scanTypeIndex = model()->index(iDataRow, 4, QModelIndex());
-		option.rect = visualRect(scanTypeIndex);
-		itemDelegate()->paint(&painter, option, scanTypeIndex);
+        // Paint the scan type
+        QModelIndex scanTypeIndex = model()->index(iDataRow, 4, QModelIndex());
+        option.rect = visualRect(scanTypeIndex);
+        itemDelegate()->paint(&painter, option, scanTypeIndex);
 
-		// paint the thumbnail title
-		QModelIndex thumbnailTitleIndex = model()->index(currentThumbnailIndex, 2, scanSerialIndex);
-		option.rect = visualRect(thumbnailTitleIndex);
-		itemDelegate()->paint(&painter, option, thumbnailTitleIndex);
-	}
+        // paint the thumbnail title
+        QModelIndex thumbnailTitleIndex = model()->index(currentThumbnailIndex, 2, scanSerialIndex);
+        option.rect = visualRect(thumbnailTitleIndex);
+        itemDelegate()->paint(&painter, option, thumbnailTitleIndex);
+    }
 
 }
 
 void AMScanThumbnailGridView::resizeEvent(QResizeEvent *event)
 {
-	QAbstractItemView::resizeEvent(event);
-	geometryManager_->setWidth(viewport()->width());
-	updateScrollBars();
+    QAbstractItemView::resizeEvent(event);
+    geometryManager_->setWidth(viewport()->width());
+    updateScrollBars();
 }
 
 void AMScanThumbnailGridView::mousePressEvent(QMouseEvent *event)
 {
-	int indexOfItemUnderMouse = geometryManager_->contentIndexAt(event->pos(), horizontalOffset(), verticalOffset());
-	bool itemIsSelected = selectionModel()->isRowSelected(indexOfItemUnderMouse, QModelIndex());
-	inputManager_->mouseDownAt(indexOfItemUnderMouse, event->pos().x(), event->pos().y(), event->buttons(), itemIsSelected);
+    int indexOfItemUnderMouse = geometryManager_->contentIndexAt(event->pos(), horizontalOffset(), verticalOffset());
+    bool itemIsSelected = selectionModel()->isRowSelected(indexOfItemUnderMouse, QModelIndex());
+    inputManager_->mouseDownAt(indexOfItemUnderMouse, event->pos().x(), event->pos().y(), event->buttons(), itemIsSelected);
 }
 
 void AMScanThumbnailGridView::mouseMoveEvent(QMouseEvent *event)
 {
-	inputManager_->mouseMovedTo(geometryManager_->contentIndexAt(event->pos(), horizontalOffset(), verticalOffset()),
-								event->pos().x(), event->pos().y(), event->buttons());
+    inputManager_->mouseMovedTo(geometryManager_->contentIndexAt(event->pos(), horizontalOffset(), verticalOffset()),
+                                event->pos().x(), event->pos().y(), event->buttons());
 }
 
 
 void AMScanThumbnailGridView::mouseReleaseEvent(QMouseEvent *event)
 {
 
-	inputManager_->mouseReleasedAt(event->pos().x(), event->pos().y(), event->buttons(), event->modifiers());
+    inputManager_->mouseReleasedAt(event->pos().x(), event->pos().y(), event->buttons(), event->modifiers());
 }
 
 void AMScanThumbnailGridView::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
-	updateScrollBars();
-	rowCurrentDisplayedThumbnailMap_.clear();
-	viewport()->update();
-	QAbstractItemView::dataChanged(topLeft, bottomRight);
+    updateScrollBars();
+    rowCurrentDisplayedThumbnailMap_.clear();
+    viewport()->update();
+    QAbstractItemView::dataChanged(topLeft, bottomRight);
 }
 
 void AMScanThumbnailGridView::rowsInserted(const QModelIndex &parent, int start, int end)
 {
-	viewport()->update();
-	rowCurrentDisplayedThumbnailMap_.clear();
-	QAbstractItemView::rowsInserted(parent, start, end);
+    viewport()->update();
+    rowCurrentDisplayedThumbnailMap_.clear();
+    QAbstractItemView::rowsInserted(parent, start, end);
 }
 
 void AMScanThumbnailGridView::rowsAboutToBeRemoved(const QModelIndex &parent, int start, int end)
 {
-	viewport()->update();
-	rowCurrentDisplayedThumbnailMap_.clear();
-	QAbstractItemView::rowsAboutToBeRemoved(parent, start, end);
+    viewport()->update();
+    rowCurrentDisplayedThumbnailMap_.clear();
+    QAbstractItemView::rowsAboutToBeRemoved(parent, start, end);
 }
 
 void AMScanThumbnailGridView::updateScrollBars()
 {
 
-	if(!model()) {
-		verticalScrollBar()->setVisible(false);
-		return;
-	}
+    if(!model()) {
+        verticalScrollBar()->setVisible(false);
+        return;
+    }
 
-	verticalScrollBar()->setVisible(true);
-	int currentGeometryHeight = geometryManager_->heightFor(model()->rowCount());
+    verticalScrollBar()->setVisible(true);
+    int currentGeometryHeight = geometryManager_->heightFor(model()->rowCount());
 
-	if(currentGeometryHeight < verticalOffset())
-		verticalScrollBar()->setValue(0);
+    if(currentGeometryHeight < verticalOffset())
+        verticalScrollBar()->setValue(0);
 
-	verticalScrollBar()->setMaximum(currentGeometryHeight);
-	verticalScrollBar()->setSingleStep(15);
-	verticalScrollBar()->setPageStep(geometryManager_->cellHeight());
+    verticalScrollBar()->setMaximum(currentGeometryHeight);
+    verticalScrollBar()->setSingleStep(15);
+    verticalScrollBar()->setPageStep(geometryManager_->cellHeight());
 }
 
 

--- a/source/ui/dataman/AMScanThumbnailGridView.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridView.cpp
@@ -53,11 +53,7 @@ QRect AMScanThumbnailGridView::visualRect(const QModelIndex &index) const
 {
 
     QRect rowContentRect;
-    /*
-    if(!index.isValid()){
-        return rowContentRect ;
-    }
-    */
+
     if(index.parent().isValid()) {
         // is  a thumbnail
         rowContentRect = geometryManager_->contentGeometryAt(index.parent().row(),

--- a/source/ui/dataman/AMScanThumbnailGridView.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridView.cpp
@@ -65,21 +65,24 @@ QRect AMScanThumbnailGridView::visualRect(const QModelIndex &index) const
 															 verticalOffset());
 	}
 
+    if(!index.isValid()){
+        return rowContentRect;
+    }
+
 	if(!index.parent().isValid()) {
 		// Is Scan
 		switch(index.column()) {
 		case 0:
-			return rowContentRect;
-		case 1:
-			return geometryManager_->scanNameRectangle(rowContentRect);
+            return geometryManager_->scanSerialRectangle(rowContentRect);
+        case 1:
+            return geometryManager_->scanNameRectangle(rowContentRect);
 		case 3:
 			return geometryManager_->scanDateRectangle(rowContentRect);
-
 		case 4:
 			return geometryManager_->scanTechniqueRectangle(rowContentRect);
 
 		default:
-			return QRect();
+            return QRect();
 		}
 	} else {
 		// Is Thumbnail
@@ -311,8 +314,8 @@ void AMScanThumbnailGridView::paintEvent(QPaintEvent *event)
 		bool isSelected = selectionModel()->isSelected(scanSerialIndex);
 		option.state = isSelected ? QStyle::State_Selected : QStyle::State_Enabled ;
 
-		option.rect = visualRect(scanSerialIndex);
-		itemDelegate()->paint(&painter, option, scanSerialIndex);
+        option.rect = visualRect(QModelIndex());
+        itemDelegate()->paint(&painter, option, QModelIndex());
 		int currentThumbnailIndex = 0;
 
 		if(model()->rowCount(scanSerialIndex) > 0) {
@@ -324,10 +327,15 @@ void AMScanThumbnailGridView::paintEvent(QPaintEvent *event)
 		option.rect = visualRect(scanThumbnailIndex);
 		itemDelegate()->paint(&painter, option, scanThumbnailIndex);
 
+        // Paint the scan index
+        QModelIndex scanIDIndex = model()->index(iDataRow, 0, QModelIndex());
+        option.rect = visualRect(scanIDIndex);
+        itemDelegate()->paint(&painter, option, scanIDIndex);
+
 		// Paint the scan name
-		QModelIndex scanNameIndex = model()->index(iDataRow, 1, QModelIndex());
-		option.rect = visualRect(scanNameIndex);
-		itemDelegate()->paint(&painter, option, scanNameIndex);
+        QModelIndex scanNameIndex = model()->index(iDataRow, 1, QModelIndex());
+        option.rect = visualRect(scanNameIndex);
+        itemDelegate()->paint(&painter, option, scanNameIndex);
 
 		// Paint the scan date
 		QModelIndex scanDateIndex = model()->index(iDataRow, 3, QModelIndex());

--- a/source/ui/dataman/AMScanThumbnailGridView.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridView.cpp
@@ -321,21 +321,19 @@ void AMScanThumbnailGridView::paintEvent(QPaintEvent *event)
 
     for(int iDataRow = 0; iDataRow < model()->rowCount(); iDataRow++) {
 
-        // Paint the scanSerialNumber (we've hijacked this column in the delegate to
-        // paint the background for this item
+        // Paint the scanSerialNumber, not highjacking serial number to paint background now.
+        // Background is generated independent of the modelindex.
         QModelIndex scanSerialIndex = model()->index(iDataRow, 0, QModelIndex());
         bool isSelected = selectionModel()->isSelected(scanSerialIndex);
         option.state = isSelected ? QStyle::State_Selected : QStyle::State_Enabled ;
 
-        //option.rect = visualRect(QModelIndex());
-        //itemDelegate()->paint(&painter, option, QModelIndex());
-
+        // To call the paintItemBackground function directly itemDelegate() is typecast to a member variable.
         AMScanThumbnailGridViewItemDelegate* itemDelegate_ = qobject_cast<AMScanThumbnailGridViewItemDelegate*>(itemDelegate());
 
         if(!itemDelegate_){
             return;
         }
-
+        // Create and paint background rectangle.
         option.rect = backgroundRect(scanSerialIndex);
         itemDelegate_->paintItemBackground(&painter, option);
         int currentThumbnailIndex = 0;

--- a/source/ui/dataman/AMScanThumbnailGridView.h
+++ b/source/ui/dataman/AMScanThumbnailGridView.h
@@ -42,9 +42,10 @@ public:
 	QRect visualRect(const QModelIndex &index) const;
 
     /**
-      * Returns a rectangle in which the visual representation of the data contained
-      * at the provided index is contains
-      * @param index::QModelIndex ~ The index whose visual geometry is to be returned
+      * Returns a rectangle in which the visual representation for the background
+      * of the data at the provided index.
+      * @param index::QModelIndex ~ The index whose background visual geometry is to
+      * be returned
       */
     QRect backgroundRect(const QModelIndex &index) const;
 

--- a/source/ui/dataman/AMScanThumbnailGridView.h
+++ b/source/ui/dataman/AMScanThumbnailGridView.h
@@ -41,6 +41,13 @@ public:
 	  */
 	QRect visualRect(const QModelIndex &index) const;
 
+    /**
+      * Returns a rectangle in which the visual representation of the data contained
+      * at the provided index is contains
+      * @param index::QModelIndex ~ The index whose visual geometry is to be returned
+      */
+    QRect backgroundRect(const QModelIndex &index) const;
+
 	/**
 	  * Scrolls the view to ensure that the visual representation of the provided
 	  * index is visible.

--- a/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.cpp
@@ -11,17 +11,21 @@ void AMScanThumbnailGridViewItemDelegate::paint(QPainter *painter,
 												const QModelIndex &index) const
 {
 
-	if(option.rect.isEmpty() || !index.isValid())
+    if(option.rect.isEmpty())
 		return;
 
 	painter->save();
+
+    if(!index.isValid()) {
+        paintItemBackground(painter, option);
+    }
 
 	if(!index.parent().isValid()) {
 		// Is a scan
 
 		switch (index.column()) {
 		case 0:
-			paintItemBackground(painter, option);
+            paintText(painter, option, index.data(Qt::DisplayRole).toString());
 			break;
 		case 1:
 			paintText(painter, option, index.data(Qt::DisplayRole).toString());

--- a/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.cpp
@@ -11,7 +11,7 @@ void AMScanThumbnailGridViewItemDelegate::paint(QPainter *painter,
 												const QModelIndex &index) const
 {
 
-    if(option.rect.isEmpty())
+    if(option.rect.isEmpty() || !index.isValid())
 		return;
 
     painter->save();

--- a/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.cpp
+++ b/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.cpp
@@ -14,14 +14,10 @@ void AMScanThumbnailGridViewItemDelegate::paint(QPainter *painter,
     if(option.rect.isEmpty())
 		return;
 
-	painter->save();
+    painter->save();
 
-    if(!index.isValid()) {
-        paintItemBackground(painter, option);
-    }
-
-	if(!index.parent().isValid()) {
-		// Is a scan
+   if(!index.parent().isValid()) {
+        // Is a scan
 
 		switch (index.column()) {
 		case 0:
@@ -37,7 +33,7 @@ void AMScanThumbnailGridViewItemDelegate::paint(QPainter *painter,
 		case 4:
 			paintText(painter, option, index.data(Qt::DisplayRole).toString());
 			break;
-		default:
+        default:
 			break;
 		}
 
@@ -85,7 +81,7 @@ void AMScanThumbnailGridViewItemDelegate::paintText(QPainter *painter,
 void AMScanThumbnailGridViewItemDelegate::paintItemBackground(QPainter *painter, const QStyleOptionViewItem &option) const
 {
 
-	if(option.state & QStyle::State_Selected) {
+    if(option.state & QStyle::State_Selected) {
 		painter->setBrush(option.palette.brush(QPalette::Normal, QPalette::Highlight));
 	} else {
 		painter->setBrush(QBrush(Qt::white));

--- a/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.h
+++ b/source/ui/dataman/AMScanThumbnailGridViewItemDelegate.h
@@ -27,9 +27,19 @@ public:
 	/// Paints the data associated with the provided index according to options stored in the given
 	/// StyleOptionViewItem
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
 signals:
-	
+
 public slots:
+
+    /**
+     * Helper method which paints the background for each item
+     * @param painter::QPainter ~ The painter with which to draw the background
+     * @param option::QStyleOptionViewItem ~ The options which determine the style
+     * of the item to draw
+     */
+    void paintItemBackground(QPainter* painter, const QStyleOptionViewItem &option) const;
+
 protected:
 
 	/**
@@ -52,13 +62,6 @@ protected:
 	void paintText(QPainter* painter, const QStyleOptionViewItem &option,
 				   const QString& string) const;
 
-	/**
-	 * Helper method which paints the background for each item
-	 * @param painter::QPainter ~ The painter with which to draw the background
-	 * @param option::QStyleOptionViewItem ~ The options which determine the style
-	 * of the item to draw
-	 */
-	void paintItemBackground(QPainter* painter, const QStyleOptionViewItem &option) const;
 };
 
 #endif // AMSCANTHUMBNAILGRIDVIEWITEMDELEGATE_H


### PR DESCRIPTION
Added method to generate a QRect for the serial number. Adjusted name rectangle so it was shifted to the right so that the serial could paint in front of it. Added calls to paint serial along with other elements.

Since the serial QModelIndex value was used to paint the background previously, new methods had to be added to generate a rectangle for the scan item background and paint it, apart from the functions dependent on the model index values.