### PR TITLE
Pull Request for Issue2343: Modifying limits functionality in BioXASControlEditor

### DIFF
--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -265,3 +265,9 @@ SOURCES += \
 	source/beamline/BioXAS/BioXASMainZebra.cpp \
 	source/ui/BioXAS/BioXASZebraOutputControlView.cpp \
 	source/ui/BioXAS/BioXASValueSetpointEditor.cpp
+
+OTHER_FILES += \
+	source/stylesheets/BioXAS/BioXASValueSetpointEditor.qss
+
+RESOURCES += \
+	source/stylesheets/BioXAS/BioXASStylesheets.qrc

--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -135,7 +135,8 @@ HEADERS += \
 	source/beamline/BioXAS/BioXASSideZebra.h \
 	source/beamline/BioXAS/BioXASMainZebra.h \
 	source/ui/BioXAS/BioXASZebraOutputControlView.h \
-	source/ui/BioXAS/BioXASValueSetpointEditor.h
+	source/ui/BioXAS/BioXASValueSetpointEditor.h \
+	source/ui/BioXAS/BioXASValueSetpointEditorDialog.h
 
 SOURCES += \
 	source/beamline/BioXAS/BioXASPseudoMotorControl.cpp \
@@ -264,7 +265,8 @@ SOURCES += \
 	source/beamline/BioXAS/BioXASSideZebra.cpp \
 	source/beamline/BioXAS/BioXASMainZebra.cpp \
 	source/ui/BioXAS/BioXASZebraOutputControlView.cpp \
-	source/ui/BioXAS/BioXASValueSetpointEditor.cpp
+	source/ui/BioXAS/BioXASValueSetpointEditor.cpp \
+	source/ui/BioXAS/BioXASValueSetpointEditorDialog.cpp
 
 OTHER_FILES += \
 	source/stylesheets/BioXAS/BioXASValueSetpointEditor.qss

--- a/bioxasCommon.pri
+++ b/bioxasCommon.pri
@@ -134,7 +134,8 @@ HEADERS += \
 	source/beamline/BioXAS/BioXASZebraOutputControl.h \
 	source/beamline/BioXAS/BioXASSideZebra.h \
 	source/beamline/BioXAS/BioXASMainZebra.h \
-	source/ui/BioXAS/BioXASZebraOutputControlView.h
+	source/ui/BioXAS/BioXASZebraOutputControlView.h \
+	source/ui/BioXAS/BioXASValueSetpointEditor.h
 
 SOURCES += \
 	source/beamline/BioXAS/BioXASPseudoMotorControl.cpp \
@@ -262,4 +263,5 @@ SOURCES += \
 	source/beamline/BioXAS/BioXASZebraOutputControl.cpp \
 	source/beamline/BioXAS/BioXASSideZebra.cpp \
 	source/beamline/BioXAS/BioXASMainZebra.cpp \
-	source/ui/BioXAS/BioXASZebraOutputControlView.cpp
+	source/ui/BioXAS/BioXASZebraOutputControlView.cpp \
+	source/ui/BioXAS/BioXASValueSetpointEditor.cpp

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -155,9 +155,6 @@ AMDatamanAppController::AMDatamanAppController(QObject *parent) :
 	finishedSender_ = 0;
 	resetFinishedSignal(this, SIGNAL(datamanStartupFinished()));
 
-	// Apply stylesheets.
-	applyStylesheets();
-
 	// Prepend the AM upgrade 1.1 to the list for the user database
 	AMDbUpgrade *am1Pt1UserDb = new AMDbUpgrade1Pt1("user", this);
 	prependDatabaseUpgrade(am1Pt1UserDb);
@@ -928,6 +925,9 @@ bool AMDatamanAppController::startupCreateUserInterface()
 	issueSubmissionView_ = 0;
 
 	scanEditorCloseView_ = 0;
+
+	// Apply stylesheets.
+	applyStylesheets();
 
 	//Create the main tab window:
 	mw_ = new AMMainWindow();

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -780,6 +780,36 @@ void AMDatamanAppController::launchScanConfigurationFromDb(const QUrl &url)
 	}
 }
 
+QString AMDatamanAppController::getStylesheet() const
+{
+	// Go through list of stylesheets to be applied,
+	// composing a 'master' sheet.
+
+	QString stylesheet;
+
+	// AMToolButton
+
+	QFile qss1(":/AMToolButton.qss");
+
+	if (qss1.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss1.readAll())));
+
+	qss1.close();
+
+	// AMDeadTimeButton
+
+	QFile qss2(":/AMDeadTimeButton.qss");
+
+	if (qss2.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss2.readAll())));
+
+	qss2.close();
+
+	// Return master sheet.
+
+	return stylesheet;
+}
+
 bool AMDatamanAppController::startupRegisterDatabases()
 {
 	AMErrorMon::information(this, AMDATAMANAPPCONTROLLER_STARTUP_MESSAGES, "Acquaman Startup: Registering Databases");
@@ -1198,32 +1228,7 @@ void AMDatamanAppController::onActionIssueSubmission()
 
 void AMDatamanAppController::applyStylesheets()
 {
-	// Go through list of stylesheets to be applied,
-	// composing a 'master' sheet.
-
-	QString stylesheet;
-
-	// AMToolButton
-
-	QFile qss1(":/AMToolButton.qss");
-
-	if (qss1.open(QFile::ReadOnly))
-		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss1.readAll())));
-
-	qss1.close();
-
-	// AMDeadTimeButton
-
-	QFile qss2(":/AMDeadTimeButton.qss");
-
-	if (qss2.open(QFile::ReadOnly))
-		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss2.readAll())));
-
-	qss2.close();
-
-	// Apply master stylesheet.
-
-	qApp->setStyleSheet(stylesheet);
+	qApp->setStyleSheet( getStylesheet() );
 }
 
 #include "dataman/AMScanEditorModelItem.h"

