### PR TITLE
Pull Request for Issue2299: Adding option to display dead time buttons with count rate.

### DIFF
--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -134,6 +134,9 @@ public:
 	/// Returns the ICR control at the given index, returns 0 if index is invalid.
 	AMControl* icrControlAt(int index) const;
 
+	/// Returns the acquire time control.
+	AMControl* acquireTimeControl() const { return acquireTimeControl_; }
+
 public slots:
 	/// Set the acquisition dwell time for triggered (RequestRead) detectors
 	virtual bool setAcquisitionTime(double seconds);

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -166,16 +166,16 @@ void AMDeadTimeButton::updateColorState()
 
 void AMDeadTimeButton::updateToolTip()
 {
-	if (countsMode_ == None)
-		setToolTip("");
-	else if (countsMode_ == Percent && canDisplayPercentage())
-		setToolTip(QString("%1%").arg(getPercent(), 0, 'f', 0));
-	else if (countsMode_ == Counts && canDisplayCounts())
-		setToolTip(QString("%1 counts").arg(getCounts()));
-	else if (countsMode_ == CountRate && canDisplayCountRate())
-		setToolTip(QString("%1 counts/s").arg(getCountRate()));
+	QString toolTip = "";
 
-	update();
+	if (countsMode_ == Percent && canDisplayPercentage())
+		toolTip = QString("%1%").arg(getPercent(), 0, 'f', 0);
+	else if (countsMode_ == Counts && canDisplayCounts())
+		toolTip = QString("%1 counts").arg(getCounts());
+	else if (countsMode_ == CountRate && canDisplayCountRate())
+		toolTip = QString("%1 counts/s").arg(getCountRate());
+
+	setToolTip(toolTip);
 }
 
 bool AMDeadTimeButton::hasDeadTimeSources() const
@@ -197,7 +197,7 @@ double AMDeadTimeButton::getPercent() const
 {
 	double result = 0;
 
-	if (canDisplayPercentage())
+	if (outputCountSource_ && inputCountSource_)
 		result = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
 
 	return result;
@@ -207,7 +207,7 @@ double AMDeadTimeButton::getCounts() const
 {
 	double result = 0;
 
-	if (canDisplayCounts())
+	if (inputCountSource_)
 		result = double(inputCountSource_->value(AMnDIndex()));
 
 	return result;
@@ -217,7 +217,7 @@ double AMDeadTimeButton::getCountRate() const
 {
 	double result = 0;
 
-	if (canDisplayCountRate())
+	if (inputCountSource_ && acquireTimeControl_)
 		result = double(inputCountSource_->value(AMnDIndex())) / acquireTimeControl_->value();
 
 	return result;
@@ -227,7 +227,7 @@ double AMDeadTimeButton::getAcquireTime() const
 {
 	double result = 0;
 
-	if (hasAcquireTime())
+	if (acquireTimeControl_)
 		result = acquireTimeControl_->value();
 
 	return result;

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -20,6 +20,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "AMDeadTimeButton.h"
+#include "beamline/AMControl.h"
 
 AMDeadTimeButton::AMDeadTimeButton(QWidget *parent)
 	: AMToolButton(parent)
@@ -28,17 +29,19 @@ AMDeadTimeButton::AMDeadTimeButton(QWidget *parent)
 	outputCountSource_ = 0;
 	goodReferencePoint_ = 0;
 	badReferencePoint_ = 0;
-	displayPercent_ = true;
+	countsMode_ = Percent;
+	acquireTimeControl_ = 0;
 }
 
-AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, bool displayPercent, QWidget *parent)
+AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, CountsMode countsMode, QWidget *parent)
 	: AMToolButton(parent)
 {
 	inputCountSource_ = 0;
 	outputCountSource_ = 0;
 	goodReferencePoint_ = goodReferencePoint;
 	badReferencePoint_ = badReferencePoint;
-	displayPercent_ = displayPercent;
+	countsMode_ = countsMode;
+	acquireTimeControl_ = 0;
 
 	setDeadTimeSources(inputCountSource, outputCountSource);
 }
@@ -46,6 +49,21 @@ AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource 
 AMDeadTimeButton::~AMDeadTimeButton()
 {
 
+}
+
+bool AMDeadTimeButton::canDisplayPercentage() const
+{
+	return hasDeadTimeSources();
+}
+
+bool AMDeadTimeButton::canDisplayCounts() const
+{
+	return hasICRDataSource();
+}
+
+bool AMDeadTimeButton::canDisplayCountRate() const
+{
+	return hasICRDataSource() && hasAcquireTime();
 }
 
 void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMDataSource *outputCountSource)
@@ -89,10 +107,31 @@ void AMDeadTimeButton::setBadReferencePoint(double newReference)
 	updateColorState();
 }
 
