### PR TITLE
Pull Request for Issue2329: 2D maps last line overwriting first line

### DIFF
--- a/source/dataman/AMScanAxisRegion.cpp
+++ b/source/dataman/AMScanAxisRegion.cpp
@@ -106,7 +106,7 @@ void AMScanAxisRegion::setRegionTime(const AMNumber &regionTime)
 
 int AMScanAxisRegion::numberOfPoints() const
 {
-	return int((double(regionEnd()) - double(regionStart()))/double(regionStep()) + 1);
+	return qRound((double(regionEnd()) - double(regionStart()))/double(regionStep()) + 1);
 }
 
 double AMScanAxisRegion::timePerRegion() const


### PR DESCRIPTION
Fixed the overwriting data issue.  AMScanAxisRegion was truncating values by casting them to integers rather than rounding the result.