--- a/source/application/AMDatamanAppController.h
+++ b/source/application/AMDatamanAppController.h
@@ -359,6 +359,9 @@ protected:
 	/// Opens a single scan configuration from a given database URL.
 	virtual void launchScanConfigurationFromDb(const QUrl &url);
 
+	/// Returns a string representation of the stylesheet to be applied application-wide on startup.
+	virtual QString getStylesheet() const;
+
 protected:
 	/// Helper method that returns the editor associated with a scan for the scanEditorsScanMapping list.  Returns 0 if not found.
 	AMGenericScanEditor *editorFromScan(AMScan *scan) const;

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -251,10 +251,12 @@ QString BioXASAppController::getStylesheet() const
 
 	// BioXASValueSetpointEditor.
 
-	QFile qss3(":/BioXAS/BioXASValueSetpointEditor.qss");
+	QFile qss(":/BioXAS/BioXASValueSetpointEditor.qss");
 
-	if (qss3.open(QFile::ReadOnly))
-		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss3.readAll())));
+	if (qss.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss.readAll())));
+
+	qss.close();
 
 	return stylesheet;
 }

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -67,45 +67,6 @@ void BioXASAppController::shutdown()
 	CLSAppController::shutdown();
 }
 
-void BioXASAppController::applyStylesheets()
-{
-	// Go through list of stylesheets to be applied,
-	// composing a 'master' sheet.
-
-	QString stylesheet;
-
-	// AMToolButton
-
-	QFile qss1(":/AMToolButton.qss");
-
-	if (qss1.open(QFile::ReadOnly))
-		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss1.readAll())));
-
-	qss1.close();
-
-	// AMDeadTimeButton
-
-	QFile qss2(":/AMDeadTimeButton.qss");
-
-	if (qss2.open(QFile::ReadOnly))
-		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss2.readAll())));
-
-	qss2.close();
-
-	// BioXASValueSetpointEditor.
-
-	QFile qss3(":/BioXAS/BioXASValueSetpointEditor.qss");
-
-	if (qss3.open(QFile::ReadOnly))
-		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss3.readAll())));
-
-	qss3.close();
-
-	// Apply master stylesheet.
-
-	qApp->setStyleSheet(stylesheet);
-}
-
 void BioXASAppController::onUserConfigurationLoadedFromDb()
 {
 	if (userConfiguration_) {
@@ -416,6 +377,20 @@ void BioXASAppController::setupScanConfigurations()
 	energyCalibrationConfiguration_->setName("Energy Calibration XAS Scan");
 	energyCalibrationConfiguration_->setUserScanName("Energy Calibration XAS Scan");
 	setupXASScanConfiguration(energyCalibrationConfiguration_);
+}
+
+QString BioXASAppController::getStylesheet() const
+{
+	QString stylesheet = CLSAppController::getStylesheet();
+
+	// BioXASValueSetpointEditor.
+
+	QFile qss3(":/BioXAS/BioXASValueSetpointEditor.qss");
+
+	if (qss3.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss3.readAll())));
+
+	return stylesheet;
 }
 
 QWidget* BioXASAppController::createGeneralPane(QWidget *view, const QString &viewName)

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -66,7 +66,7 @@ void BioXASAppController::shutdown()
 	// Make sure we release/clean-up the beamline interface
 	CLSAppController::shutdown();
 }
-#include <QDebug>
+
 void BioXASAppController::applyStylesheets()
 {
 	// Go through list of stylesheets to be applied,
@@ -102,8 +102,6 @@ void BioXASAppController::applyStylesheets()
 	qss3.close();
 
 	// Apply master stylesheet.
-
-	qDebug() << "\n\n" << stylesheet;
 
 	qApp->setStyleSheet(stylesheet);
 }

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -66,6 +66,47 @@ void BioXASAppController::shutdown()
 	// Make sure we release/clean-up the beamline interface
 	CLSAppController::shutdown();
 }