-void AMDeadTimeButton::setDisplayAsPercent(bool showPercent)
+void AMDeadTimeButton::setCountsMode(CountsMode newMode)
 {
-	displayPercent_ = showPercent;
+	countsMode_ = newMode;
 	updateToolTip();
+}
+
+void AMDeadTimeButton::setAcquireTimeControl(AMControl *newControl)
+{
+	if (acquireTimeControl_ != newControl) {
+
+		if (acquireTimeControl_)
+			disconnect( acquireTimeControl_, 0, this, 0 );
+
+		acquireTimeControl_ = newControl;
+
+		if (acquireTimeControl_) {
+			connect( acquireTimeControl_, SIGNAL(connected(bool)), this, SLOT(updateColorState()) );
+			connect( acquireTimeControl_, SIGNAL(connected(bool)), this, SLOT(updateToolTip()) );
+			connect( acquireTimeControl_, SIGNAL(valueChanged(double)), this, SLOT(updateColorState()) );
+			connect( acquireTimeControl_, SIGNAL(valueChanged(double)), this, SLOT(updateToolTip()) );
+		}
+
+		updateColorState();
+		updateToolTip();
+	}
 }
 
 void AMDeadTimeButton::updateColorState()
@@ -105,10 +144,12 @@ void AMDeadTimeButton::updateColorState()
 
 		double newValue = badReferencePoint_;
 
-		if (hasDeadTimeSources())
-			newValue = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
-		else if (hasICRDataSource())
-			newValue = double(inputCountSource_->value(AMnDIndex()));
+		if (countsMode_ == Percent && canDisplayPercentage())
+			newValue = getPercent();
+		else if (countsMode_ == Counts && canDisplayCounts())
+			newValue = getCounts();
+		else if (countsMode_ == CountRate && canDisplayCountRate())
+			newValue = getCountRate();
 
 		// Identify the new color state.
 
@@ -125,10 +166,14 @@ void AMDeadTimeButton::updateColorState()
 
 void AMDeadTimeButton::updateToolTip()
 {
-	if (displayPercent_ && inputCountSource_ && outputCountSource_)
-		setToolTip(QString("%1%").arg(100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex()))), 0, 'f', 0));
-	else if (!displayPercent_ && inputCountSource_)
-		setToolTip(QString("%1 counts").arg(double(inputCountSource_->value(AMnDIndex()))));
+	if (countsMode_ == None)
+		setToolTip("");
+	else if (countsMode_ == Percent && canDisplayPercentage())
+		setToolTip(QString("%1%").arg(getPercent(), 0, 'f', 0));
+	else if (countsMode_ == Counts && canDisplayCounts())
+		setToolTip(QString("%1 counts").arg(getCounts()));
+	else if (countsMode_ == CountRate && canDisplayCountRate())
+		setToolTip(QString("%1 counts/s").arg(getCountRate()));
 
 	update();
 }
@@ -141,4 +186,49 @@ bool AMDeadTimeButton::hasDeadTimeSources() const
 bool AMDeadTimeButton::hasICRDataSource() const
 {
 	return !(inputCountSource_ == 0);
+}
+
+bool AMDeadTimeButton::hasAcquireTime() const
+{
+	return !(acquireTimeControl_ == 0);
+}
+
+double AMDeadTimeButton::getPercent() const
+{
+	double result = 0;
+
+	if (canDisplayPercentage())
+		result = 100*(1 - double(outputCountSource_->value(AMnDIndex()))/double(inputCountSource_->value(AMnDIndex())));
+
+	return result;
+}
+
+double AMDeadTimeButton::getCounts() const
+{
+	double result = 0;
+
+	if (canDisplayCounts())
+		result = double(inputCountSource_->value(AMnDIndex()));
+
+	return result;
+}
+
+double AMDeadTimeButton::getCountRate() const
+{
+	double result = 0;
+
+	if (canDisplayCountRate())
+		result = double(inputCountSource_->value(AMnDIndex())) / acquireTimeControl_->value();
+
+	return result;
+}
+
+double AMDeadTimeButton::getAcquireTime() const
+{
+	double result = 0;
+
+	if (hasAcquireTime())
+		result = acquireTimeControl_->value();
+
+	return result;
 }

--- a/source/ui/beamline/AMDeadTimeButton.h
+++ b/source/ui/beamline/AMDeadTimeButton.h
@@ -25,18 +25,30 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/AMToolButton.h"
 #include "dataman/datasource/AMDataSource.h"
 
