### PR TITLE
Pull Request for Issue2307: Solving problem with acquisition state.

### DIFF
--- a/source/beamline/AMXRFDetector.h
+++ b/source/beamline/AMXRFDetector.h
@@ -65,6 +65,8 @@ public:
 	virtual int type() { return -1; }
 	/// Returns the number of elements in the detector.
 	int elements() const { return rawSpectraSources_.size(); }
+	/// Returns the number of enabled elements in the detector.
+	int enabledElements() const { return enabledElements_.size(); }
 	/// Returns the current acquisition dwell time from the integration time control
 	virtual double acquisitionTime() const;
 	/// Returns the acquisition time tolerance.  Used for automatic setting that should be re-implemented if you have specific requirements.

--- a/source/beamline/AMXspress3XRFDetector.cpp
+++ b/source/beamline/AMXspress3XRFDetector.cpp
@@ -96,7 +96,7 @@ void AMXspress3XRFDetector::updateAcquisitionState()
 	else if (!isAcquiring() && acquisitionStatusControl_->withinTolerance(1) && acquireControl_->withinTolerance(1)){
 
 		dataReady_ = false;
-		dataReadyCounter_ = elements();
+		dataReadyCounter_ = enabledElements();
 		setAcquiring();
 	}
 


### PR DESCRIPTION
Added getter to AMXRFDetector that returns the number of enabled elements. Added call to this getter to AMXspress3XRFDetector, replacing the old call to elements() when updating the acquisition state. Waiting on all elements to update was causing the acquisition to hang, because the wait is for enabled and disabled elements. Should only consider enabled elements.