+#include <QDebug>
+void BioXASAppController::applyStylesheets()
+{
+	// Go through list of stylesheets to be applied,
+	// composing a 'master' sheet.
+
+	QString stylesheet;
+
+	// AMToolButton
+
+	QFile qss1(":/AMToolButton.qss");
+
+	if (qss1.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss1.readAll())));
+
+	qss1.close();
+
+	// AMDeadTimeButton
+
+	QFile qss2(":/AMDeadTimeButton.qss");
+
+	if (qss2.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss2.readAll())));
+
+	qss2.close();
+
+	// BioXASValueSetpointEditor.
+
+	QFile qss3(":/BioXAS/BioXASValueSetpointEditor.qss");
+
+	if (qss3.open(QFile::ReadOnly))
+		stylesheet.append(QString("\n\n%1").arg(QLatin1String(qss3.readAll())));
+
+	qss3.close();
+
+	// Apply master stylesheet.
+
+	qDebug() << "\n\n" << stylesheet;
+
+	qApp->setStyleSheet(stylesheet);
+}
 
 void BioXASAppController::onUserConfigurationLoadedFromDb()
 {

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -92,9 +92,6 @@ public:
 	virtual void shutdown();
 
 protected slots:
-	/// Applies BioXAS-specific stylesheets.
-	virtual void applyStylesheets();
-
 	/// Handles setting up all the necessary settings based on the loaded user configuration.
 	void onUserConfigurationLoadedFromDb();
 
@@ -142,6 +139,9 @@ protected:
 	virtual bool setupDataFolder() { return false; }
 	/// Sets up the available scan configurations.
 	virtual void setupScanConfigurations();
+
+	/// Returns a string representation of the stylesheet to be applied application-wide on startup.
+	virtual QString getStylesheet() const;
 
 	/// Creates and returns a 'General' main window pane for the given widget, with the given title name.
 	virtual QWidget* createGeneralPane(QWidget *view, const QString &viewName);

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -92,6 +92,9 @@ public:
 	virtual void shutdown();
 
 protected slots:
+	/// Applies BioXAS-specific stylesheets.
+	virtual void applyStylesheets();
+
 	/// Handles setting up all the necessary settings based on the loaded user configuration.
 	void onUserConfigurationLoadedFromDb();
 

--- a/source/stylesheets/BioXAS/BioXASStylesheets.qrc
+++ b/source/stylesheets/BioXAS/BioXASStylesheets.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/BioXAS">
+        <file>BioXASValueSetpointEditor.qss</file>
+    </qresource>
+</RCC>

--- a/source/stylesheets/BioXAS/BioXASValueSetpointEditor.qss
+++ b/source/stylesheets/BioXAS/BioXASValueSetpointEditor.qss
@@ -1,9 +1,13 @@
 /* Default styling. */
 
-BioXASValueSetpointEditor[inputStatus="1"] QSpinBox {
-border-color: red;
+BioXASValueSetpointEditor {
+margin: 0px;
+padding: 0px;
 }
 
-BioXASValueSetpointEditor[inputStatus="1"] QComboBox {
+BioXASValueSetpointEditor[inputStatus="1"] {
+border-width: 2px;
+border-style: solid;
 border-color: red;
+border-radius: 2px;
 }

--- a/source/stylesheets/BioXAS/BioXASValueSetpointEditor.qss
+++ b/source/stylesheets/BioXAS/BioXASValueSetpointEditor.qss
@@ -1,0 +1,9 @@
+/* Default styling. */
+
+BioXASValueSetpointEditor[inputStatus="1"] QSpinBox {
+border-color: red;
+}
+
+BioXASValueSetpointEditor[inputStatus="1"] QComboBox {
+border-color: red;
+}

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -27,8 +27,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/BioXAS/BioXASControlEditor.h"
 #include "ui/BioXAS/BioXASCryostatView.h"
 #include "ui/BioXAS/BioXASSIS3820ScalerChannelsView.h"
-#include "ui/AMToolButton.h"
-#include "ui/BioXAS/BioXASValueSetpointEditor.h"
 
 BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
     QWidget(parent)

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -28,6 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "ui/BioXAS/BioXASCryostatView.h"
 #include "ui/BioXAS/BioXASSIS3820ScalerChannelsView.h"
 #include "ui/AMToolButton.h"
+#include "ui/BioXAS/BioXASValueSetpointEditor.h"
 
 BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
     QWidget(parent)
@@ -36,6 +37,14 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 
 	QVBoxLayout *layout = new QVBoxLayout();
 	setLayout(layout);
+
+	// Testing.
+
+	BioXASValueSetpointEditor *doubleSetpoint = new BioXASValueSetpointEditor();
+	layout->addWidget(doubleSetpoint);
+
+	BioXASValueSetpointEditor *enumSetpoint = new BioXASValueSetpointEditor(BioXASValueSetpointEditor::TypeEnum);
+	layout->addWidget(enumSetpoint);
 
 	// Create SR1 current view.
 

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -38,14 +38,6 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 	QVBoxLayout *layout = new QVBoxLayout();
 	setLayout(layout);
 
-	// Testing.
-
-	BioXASValueSetpointEditor *doubleSetpoint = new BioXASValueSetpointEditor();
-	layout->addWidget(doubleSetpoint);
-
-	BioXASValueSetpointEditor *enumSetpoint = new BioXASValueSetpointEditor(BioXASValueSetpointEditor::TypeEnum);
-	layout->addWidget(enumSetpoint);
-
 	// Create SR1 current view.
 
 	BioXASControlEditor *sr1CurrentEditor = new BioXASControlEditor(CLSStorageRing::storageRing()->ringCurrentControl());

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorBasicView.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorBasicView.cpp
@@ -23,7 +23,6 @@ BioXASSSRLMonochromatorBasicView::BioXASSSRLMonochromatorBasicView(BioXASSSRLMon
 
 	regionEditor_ = new BioXASSSRLMonochromatorRegionControlEditor(0);
 	regionEditor_->setTitle("Region");
-	regionEditor_->setNoUnitsBox(true);
 
 	// Create and set layouts.
 

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.cpp
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.cpp
@@ -2,9 +2,9 @@
 #include "beamline/BioXAS/BioXASSSRLMonochromatorRegionControl.h"
 
 BioXASSSRLMonochromatorRegionControlEditor::BioXASSSRLMonochromatorRegionControlEditor(BioXASSSRLMonochromatorRegionControl *regionControl, QWidget *parent) :
-	AMExtendedControlEditor(regionControl, 0, false, false, parent)
+	BioXASControlEditor(regionControl, parent)
 {
-	setNoUnitsBox(true);
+
 }
 
 BioXASSSRLMonochromatorRegionControlEditor::~BioXASSSRLMonochromatorRegionControlEditor()
@@ -18,7 +18,7 @@ void BioXASSSRLMonochromatorRegionControlEditor::setControl(AMControl *newContro
 		disconnect( control_, 0, this, 0 );
 	}
 
-	AMExtendedControlEditor::setControl(newControl);
+	BioXASControlEditor::setControl(newControl);
 
 	if (control_) {
 		connect( control_, SIGNAL(moveStarted()), this, SLOT(onRegionControlMoveStarted()) );

--- a/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.h
+++ b/source/ui/BioXAS/BioXASSSRLMonochromatorRegionControlEditor.h
@@ -7,11 +7,11 @@
 #include <QDialogButtonBox>
 #include <QProgressBar>
 
-#include "ui/beamline/AMExtendedControlEditor.h"
+#include "ui/BioXAS/BioXASControlEditor.h"
 
 class BioXASSSRLMonochromatorRegionControl;
 
-class BioXASSSRLMonochromatorRegionControlEditor : public AMExtendedControlEditor
+class BioXASSSRLMonochromatorRegionControlEditor : public BioXASControlEditor
 {
 	Q_OBJECT
 public:

--- a/source/ui/BioXAS/BioXASValueEditor.cpp
+++ b/source/ui/BioXAS/BioXASValueEditor.cpp
@@ -1,4 +1,5 @@
 #include "BioXASValueEditor.h"
+#include "ui/BioXAS/BioXASValueSetpointEditorDialog.h"
 #include "float.h"
 
 BioXASValueEditor::BioXASValueEditor(QWidget *parent) :
@@ -221,13 +222,17 @@ AMNumber BioXASValueEditor::getDoubleValue()
 {
 	AMNumber result = AMNumber(AMNumber::InvalidError);
 
-	QString dialogTitle = (title_.isEmpty()) ? QString("Edit value") : QString("Editing %1").arg(title_);
-	bool inputOK = false;
+	QString dialogTitle = (title_.isEmpty()) ? QString("Edit value") : QString("Editing %1").arg(title_.toLower());
 
-	double newValue = QInputDialog::getDouble(this, dialogTitle, QString("New value: "), double(value_), minimumValue_, maximumValue_, precision_, &inputOK);
+	BioXASValueSetpointEditorDialog inputDialog;
+	inputDialog.setValue(value_);
+	inputDialog.setMinimum(minimumValue_);
+	inputDialog.setMaximum(maximumValue_);
+	inputDialog.setWindowTitle(dialogTitle);
+	inputDialog.move(mapToGlobal(QPoint(width()/2, height()/2)));
 
-	if (inputOK)
-		result = AMNumber(newValue);
+	if (inputDialog.exec())
+		result = AMNumber(inputDialog.value());
 
 	return result;
 }
@@ -236,17 +241,16 @@ AMNumber BioXASValueEditor::getEnumValue()
 {
 	AMNumber result = AMNumber(AMNumber::InvalidError);
 
-	QString dialogTitle = (title_.isEmpty()) ? QString("Edit value") : QString("Editing %1").arg(title_);
-	bool inputOK = false;
+	QString dialogTitle = (title_.isEmpty()) ? QString("Edit value") : QString("Editing %1").arg(title_.toLower());
 
-	QString newValueName = QInputDialog::getItem(this, dialogTitle, QString("New value: "), moveValues_, int(value_), false, &inputOK);
+	BioXASValueSetpointEditorDialog inputDialog(this);
+	inputDialog.setValues(moveValues_);
+	inputDialog.setValue(value_);
+	inputDialog.setWindowTitle(dialogTitle);
+	inputDialog.move(mapToGlobal(QPoint(width()/2, height()/2)));
 
-	if (inputOK) {
-		int newValueIndex = values_.indexOf(newValueName);
-
-		if (newValueIndex > -1)
-			result = AMNumber(newValueIndex);
-	}
+	if (inputDialog.exec())
+		result = AMNumber(inputDialog.value());
 
 	return result;
 }

--- a/source/ui/BioXAS/BioXASValueSetpointEditor.cpp
+++ b/source/ui/BioXAS/BioXASValueSetpointEditor.cpp
@@ -1,6 +1,7 @@
 #include "BioXASValueSetpointEditor.h"
+#include "float.h"
 
-BioXASValueSetpointEditor::BioXASValueSetpointEditor(QWidget *parent) :
+BioXASValueSetpointEditor::BioXASValueSetpointEditor(InputType type, QWidget *parent) :
 	QWidget(parent)
 {
 	// Initialize class variables.
@@ -17,6 +18,8 @@ BioXASValueSetpointEditor::BioXASValueSetpointEditor(QWidget *parent) :
 	// Create UI elements.
 
 	spinBox_ = new QDoubleSpinBox();
+	spinBox_->setMinimum(-DBL_MAX);
+	spinBox_->setMaximum(DBL_MAX);
 	connect( spinBox_, SIGNAL(valueChanged(double)), this, SLOT(onSpinBoxValueChanged()) );
 
 	comboBox_ = new QComboBox();
@@ -32,7 +35,8 @@ BioXASValueSetpointEditor::BioXASValueSetpointEditor(QWidget *parent) :
 
 	// Current settings.
 
-	updateBoxes();
+	setInputType(type);
+	setInputStatus(StatusBad);
 }
 
 BioXASValueSetpointEditor::~BioXASValueSetpointEditor()
@@ -57,10 +61,10 @@ void BioXASValueSetpointEditor::setInputType(InputType newType)
 	if (type_ != newType) {
 		type_ = newType;
 
-		updateBoxes();
-
 		emit inputTypeChanged(type_);
 	}
+
+	updateBoxes();
 }
 
 void BioXASValueSetpointEditor::setValue(double newValue)
@@ -83,10 +87,10 @@ void BioXASValueSetpointEditor::setMinimum(double newMin)
 		minimumSet_ = true;
 		minimum_ = newMin;
 
-		updateInputStatus();
-
 		emit minimumChanged(minimum_);
 	}
+
+	updateInputStatus();
 }
 
 void BioXASValueSetpointEditor::setMaximum(double newMax)
@@ -95,40 +99,45 @@ void BioXASValueSetpointEditor::setMaximum(double newMax)
 		maximumSet_ = true;
 		maximum_ = newMax;
 
-		updateInputStatus();
-
 		emit maximumChanged(maximum_);
 	}
-}
 
+	updateInputStatus();
+}
+#include <QDebug>
 void BioXASValueSetpointEditor::setInputStatus(InputStatus newStatus)
 {
+	qDebug() << "Setting status to:" << (newStatus == StatusBad ? "Bad" : "None");
+
 	if (status_ != newStatus) {
 		status_ = newStatus;
 
-		style()->unpolish(this);
-		style()->polish(this);
-
-		update();
-
 		emit inputStatusChanged(status_);
 	}
+
+	style()->unpolish(this);
+	style()->polish(this);
+
+	update();
 }
 
 void BioXASValueSetpointEditor::updateInputStatus()
 {
-	InputStatus newStatus = StatusNone;
+	qDebug() << "Updating input status.";
+//	InputStatus newStatus = StatusNone;
 
-	if (type_ == TypeDouble && minimumSet_ && spinBox_->value() < minimum_)
-		newStatus = StatusBad;
-	else if (type_ == TypeDouble && maximumSet_ && spinBox_->value() > maximum_)
-		newStatus = StatusBad;
-	else if (type_ == TypeEnum && minimumSet_ && comboBox_->currentIndex() < minimum_)
-		newStatus = StatusBad;
-	else if (type_ == TypeEnum && maximumSet_ && comboBox_->currentIndex() > maximum_)
-		newStatus = StatusBad;
+//	if (type_ == TypeDouble && minimumSet_ && spinBox_->value() < minimum_)
+//		newStatus = StatusBad;
+//	else if (type_ == TypeDouble && maximumSet_ && spinBox_->value() > maximum_)
+//		newStatus = StatusBad;
+//	else if (type_ == TypeEnum && minimumSet_ && comboBox_->currentIndex() < minimum_)
+//		newStatus = StatusBad;
+//	else if (type_ == TypeEnum && maximumSet_ && comboBox_->currentIndex() > maximum_)
+//		newStatus = StatusBad;
 
-	setInputStatus(newStatus);
+//	setInputStatus(newStatus);
+
+	setInputStatus(StatusBad);
 }
 
 void BioXASValueSetpointEditor::updateBoxes()

