### PR TITLE
PullRequest for Issue2305 add 'Ma1' to the exporter regular expression

### DIFF
--- a/source/application/SXRMB/SXRMB.h
+++ b/source/application/SXRMB/SXRMB.h
@@ -141,7 +141,7 @@ namespace SXRMB {
 		sxrmbExporterOption->setSeparateHigherDimensionalSources(true);
 		sxrmbExporterOption->setSeparateSectionFileName("$name_$dataSetName_$fsIndex.dat");
 		sxrmbExporterOption->setHigherDimensionsInRows(exportSpectraInRows);
-		sxrmbExporterOption->setRegExpString("^\\w{1,2}Ka1|^\\w{1,2}Kb1|^\\w{1,2}La1|^\\w{1,2}Lb1|^\\w{1,2}Lg1|I0Detector|TEYDetector");
+		sxrmbExporterOption->setRegExpString("^\\w{1,2}Ka1|^\\w{1,2}Kb1|^\\w{1,2}La1|^\\w{1,2}Lb1|^\\w{1,2}Lg1|^\\w{1,2}Ma1|I0Detector|TEYDetector");
 		sxrmbExporterOption->storeToDb(AMDatabase::database("user"));
 
 		return sxrmbExporterOption;


### PR DESCRIPTION
As mentioned in #2305, when user chose Hg Ma1 as ROI, the corresponding data will be missing from the SMAK exported file. 

The reason for that is we didn't include the "Ma1" in the SMAK exporter regex at the first page. It is added now.