+class AMControl;
+
 /// This class takes a data source (expected to be the dead time) and changes the color based on the current value and the chosen reference positions.  The expected behaviour is anything below the "good" setpoint is green, anything above the "bad" setpoint is red, and everything else is yellow.
 class AMDeadTimeButton : public AMToolButton
 {
 	Q_OBJECT
 
 public:
+	/// Enumeration of different ways of displaying counts information.
+	enum CountsMode { None = 0, Percent = 1, Counts = 2, CountRate = 3 };
+
 	/// Constructor.  Makes a default button with no changing other than looking disabled.
 	AMDeadTimeButton(QWidget *parent = 0);
 	/// Constructor.  Takes two data sources (the data source is assumed to have rank 0), one for the input counts and one for the output counts, the good reference point, and the bad reference point.
-	AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, bool displayPercent = true, QWidget *parent = 0);
+	AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, CountsMode CountsMode = Percent, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~AMDeadTimeButton();
+
+	/// Returns true if this button can display counts information as a percentage.
+	bool canDisplayPercentage() const;
+	/// Returns true if this button can display counts information.
+	bool canDisplayCounts() const;
+	/// Returns true if this button can display counts information as a count rate.
+	bool canDisplayCountRate() const;
 
 	/// Returns the input count source.
 	AMDataSource* inputCountSource() const { return inputCountSource_; }
@@ -45,7 +57,11 @@ public:
 	/// Returns the good reference point currently used by this button.
 	double goodReferencePoint() const { return goodReferencePoint_; }
 	/// Returns the bad reference point currently used by this button.
-	double badReferencecPoint() const { return badReferencePoint_; }
+	double badReferencePoint() const { return badReferencePoint_; }
+	/// Returns the display mode.
+	CountsMode countsMode() const { return countsMode_; }
+	/// Returns the acquire time control.
+	AMControl* acquireTimeControl() const { return acquireTimeControl_; }
 
 public slots:
 	/// Sets a new data source for the dead time (the data source is assumed to have rank 0).  Sources can be 0/null pointers.
@@ -54,8 +70,10 @@ public slots:
 	void setGoodReferencePoint(double newReference);
 	/// Sets the bad reference point.
 	void setBadReferencePoint(double newReference);
-	/// Sets the flag indicating whether to display dead time as percent (or counts).
-	void setDisplayAsPercent(bool showPercent);
+	/// Sets the display mode.
+	void setCountsMode(CountsMode newMode);
+	/// Sets the acquire time control.
+	void setAcquireTimeControl(AMControl *newControl);
 
 protected slots:
 	/// Updates the color state.
@@ -68,7 +86,19 @@ protected:
 	bool hasDeadTimeSources() const;
 	/// Helper method that returns whether there is a valid ICR data source.
 	bool hasICRDataSource() const;
+	/// Helper method that returns whether there is a valid acquisition time.
+	bool hasAcquireTime() const;
 
+	/// Returns the counts as a percentage. Returns 0 if either the input or the output count source are invalid.
+	double getPercent() const;
+	/// Returns the counts. Returns 0 if the input count source is invalid.
+	double getCounts() const;
+	/// Returns the count rate. Returns 0 if the input count source or the time control are invalid.
+	double getCountRate() const;
+	/// Returns the acquire time. Returns 0 if the acquire time control is invalid.
+	double getAcquireTime() const;
+
+protected:
 	/// The data source that holds the input counts.
 	AMDataSource *inputCountSource_;
 	/// The data source that holds the output counts.
@@ -77,8 +107,10 @@ protected:
 	double goodReferencePoint_;
 	/// The bad reference point.
 	double badReferencePoint_;
-	/// The flag indicating whether to display dead time as percent (or counts).
-	bool displayPercent_;
+	/// The counts display mode.
+	CountsMode countsMode_;
+	/// The acquire time control.
+	AMControl *acquireTimeControl_;
 };
 
 #endif // AMDEADTIMEBUTTON_H

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -129,10 +129,14 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 
 		for (int i = 0, elements = detector_->elements(); i < elements; i++){
 
-			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), 0, 300000, 1000000, false);
+			AMDeadTimeButton *deadTimeButton = new AMDeadTimeButton(detector_->inputCountSourceAt(i), 0, 300000, 1000000, AMDeadTimeButton::CountRate);
 			deadTimeButton->setCheckable(true);
+			deadTimeButton->setAcquireTimeControl(detector_->acquireTimeControl());
 			deadTimeButton->setChecked(detector_->isElementDisabled(i)); // Elements are disabled by checking the corresponding toolbutton.
 			deadTimeButton->setEnabled(detector_->canEnableElement(i)); // Elements that are not enabled initially will always be disabled (ie. permanently disabled elements).
+			if (!detector_->canEnableElement(i))
+				deadTimeButton->setCountsMode(AMDeadTimeButton::None);
+
 			deadTimeButtonLayout->addWidget(deadTimeButton, int(i/deadTimeViewFactor_), i%deadTimeViewFactor_);
 			deadTimeButtons_->addButton(deadTimeButton, i);
 		}


### PR DESCRIPTION
Added getter to AMXRFDetector for the acquire time control. For the Xspress3 detectors on BioXAS, this control is the Zebra pulse width (in seconds) pseudomotor control. Modified AMDeadTimeButton to have a couple of different CountMode options: can view the counts information as a percentage, as flat counts, or as a count rate provided the button has the appropriate resources. Modified AMXRFDetailedDetectorView to use the new AMDeadTimeButton display changes.