--- a/source/ui/BioXAS/BioXASValueSetpointEditor.cpp
+++ b/source/ui/BioXAS/BioXASValueSetpointEditor.cpp
@@ -1,0 +1,161 @@
+#include "BioXASValueSetpointEditor.h"
+
+BioXASValueSetpointEditor::BioXASValueSetpointEditor(QWidget *parent) :
+	QWidget(parent)
+{
+	// Initialize class variables.
+
+	status_ = StatusNone;
+	type_ = TypeDouble;
+
+	minimumSet_ = false;
+	minimum_ = 0;
+
+	maximumSet_ = false;
+	maximum_ = 0;
+
+	// Create UI elements.
+
+	spinBox_ = new QDoubleSpinBox();
+	connect( spinBox_, SIGNAL(valueChanged(double)), this, SLOT(onSpinBoxValueChanged()) );
+
+	comboBox_ = new QComboBox();
+	connect( comboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onComboBoxValueChanged()) );
+
+	// Create and set layouts.
+
+	QHBoxLayout *layout = new QHBoxLayout();
+	layout->addWidget(spinBox_);
+	layout->addWidget(comboBox_);
+
+	setLayout(layout);
+
+	// Current settings.
+
+	updateBoxes();
+}
+
+BioXASValueSetpointEditor::~BioXASValueSetpointEditor()
+{
+
+}
+
+double BioXASValueSetpointEditor::value() const
+{
+	double result = 0;
+
+	if (type_ == TypeDouble)
+		result = spinBox_->value();
+	else if (type_ == TypeEnum)
+		result = comboBox_->currentIndex();
+
+	return result;
+}
+
+void BioXASValueSetpointEditor::setInputType(InputType newType)
+{
+	if (type_ != newType) {
+		type_ = newType;
+
+		updateBoxes();
+
+		emit inputTypeChanged(type_);
+	}
+}
+
+void BioXASValueSetpointEditor::setValue(double newValue)
+{
+	if (type_ == TypeDouble)
+		spinBox_->setValue(newValue);
+	else if (type_ == TypeEnum)
+		comboBox_->setCurrentIndex(newValue);
+}
+
+void BioXASValueSetpointEditor::setValues(const QStringList &newValues)
+{
+	comboBox_->clear();
+	comboBox_->addItems(newValues);
+}
+
+void BioXASValueSetpointEditor::setMinimum(double newMin)
+{
+	if (minimum_ != newMin || !minimumSet_) {
+		minimumSet_ = true;
+		minimum_ = newMin;
+
+		updateInputStatus();
+
+		emit minimumChanged(minimum_);
+	}
+}
+
+void BioXASValueSetpointEditor::setMaximum(double newMax)
+{
+	if (maximum_ != newMax || !maximumSet_) {
+		maximumSet_ = true;
+		maximum_ = newMax;
+
+		updateInputStatus();
+
+		emit maximumChanged(maximum_);
+	}
+}
+
+void BioXASValueSetpointEditor::setInputStatus(InputStatus newStatus)
+{
+	if (status_ != newStatus) {
+		status_ = newStatus;
+
+		style()->unpolish(this);
+		style()->polish(this);
+
+		update();
+
+		emit inputStatusChanged(status_);
+	}
+}
+
+void BioXASValueSetpointEditor::updateInputStatus()
+{
+	InputStatus newStatus = StatusNone;
+
+	if (type_ == TypeDouble && minimumSet_ && spinBox_->value() < minimum_)
+		newStatus = StatusBad;
+	else if (type_ == TypeDouble && maximumSet_ && spinBox_->value() > maximum_)
+		newStatus = StatusBad;
+	else if (type_ == TypeEnum && minimumSet_ && comboBox_->currentIndex() < minimum_)
+		newStatus = StatusBad;
+	else if (type_ == TypeEnum && maximumSet_ && comboBox_->currentIndex() > maximum_)
+		newStatus = StatusBad;
+
+	setInputStatus(newStatus);
+}
+
+void BioXASValueSetpointEditor::updateBoxes()
+{
+	// Update the spinbox.
+
+	if (type_ == TypeDouble)
+		spinBox_->show();
+	else
+		spinBox_->hide();
+
+	// Update the combobox.
+
+	if (type_ == TypeEnum)
+		comboBox_->show();
+	else
+		comboBox_->hide();
+}
+
+void BioXASValueSetpointEditor::onSpinBoxValueChanged()
+{
+	if (type_ == TypeDouble)
+		emit valueChanged(spinBox_->value());
+}
+
+void BioXASValueSetpointEditor::onComboBoxValueChanged()
+{
+	if (type_ == TypeEnum)
+		emit valueChanged(comboBox_->currentIndex());
+}

--- a/source/ui/BioXAS/BioXASValueSetpointEditor.h
+++ b/source/ui/BioXAS/BioXASValueSetpointEditor.h
@@ -11,7 +11,10 @@ class BioXASValueSetpointEditor : public QWidget
 	Q_OBJECT
 
 	Q_PROPERTY(InputType inputType READ inputType WRITE setInputType NOTIFY inputTypeChanged)
+	Q_ENUMS(InputType)
+
 	Q_PROPERTY(InputStatus inputStatus READ inputStatus WRITE setInputStatus NOTIFY inputStatusChanged)
+	Q_ENUMS(InputStatus)
 
 public:
 	/// Enumeration of the input status.
@@ -20,7 +23,7 @@ public:
 	enum InputType { TypeDouble = 0, TypeEnum = 1 };
 
 	/// Constructor.
-	explicit BioXASValueSetpointEditor(QWidget *parent = 0);
+	explicit BioXASValueSetpointEditor(InputType type = TypeDouble, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~BioXASValueSetpointEditor();
 

--- a/source/ui/BioXAS/BioXASValueSetpointEditor.h
+++ b/source/ui/BioXAS/BioXASValueSetpointEditor.h
@@ -10,11 +10,11 @@ class BioXASValueSetpointEditor : public QWidget
 {
 	Q_OBJECT
 
-	Q_PROPERTY(InputType inputType READ inputType WRITE setInputType NOTIFY inputTypeChanged)
-	Q_ENUMS(InputType)
-
 	Q_PROPERTY(InputStatus inputStatus READ inputStatus WRITE setInputStatus NOTIFY inputStatusChanged)
 	Q_ENUMS(InputStatus)
+
+	Q_PROPERTY(InputType inputType READ inputType WRITE setInputType NOTIFY inputTypeChanged)
+	Q_ENUMS(InputType)
 
 public:
 	/// Enumeration of the input status.
@@ -41,6 +41,11 @@ public:
 	bool maximumSet() const { return maximumSet_; }
 	/// Returns the maximum value.
 	double maximum() const { return maximum_; }
+
+	/// Returns true if the minimum value is set and the current value is less than the minimum, indicating a bad input state.
+	bool valueLessThanMinimum() const;
+	/// Returns true if the maximum value is set and the current value is greater than the maximum, indicating a bad input state.
+	bool valueGreaterThanMaximum() const;
 
 signals:
 	/// Notifier that the input status has changed.
@@ -72,16 +77,27 @@ public slots:
 protected slots:
 	/// Sets the input status.
 	void setInputStatus(InputStatus newStatus);
+
 	/// Updates the input status.
 	void updateInputStatus();
-
+	/// Updates the tooltip.
+	void updateToolTip();
 	/// Updates the spinbox and the combobox.
 	void updateBoxes();
 
-	/// Handles emitting the appropriate signals when the spinbox changes value.
-	void onSpinBoxValueChanged();
-	/// Handles emitting the appropriate signals when the combobox changes value.
-	void onComboBoxValueChanged();
+	/// Handles emitting the appropriate signals when one of the box widget's value changes.
+	void onBoxValueChanged();
+
+protected:
+	/// Handles painting the widget. Reimplemented for stylesheet to take effect.
+	virtual void paintEvent(QPaintEvent *e);
+
+	/// Returns the value, based on the current input type.
+	virtual double getValue() const;
+	/// Returns the input status, based on the current input type and available min and max values.
+	virtual InputStatus getInputStatus() const;
+	/// Returns the tooltip text, based on the current input status, value, and available min and max values.
+	virtual QString getToolTipText() const;
 
 protected:
 	/// The input status.

--- a/source/ui/BioXAS/BioXASValueSetpointEditor.h
+++ b/source/ui/BioXAS/BioXASValueSetpointEditor.h
@@ -1,0 +1,103 @@
+#ifndef BIOXASVALUESETPOINTEDITOR_H
+#define BIOXASVALUESETPOINTEDITOR_H
+
+#include <QWidget>
+#include <QDoubleSpinBox>
+#include <QComboBox>
+#include <QLayout>
+
+class BioXASValueSetpointEditor : public QWidget
+{
+	Q_OBJECT
+
+	Q_PROPERTY(InputType inputType READ inputType WRITE setInputType NOTIFY inputTypeChanged)
+	Q_PROPERTY(InputStatus inputStatus READ inputStatus WRITE setInputStatus NOTIFY inputStatusChanged)
+
+public:
+	/// Enumeration of the input status.
+	enum InputStatus { StatusNone = 0, StatusBad = 1 };
+	/// Enumeration of the input type.
+	enum InputType { TypeDouble = 0, TypeEnum = 1 };
+
+	/// Constructor.
+	explicit BioXASValueSetpointEditor(QWidget *parent = 0);
+	/// Destructor.
+	virtual ~BioXASValueSetpointEditor();
+
+	/// Returns the input status.
+	InputStatus inputStatus() const { return status_; }
+	/// Returns the input type.
+	InputType inputType() const { return type_; }
+	/// Returns the current value.
+	double value() const;
+	/// Returns true if the minimum value has been set.
+	bool minimumSet() const { return minimumSet_; }
+	/// Returns the minimum value.
+	double minimum() const { return minimum_; }
+	/// Returns true if the maximum value has been set.
+	bool maximumSet() const { return maximumSet_; }
+	/// Returns the maximum value.
+	double maximum() const { return maximum_; }
+
+signals:
+	/// Notifier that the input status has changed.
+	void inputStatusChanged(InputStatus newStatus);
+	/// Notifier that the input type has changed.
+	void inputTypeChanged(InputType newType);
+	/// Notifier that the value has changed.
+	void valueChanged(double newValue);
+	/// Notifier that the values have changed.
+	void valuesChanged(const QStringList &newValues);
+	/// Notifier that the minimum value has changed.
+	void minimumChanged(double newMin);
+	/// Notifier that the maximum value has changed.
+	void maximumChanged(double newMax);
+
+public slots:
+	/// Sets the input type.
+	void setInputType(InputType newType);
+
+	/// Sets the current value.
+	void setValue(double newValue);
+	/// Set the value options to choose from, for enum values.
+	void setValues(const QStringList &newValues);
+	/// Sets the minimum value.
+	void setMinimum(double newMin);
+	/// Sets the maximum value.
+	void setMaximum(double newMax);
+
+protected slots:
+	/// Sets the input status.
+	void setInputStatus(InputStatus newStatus);
+	/// Updates the input status.
+	void updateInputStatus();
+
+	/// Updates the spinbox and the combobox.
+	void updateBoxes();
+
+	/// Handles emitting the appropriate signals when the spinbox changes value.
+	void onSpinBoxValueChanged();
+	/// Handles emitting the appropriate signals when the combobox changes value.
+	void onComboBoxValueChanged();
+
+protected:
+	/// The input status.
+	InputStatus status_;
+	/// The input type.
+	InputType type_;
+	/// Flag indicating whether a minimum has been set.
+	bool minimumSet_;
+	/// The minimum value.
+	double minimum_;
+	/// Flag indicating whether a maximum has been set.
+	bool maximumSet_;
+	/// The maximum value.
+	double maximum_;
+
+	/// The input spinbox.
+	QDoubleSpinBox *spinBox_;
+	/// The input combobox.
+	QComboBox *comboBox_;
+};
+
+#endif // BIOXASVALUESETPOINTEDITOR_H

--- a/source/ui/BioXAS/BioXASValueSetpointEditorDialog.cpp
+++ b/source/ui/BioXAS/BioXASValueSetpointEditorDialog.cpp
@@ -1,0 +1,100 @@
+#include "BioXASValueSetpointEditorDialog.h"
+#include "ui/BioXAS/BioXASValueSetpointEditor.h"
+#include <QPushButton>
+
+BioXASValueSetpointEditorDialog::BioXASValueSetpointEditorDialog(QWidget *parent, Qt::WindowFlags flags) :
+	QDialog(parent, flags)
+{
+	// Create UI elements.
+
+	QLabel *prompt = new QLabel("New value:");
+
+	setpointEditor_ = new BioXASValueSetpointEditor(BioXASValueSetpointEditor::TypeDouble);
+	connect( setpointEditor_, SIGNAL(inputStatusChanged(InputStatus)), this, SLOT(updateButtons()) );
+
+	buttonBox_ = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+	connect( buttonBox_, SIGNAL(accepted()), this, SLOT(accept()) );
+	connect( buttonBox_, SIGNAL(rejected()), this, SLOT(reject()) );
+
+	// Create and set main layouts.
+
+	QHBoxLayout *buttonsLayout = new QHBoxLayout();
+	buttonsLayout->setMargin(0);
+	buttonsLayout->addStretch();
+	buttonsLayout->addWidget(buttonBox_);
+	buttonsLayout->addStretch();
+
+	QGridLayout *layout = new QGridLayout();
+	layout->addWidget(prompt, 0, 0, 1, 1, Qt::AlignRight);
+	layout->addWidget(setpointEditor_, 0, 1);
+	layout->addLayout(buttonsLayout, 1, 1);
+
+	setLayout(layout);
+}
+
+BioXASValueSetpointEditorDialog::~BioXASValueSetpointEditorDialog()
+{
+
+}
+
+double BioXASValueSetpointEditorDialog::value() const
+{
+	return setpointEditor_->value();
+}
+
+bool BioXASValueSetpointEditorDialog::minimumSet() const
+{
+	return setpointEditor_->minimumSet();
+}
+
+double BioXASValueSetpointEditorDialog::minimum() const
+{
+	return setpointEditor_->minimum();
+}
+
+bool BioXASValueSetpointEditorDialog::maximumSet() const
+{
+	return setpointEditor_->maximumSet();
+}
+
+double BioXASValueSetpointEditorDialog::maximum() const
+{
+	return setpointEditor_->maximum();
+}
+
+void BioXASValueSetpointEditorDialog::setValue(double newValue)
+{
+	setpointEditor_->setValue(newValue);
+}
+
+void BioXASValueSetpointEditorDialog::setValues(const QStringList &newValues)
+{
+	setpointEditor_->setInputType(BioXASValueSetpointEditor::TypeEnum);
+	setpointEditor_->setValues(newValues);
+}
+
+void BioXASValueSetpointEditorDialog::setMinimum(double newMin)
+{
+	setpointEditor_->setMinimum(newMin);
+}
+
+void BioXASValueSetpointEditorDialog::setMaximum(double newMax)
+{
+	setpointEditor_->setMaximum(newMax);
+}
+
+void BioXASValueSetpointEditorDialog::updateButtons()
+{
+	bool okEnabled = true;
+
+	// Determine the enabled state of the OK button.
+
+	BioXASValueSetpointEditor::InputStatus inputStatus = setpointEditor_->inputStatus();
+
+	if (inputStatus == BioXASValueSetpointEditor::StatusBad)
+		okEnabled = false;
+
+	// Set the new enabled state.
+
+	buttonBox_->button(QDialogButtonBox::Ok)->setEnabled(okEnabled);
+}

--- a/source/ui/BioXAS/BioXASValueSetpointEditorDialog.h
+++ b/source/ui/BioXAS/BioXASValueSetpointEditorDialog.h
@@ -1,0 +1,53 @@
+#ifndef BIOXASVALUESETPOINTEDITORDIALOG_H
+#define BIOXASVALUESETPOINTEDITORDIALOG_H
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QLayout>
+
+class BioXASValueSetpointEditor;
+
+class BioXASValueSetpointEditorDialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	/// Constructor.
+	BioXASValueSetpointEditorDialog(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+	/// Destructor.
+	virtual ~BioXASValueSetpointEditorDialog();
+
+	/// Returns the current value.
+	double value() const;
+	/// Returns true if the minimum value has been set.
+	bool minimumSet() const;
+	/// Returns the minimum value.
+	double minimum() const;
+	/// Returns true if the maximum value has been set.
+	bool maximumSet() const;
+	/// Returns the maximum value.
+	double maximum() const;
+
+public slots:
+	/// Sets the current value.
+	void setValue(double newValue);
+	/// Set the value options to choose from, for enum values.
+	void setValues(const QStringList &newValues);
+	/// Sets the minimum value.
+	void setMinimum(double newMin);
+	/// Sets the maximum value.
+	void setMaximum(double newMax);
+
+protected slots:
+	/// Updates the buttons.
+	void updateButtons();
+
+protected:
+	/// The setpoint editor.
+	BioXASValueSetpointEditor *setpointEditor_;
+	/// The dialog button box.
+	QDialogButtonBox *buttonBox_;
+};
+
+#endif // BIOXASVALUESETPOINTEDITORDIALOG_H


### PR DESCRIPTION
Changes:
- Created new class BioXASValueSetpointEditor that's a combo spinbox/combobox as appropriate, depending on the InputType. The class also has an InputStatus property that's used to style the widget according to the whether or not the input is okay.
- Created new stylesheet for the setpoint editor that gives it a red border for bad input values.
- Modified AMAppController to apply stylesheets while setting up the user interface, instead of in the constructor. This allows for app controller subclasses to reimplement applyStylesheets() properly.
- Created new class BioXASValueSetpointEditorDialog, a dialog with the new setpoint editor and OK/Cancel buttons.
- Modified BioXASValueEditor to use the new dialog instead of the old default 'QInputDialog' option.
- Modified BioXASSSRLMonochromatorRegionControlEditor to inherit from BioXASControlEditor instead of AMExtendedControlEditor.