### PR TITLE
Pull Request for Issue2341: Create New Data Folder Dialog Gets in Bad State When Cancelled

### DIFF
--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -16,222 +16,224 @@
 
 bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, const QString &remoteRootDirectory, const QString &dataDirectory, const QStringList &extraDataDirectory, QWidget *parent)
 {
-	AMUserSettings::load();
+        AMUserSettings::load();
 
-	AMChooseDataFolderDialog dialog(AMUserSettings::userDataFolder, localRootDirectory, remoteRootDirectory, dataDirectory, parent);
-	dialog.exec();
+        AMChooseDataFolderDialog dialog(AMUserSettings::userDataFolder, localRootDirectory, remoteRootDirectory, dataDirectory, parent);
+        dialog.exec();
 
-	if (dialog.result() == QDialog::Accepted){
+        if (dialog.result() == QDialog::Accepted){
 
-		// when we are using this dialog, we are not user-account based storage
-		AMUserSettings::userBasedDataStorage = false;
+                // when we are using this dialog, we are not user-account based storage
+                AMUserSettings::userBasedDataStorage = false;
 
-		QString dialogInput = dialog.filePath();
+                QString dialogInput = dialog.filePath();
 
                 if (!dialog.isFullPath()){
 
-			QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
+                        QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
+                        QFileInfo localFullPath(QString("%1/%2/%3").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput));
 
-			bool isFirstTimeUser = !remoteFullPath.exists();
-                        QFileInfo testLocalRootPath(localRootDirectory);
-                        QFileInfo testRemoteRootPath(remoteRootDirectory);
+                        bool isFirstTimeUser = !remoteFullPath.exists();
+                        bool failedFirstTimeStartup = (remoteFullPath.exists() && !localFullPath.exists());
 
-                        //In the case that the startup procedure is interupted local and remote may not both exist.
-                        //If local does not exist and remote does, run startup again.
-                        if (isFirstTimeUser || (!testLocalRootPath.exists() && testRemoteRootPath.exists())){
+                        if (isFirstTimeUser && !failedFirstTimeStartup){
+                                QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
+                                newPath.mkpath(QString("%1/userData").arg(dialogInput));
 
-				QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
-				newPath.mkpath(QString("%1/userData").arg(dialogInput));
+                                foreach (QString newExtraDestination, extraDataDirectory)
+                                        newPath.mkpath(QString("%1/%2").arg(dialogInput).arg(newExtraDestination));
 
-				foreach (QString newExtraDestination, extraDataDirectory)
-					newPath.mkpath(QString("%1/%2").arg(dialogInput).arg(newExtraDestination));
+                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::remoteDataFolder = "";
+                                AMUserSettings::save(true);
 
-				AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-				AMUserSettings::remoteDataFolder = "";
-				AMUserSettings::save(true);
-			}
+                        }
+                        else if(failedFirstTimeStartup){
+                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::save(true);
+                        }
+                        else {
 
-			else {
+                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::save();
+                        }
+                }
 
-				AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
-				AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-				AMUserSettings::save();
-			}
-		}
+                else {
 
-		else {
+                        QString userDataPath;
+                        if (dialogInput.endsWith("/userData") || dialogInput.endsWith("/userData/")) {
+                                userDataPath = dialogInput;
+                        } else {
+                                userDataPath = QString("%1/userData").arg(dialogInput);
+                        }
 
-			QString userDataPath;
-			if (dialogInput.endsWith("/userData") || dialogInput.endsWith("/userData/")) {
-				userDataPath = dialogInput;
-			} else {
-				userDataPath = QString("%1/userData").arg(dialogInput);
-			}
+                        QFileInfo remoteFullPath(userDataPath);
+                        if (!remoteFullPath.exists()) {
+                                QDir newPath(dialogInput);
+                                newPath.mkpath(userDataPath);
+                        }
 
-			QFileInfo remoteFullPath(userDataPath);
-			if (!remoteFullPath.exists()) {
-				QDir newPath(dialogInput);
-				newPath.mkpath(userDataPath);
-			}
+                        if (!userDataPath.endsWith("/"))
+                                userDataPath.append("/");
 
-			if (!userDataPath.endsWith("/"))
-				userDataPath.append("/");
+                        AMUserSettings::userDataFolder = userDataPath;
+                        AMUserSettings::save();
+                }
 
-			AMUserSettings::userDataFolder = userDataPath;
-			AMUserSettings::save();
-		}
+                return true;
+        }
 
-		return true;
-	}
-
-	else
-		return false;
+        else
+                return false;
 }
 
 //////////////////////////////////////
 
 AMChooseDataFolderDialog::AMChooseDataFolderDialog(const QString &dataFolder, const QString &localRootDirectory, const QString &remoteRootDirectory, const QString &dataDirectory, QWidget *parent)
-	: QDialog(parent)
+        : QDialog(parent)
 {
-	setWindowTitle("Choose Data Ouput Destination");
+        setWindowTitle("Choose Data Ouput Destination");
 
-	QString dataDestinationPath = dataDirectory.startsWith("/") ? dataDirectory : QString("/%1").arg(dataDirectory);
-	QString localDataDirectory = QString("%1%2").arg(localRootDirectory).arg(dataDestinationPath);
-	QString remoteDataDirectory = QString("%1%2").arg(remoteRootDirectory).arg(dataDestinationPath);
-	folder_ = dataFolder;
+        QString dataDestinationPath = dataDirectory.startsWith("/") ? dataDirectory : QString("/%1").arg(dataDirectory);
+        QString localDataDirectory = QString("%1%2").arg(localRootDirectory).arg(dataDestinationPath);
+        QString remoteDataDirectory = QString("%1%2").arg(remoteRootDirectory).arg(dataDestinationPath);
+        folder_ = dataFolder;
 
-	QLabel *explanation = new QLabel("Enter the proposal number or the absolute path to where you want your data to be saved.");
-	pathComboBox_ = new QComboBox;
-	pathComboBox_->setEditable(true);
+        QLabel *explanation = new QLabel("Enter the proposal number or the absolute path to where you want your data to be saved.");
+        pathComboBox_ = new QComboBox;
+        pathComboBox_->setEditable(true);
 
-	if (folder_.contains(dataDestinationPath)){
+        if (folder_.contains(dataDestinationPath)){
 
-		QString tempFolder = folder_;
-		tempFolder = tempFolder.left( tempFolder.indexOf(QRegExp(dataDestinationPath))+dataDestinationPath.length() );
-		QDir dir(tempFolder);
+                QString tempFolder = folder_;
+                tempFolder = tempFolder.left( tempFolder.indexOf(QRegExp(dataDestinationPath))+dataDestinationPath.length() );
+                QDir dir(tempFolder);
 
-		directories_ = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-	}
+                directories_ = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+        }
 
-	pathComboBox_->addItems(directories_);
+        pathComboBox_->addItems(directories_);
 
-	pathStatusLabel_ = new QLabel;
-	QFont pathFont(this->font());
-	pathFont.setItalic(true);
-	pathStatusLabel_->setFont(pathFont);
+        pathStatusLabel_ = new QLabel;
+        QFont pathFont(this->font());
+        pathFont.setItalic(true);
+        pathStatusLabel_->setFont(pathFont);
 
-	folderButton_ = new QToolButton;
-	folderButton_->setIcon(QIcon(":/22x22/folder.png"));
-	okButton_ = new QPushButton(QIcon(":/22x22/greenCheck.png"), "Okay");
-	QPushButton *cancelButton = new QPushButton(QIcon(":/22x22/list-remove-2.png"), "Cancel");
-	QString shortFormPath = "";
+        folderButton_ = new QToolButton;
+        folderButton_->setIcon(QIcon(":/22x22/folder.png"));
+        okButton_ = new QPushButton(QIcon(":/22x22/greenCheck.png"), "Okay");
+        QPushButton *cancelButton = new QPushButton(QIcon(":/22x22/list-remove-2.png"), "Cancel");
+        QString shortFormPath = "";
 
-	if (folder_.contains(localDataDirectory) || folder_.contains(remoteDataDirectory)){
+        if (folder_.contains(localDataDirectory) || folder_.contains(remoteDataDirectory)){
 
-		shortFormPath = folder_;
-		shortFormPath = shortFormPath.remove(QRegExp(QString("%1|%2").arg(localDataDirectory).arg(remoteDataDirectory)));
-		shortFormPath = shortFormPath.remove("/userData");
-		shortFormPath = shortFormPath.remove("/");
-	}
+                shortFormPath = folder_;
+                shortFormPath = shortFormPath.remove(QRegExp(QString("%1|%2").arg(localDataDirectory).arg(remoteDataDirectory)));
+                shortFormPath = shortFormPath.remove("/userData");
+                shortFormPath = shortFormPath.remove("/");
+        }
 
-	// If small form could not be resolved, then just use a full path.  Otherwise, set the folder text to the short form.
-	if (shortFormPath.isEmpty())
-		shortFormPath = folder_;
+        // If small form could not be resolved, then just use a full path.  Otherwise, set the folder text to the short form.
+        if (shortFormPath.isEmpty())
+                shortFormPath = folder_;
 
-	else
-		folder_ = shortFormPath;
+        else
+                folder_ = shortFormPath;
 
-	pathComboBox_->setEditText(shortFormPath);
+        pathComboBox_->setEditText(shortFormPath);
 
-	QHBoxLayout *lineEditLayout = new QHBoxLayout;
-	lineEditLayout->addWidget(pathComboBox_);
-	lineEditLayout->addWidget(pathStatusLabel_, 0, Qt::AlignCenter);
-	lineEditLayout->addWidget(folderButton_);
+        QHBoxLayout *lineEditLayout = new QHBoxLayout;
+        lineEditLayout->addWidget(pathComboBox_);
+        lineEditLayout->addWidget(pathStatusLabel_, 0, Qt::AlignCenter);
+        lineEditLayout->addWidget(folderButton_);
 
-	QHBoxLayout *buttonLayout = new QHBoxLayout;
-	buttonLayout->addStretch();
-	buttonLayout->addWidget(okButton_);
-	buttonLayout->addWidget(cancelButton);
+        QHBoxLayout *buttonLayout = new QHBoxLayout;
+        buttonLayout->addStretch();
+        buttonLayout->addWidget(okButton_);
+        buttonLayout->addWidget(cancelButton);
 
-	QVBoxLayout *layout = new QVBoxLayout;
-	layout->addWidget(explanation);
-	layout->addLayout(lineEditLayout);
-	layout->addLayout(buttonLayout);
+        QVBoxLayout *layout = new QVBoxLayout;
+        layout->addWidget(explanation);
+        layout->addLayout(lineEditLayout);
+        layout->addLayout(buttonLayout);
 
-	setLayout(layout);
+        setLayout(layout);
 
-	connect(folderButton_, SIGNAL(clicked()), this, SLOT(getFilePath()));
-	connect(okButton_, SIGNAL(clicked()), this, SLOT(accept()));
-	connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
-	connect(pathComboBox_, SIGNAL(editTextChanged(QString)), this, SLOT(onTextChanged(QString)));
+        connect(folderButton_, SIGNAL(clicked()), this, SLOT(getFilePath()));
+        connect(okButton_, SIGNAL(clicked()), this, SLOT(accept()));
+        connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+        connect(pathComboBox_, SIGNAL(editTextChanged(QString)), this, SLOT(onTextChanged(QString)));
 
-	onTextChanged(pathComboBox_->currentText());
+        onTextChanged(pathComboBox_->currentText());
 }
 
 bool AMChooseDataFolderDialog::isFullPath() const
 {
-	return folder_.contains("/");
+        return folder_.contains("/");
 }
 
 void AMChooseDataFolderDialog::onTextChanged(const QString &text)
 {
-	QPalette palette(this->palette());
-	QPalette pathPalette(this->palette());
-	QString pathStatusString = pathStatus(text);
+        QPalette palette(this->palette());
+        QPalette pathPalette(this->palette());
+        QString pathStatusString = pathStatus(text);
 
-	okButton_->setDisabled(text.isEmpty() || pathStatusString == "Absolute path does not exist!");
+        okButton_->setDisabled(text.isEmpty() || pathStatusString == "Absolute path does not exist!");
 
-	if (pathStatusString.contains("does not exist", Qt::CaseInsensitive)){
+        if (pathStatusString.contains("does not exist", Qt::CaseInsensitive)){
 
-		palette.setColor(QPalette::Text, Qt::red);
-		pathPalette.setColor(QPalette::WindowText, Qt::darkRed);
-	}
+                palette.setColor(QPalette::Text, Qt::red);
+                pathPalette.setColor(QPalette::WindowText, Qt::darkRed);
+        }
 
-	else if (pathStatusString.contains("Valid") || pathStatusString.contains("okay"))
-		pathPalette.setColor(QPalette::WindowText, Qt::darkGreen);
+        else if (pathStatusString.contains("Valid") || pathStatusString.contains("okay"))
+                pathPalette.setColor(QPalette::WindowText, Qt::darkGreen);
 
-	pathStatusLabel_->setText(pathStatusString);
-	pathStatusLabel_->setPalette(pathPalette);
-	pathComboBox_->setPalette(palette);
-	folder_ = text;
+        pathStatusLabel_->setText(pathStatusString);
+        pathStatusLabel_->setPalette(pathPalette);
+        pathComboBox_->setPalette(palette);
+        folder_ = text;
 }
 
 QString AMChooseDataFolderDialog::pathStatus(const QString &path) const
 {
-	bool isPath = path.contains("/");
-	bool pathExists = QFileInfo(path).exists();
+        bool isPath = path.contains("/");
+        bool pathExists = QFileInfo(path).exists();
 
-	if (path.isEmpty())
-		return "Does not exist!";
+        if (path.isEmpty())
+                return "Does not exist!";
 
-	else if (isPath && pathExists)
-		return "Absolute path okay!";
+        else if (isPath && pathExists)
+                return "Absolute path okay!";
 
-	else if (isPath && !pathExists)
-		return "Absolute path does not exist!";
+        else if (isPath && !pathExists)
+                return "Absolute path does not exist!";
 
-	else if (isProposalNumber(path))
-		return "Valid proposal number!";
+        else if (isProposalNumber(path))
+                return "Valid proposal number!";
 
-	else if (directories_.contains(path))
-		return "Valid existing experiment!";
+        else if (directories_.contains(path))
+                return "Valid existing experiment!";
 
-	else
-		return "New experiment!";
+        else
+                return "New experiment!";
 }
 
 bool AMChooseDataFolderDialog::isProposalNumber(const QString &path) const
 {
-	return path.contains(QRegExp("^\\d{2,2}-\\d{4,4}$"));
+        return path.contains(QRegExp("^\\d{2,2}-\\d{4,4}$"));
 }
 
 void AMChooseDataFolderDialog::getFilePath()
 {
-	QString path = folder_;
-	path.chop(1);
-	path = path.remove("/userData");
-	QString dir = QFileDialog::getExistingDirectory(this, "Choose a destination folder for your data.", path, QFileDialog::ShowDirsOnly);
+        QString path = folder_;
+        path.chop(1);
+        path = path.remove("/userData");
+        QString dir = QFileDialog::getExistingDirectory(this, "Choose a destination folder for your data.", path, QFileDialog::ShowDirsOnly);
 
-	if (!dir.isEmpty())
-		pathComboBox_->setEditText(dir);
+        if (!dir.isEmpty())
+                pathComboBox_->setEditText(dir);
 }

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -34,9 +34,9 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
                         QFileInfo localFullPath(QString("%1/%2/%3").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput));
 
                         bool isFirstTimeUser = !remoteFullPath.exists();
-                        bool failedFirstTimeStartup = (remoteFullPath.exists() && !localFullPath.exists());
+                        bool successfulFirstTimeStartup = localFullPath.exists();
 
-                        if (isFirstTimeUser && !failedFirstTimeStartup){
+                        if (isFirstTimeUser){
                                 QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
                                 newPath.mkpath(QString("%1/userData").arg(dialogInput));
 
@@ -48,17 +48,19 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
                                 AMUserSettings::save(true);
 
                         }
-                        else if(failedFirstTimeStartup){
-                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-                                AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-                                AMUserSettings::save(true);
-                        }
-                        else {
-
+                        else if(successfulFirstTimeStartup){
                                 AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
                                 AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
                                 AMUserSettings::save();
                         }
+                        else{
+                            //If this is not the first startup or startup was not successful last time:
+                            //Reset .ini user/remote folders to startup settings.
+                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::remoteDataFolder = "";
+                                AMUserSettings::save(true);
+                        }
+
                 }
 
                 else {

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -87,13 +87,12 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
                         //Then if the user switches from a short name data folder to full path data
                         //folder we avoid the case where the remote data folder .ini entry is not
                         //updated.
-                        QDir testRemotePath(dialog.filePath());
+                        QDir testRemotePath(userDataPath);
                         testRemotePath.cdUp();
                         if(!AMUserSettings::remoteDataFolder.contains(testRemotePath.dirName())){
                                 AMUserSettings::removeRemoteDataFolderEntry();
                         }
-
-			AMUserSettings::save();
+                        AMUserSettings::save();
 		}
 
 		return true;

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -27,12 +27,14 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
 		AMUserSettings::userBasedDataStorage = false;
 
 		QString dialogInput = dialog.filePath();
+                QFileInfo localFullPath(QString("%1/%2/%3").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput));
 
 		if (!dialog.isFullPath()){
 
 			QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
 
 			bool isFirstTimeUser = !remoteFullPath.exists();
+                        bool successfulFirstTimeStartup = localFullPath.exists();
 			if (isFirstTimeUser){
 
 				QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
@@ -46,12 +48,19 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
 				AMUserSettings::save(true);
 			}
 
-			else {
+                        else if(successfulFirstTimeStartup){
 
-				AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
-				AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-				AMUserSettings::save();
-			}
+                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::save();
+                        }
+                        else{
+                                //If this is not the first startup and first startup was not successful:
+                                //Reset .ini user and remote folders to first-startup settings.
+                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+                                AMUserSettings::remoteDataFolder = "";
+                                AMUserSettings::save(true);
+                        }
 		}
 
 		else {
@@ -73,6 +82,17 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
 				userDataPath.append("/");
 
 			AMUserSettings::userDataFolder = userDataPath;
+
+                        //Find the data folder name and see if it exists in the remoteDataFolder
+                        //Then if the user switches from a short name data folder to full path data
+                        //folder we avoid the case where the remote data folder .ini entry is not
+                        //updated.
+                        QDir testAPath(dialog.filePath());
+                        testAPath.cdUp();
+                        if(!AMUserSettings::remoteDataFolder.contains(testAPath.dirName())){
+                                AMUserSettings::removeRemoteDataFolderEntry();
+                        }
+
 			AMUserSettings::save();
 		}
 

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -27,11 +27,11 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
 		AMUserSettings::userBasedDataStorage = false;
 
 		QString dialogInput = dialog.filePath();
-                QFileInfo localFullPath(QString("%1/%2/%3").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput));
 
 		if (!dialog.isFullPath()){
 
 			QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
+                        QFileInfo localFullPath(QString("%1/%2/%3").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput));
 
 			bool isFirstTimeUser = !remoteFullPath.exists();
                         bool successfulFirstTimeStartup = localFullPath.exists();
@@ -87,9 +87,9 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
                         //Then if the user switches from a short name data folder to full path data
                         //folder we avoid the case where the remote data folder .ini entry is not
                         //updated.
-                        QDir testAPath(dialog.filePath());
-                        testAPath.cdUp();
-                        if(!AMUserSettings::remoteDataFolder.contains(testAPath.dirName())){
+                        QDir testRemotePath(dialog.filePath());
+                        testRemotePath.cdUp();
+                        if(!AMUserSettings::remoteDataFolder.contains(testRemotePath.dirName())){
                                 AMUserSettings::removeRemoteDataFolderEntry();
                         }
 

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -16,226 +16,217 @@
 
 bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, const QString &remoteRootDirectory, const QString &dataDirectory, const QStringList &extraDataDirectory, QWidget *parent)
 {
-        AMUserSettings::load();
+	AMUserSettings::load();
 
-        AMChooseDataFolderDialog dialog(AMUserSettings::userDataFolder, localRootDirectory, remoteRootDirectory, dataDirectory, parent);
-        dialog.exec();
+	AMChooseDataFolderDialog dialog(AMUserSettings::userDataFolder, localRootDirectory, remoteRootDirectory, dataDirectory, parent);
+	dialog.exec();
 
-        if (dialog.result() == QDialog::Accepted){
+	if (dialog.result() == QDialog::Accepted){
 
-                // when we are using this dialog, we are not user-account based storage
-                AMUserSettings::userBasedDataStorage = false;
+		// when we are using this dialog, we are not user-account based storage
+		AMUserSettings::userBasedDataStorage = false;
 
-                QString dialogInput = dialog.filePath();
+		QString dialogInput = dialog.filePath();
 
-                if (!dialog.isFullPath()){
+		if (!dialog.isFullPath()){
 
-                        QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
-                        QFileInfo localFullPath(QString("%1/%2/%3").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput));
+			QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
 
-                        bool isFirstTimeUser = !remoteFullPath.exists();
-                        bool successfulFirstTimeStartup = localFullPath.exists();
+			bool isFirstTimeUser = !remoteFullPath.exists();
+			if (isFirstTimeUser){
 
-                        if (isFirstTimeUser){
-                                QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
-                                newPath.mkpath(QString("%1/userData").arg(dialogInput));
+				QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
+				newPath.mkpath(QString("%1/userData").arg(dialogInput));
 
-                                foreach (QString newExtraDestination, extraDataDirectory)
-                                        newPath.mkpath(QString("%1/%2").arg(dialogInput).arg(newExtraDestination));
+				foreach (QString newExtraDestination, extraDataDirectory)
+					newPath.mkpath(QString("%1/%2").arg(dialogInput).arg(newExtraDestination));
 
-                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-                                AMUserSettings::remoteDataFolder = "";
-                                AMUserSettings::save(true);
+				AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+				AMUserSettings::remoteDataFolder = "";
+				AMUserSettings::save(true);
+			}
 
-                        }
-                        else if(successfulFirstTimeStartup){
-                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
-                                AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-                                AMUserSettings::save();
-                        }
-                        else{
-                            //If this is not the first startup or startup was not successful last time:
-                            //Reset .ini user/remote folders to startup settings.
-                                AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
-                                AMUserSettings::remoteDataFolder = "";
-                                AMUserSettings::save(true);
-                        }
+			else {
 
-                }
+				AMUserSettings::userDataFolder = QString("%1/%2/%3/userData/").arg(localRootDirectory).arg(dataDirectory).arg(dialogInput);
+				AMUserSettings::remoteDataFolder = QString("%1/%2/%3/userData/").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput);
+				AMUserSettings::save();
+			}
+		}
 
-                else {
+		else {
 
-                        QString userDataPath;
-                        if (dialogInput.endsWith("/userData") || dialogInput.endsWith("/userData/")) {
-                                userDataPath = dialogInput;
-                        } else {
-                                userDataPath = QString("%1/userData").arg(dialogInput);
-                        }
+			QString userDataPath;
+			if (dialogInput.endsWith("/userData") || dialogInput.endsWith("/userData/")) {
+				userDataPath = dialogInput;
+			} else {
+				userDataPath = QString("%1/userData").arg(dialogInput);
+			}
 
-                        QFileInfo remoteFullPath(userDataPath);
-                        if (!remoteFullPath.exists()) {
-                                QDir newPath(dialogInput);
-                                newPath.mkpath(userDataPath);
-                        }
+			QFileInfo remoteFullPath(userDataPath);
+			if (!remoteFullPath.exists()) {
+				QDir newPath(dialogInput);
+				newPath.mkpath(userDataPath);
+			}
 
-                        if (!userDataPath.endsWith("/"))
-                                userDataPath.append("/");
+			if (!userDataPath.endsWith("/"))
+				userDataPath.append("/");
 
-                        AMUserSettings::userDataFolder = userDataPath;
-                        AMUserSettings::save();
-                }
+			AMUserSettings::userDataFolder = userDataPath;
+			AMUserSettings::save();
+		}
 
-                return true;
-        }
+		return true;
+	}
 
-        else
-                return false;
+	else
+		return false;
 }
 
 //////////////////////////////////////
 
 AMChooseDataFolderDialog::AMChooseDataFolderDialog(const QString &dataFolder, const QString &localRootDirectory, const QString &remoteRootDirectory, const QString &dataDirectory, QWidget *parent)
-        : QDialog(parent)
+	: QDialog(parent)
 {
-        setWindowTitle("Choose Data Ouput Destination");
+	setWindowTitle("Choose Data Ouput Destination");
 
-        QString dataDestinationPath = dataDirectory.startsWith("/") ? dataDirectory : QString("/%1").arg(dataDirectory);
-        QString localDataDirectory = QString("%1%2").arg(localRootDirectory).arg(dataDestinationPath);
-        QString remoteDataDirectory = QString("%1%2").arg(remoteRootDirectory).arg(dataDestinationPath);
-        folder_ = dataFolder;
+	QString dataDestinationPath = dataDirectory.startsWith("/") ? dataDirectory : QString("/%1").arg(dataDirectory);
+	QString localDataDirectory = QString("%1%2").arg(localRootDirectory).arg(dataDestinationPath);
+	QString remoteDataDirectory = QString("%1%2").arg(remoteRootDirectory).arg(dataDestinationPath);
+	folder_ = dataFolder;
 
-        QLabel *explanation = new QLabel("Enter the proposal number or the absolute path to where you want your data to be saved.");
-        pathComboBox_ = new QComboBox;
-        pathComboBox_->setEditable(true);
+	QLabel *explanation = new QLabel("Enter the proposal number or the absolute path to where you want your data to be saved.");
+	pathComboBox_ = new QComboBox;
+	pathComboBox_->setEditable(true);
 
-        if (folder_.contains(dataDestinationPath)){
+	if (folder_.contains(dataDestinationPath)){
 
-                QString tempFolder = folder_;
-                tempFolder = tempFolder.left( tempFolder.indexOf(QRegExp(dataDestinationPath))+dataDestinationPath.length() );
-                QDir dir(tempFolder);
+		QString tempFolder = folder_;
+		tempFolder = tempFolder.left( tempFolder.indexOf(QRegExp(dataDestinationPath))+dataDestinationPath.length() );
+		QDir dir(tempFolder);
 
-                directories_ = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-        }
+		directories_ = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+	}
 
-        pathComboBox_->addItems(directories_);
+	pathComboBox_->addItems(directories_);
 
-        pathStatusLabel_ = new QLabel;
-        QFont pathFont(this->font());
-        pathFont.setItalic(true);
-        pathStatusLabel_->setFont(pathFont);
+	pathStatusLabel_ = new QLabel;
+	QFont pathFont(this->font());
+	pathFont.setItalic(true);
+	pathStatusLabel_->setFont(pathFont);
 
-        folderButton_ = new QToolButton;
-        folderButton_->setIcon(QIcon(":/22x22/folder.png"));
-        okButton_ = new QPushButton(QIcon(":/22x22/greenCheck.png"), "Okay");
-        QPushButton *cancelButton = new QPushButton(QIcon(":/22x22/list-remove-2.png"), "Cancel");
-        QString shortFormPath = "";
+	folderButton_ = new QToolButton;
+	folderButton_->setIcon(QIcon(":/22x22/folder.png"));
+	okButton_ = new QPushButton(QIcon(":/22x22/greenCheck.png"), "Okay");
+	QPushButton *cancelButton = new QPushButton(QIcon(":/22x22/list-remove-2.png"), "Cancel");
+	QString shortFormPath = "";
 
-        if (folder_.contains(localDataDirectory) || folder_.contains(remoteDataDirectory)){
+	if (folder_.contains(localDataDirectory) || folder_.contains(remoteDataDirectory)){
 
-                shortFormPath = folder_;
-                shortFormPath = shortFormPath.remove(QRegExp(QString("%1|%2").arg(localDataDirectory).arg(remoteDataDirectory)));
-                shortFormPath = shortFormPath.remove("/userData");
-                shortFormPath = shortFormPath.remove("/");
-        }
+		shortFormPath = folder_;
+		shortFormPath = shortFormPath.remove(QRegExp(QString("%1|%2").arg(localDataDirectory).arg(remoteDataDirectory)));
+		shortFormPath = shortFormPath.remove("/userData");
+		shortFormPath = shortFormPath.remove("/");
+	}
 
-        // If small form could not be resolved, then just use a full path.  Otherwise, set the folder text to the short form.
-        if (shortFormPath.isEmpty())
-                shortFormPath = folder_;
+	// If small form could not be resolved, then just use a full path.  Otherwise, set the folder text to the short form.
+	if (shortFormPath.isEmpty())
+		shortFormPath = folder_;
 
-        else
-                folder_ = shortFormPath;
+	else
+		folder_ = shortFormPath;
 
-        pathComboBox_->setEditText(shortFormPath);
+	pathComboBox_->setEditText(shortFormPath);
 
-        QHBoxLayout *lineEditLayout = new QHBoxLayout;
-        lineEditLayout->addWidget(pathComboBox_);
-        lineEditLayout->addWidget(pathStatusLabel_, 0, Qt::AlignCenter);
-        lineEditLayout->addWidget(folderButton_);
+	QHBoxLayout *lineEditLayout = new QHBoxLayout;
+	lineEditLayout->addWidget(pathComboBox_);
+	lineEditLayout->addWidget(pathStatusLabel_, 0, Qt::AlignCenter);
+	lineEditLayout->addWidget(folderButton_);
 
-        QHBoxLayout *buttonLayout = new QHBoxLayout;
-        buttonLayout->addStretch();
-        buttonLayout->addWidget(okButton_);
-        buttonLayout->addWidget(cancelButton);
+	QHBoxLayout *buttonLayout = new QHBoxLayout;
+	buttonLayout->addStretch();
+	buttonLayout->addWidget(okButton_);
+	buttonLayout->addWidget(cancelButton);
 
-        QVBoxLayout *layout = new QVBoxLayout;
-        layout->addWidget(explanation);
-        layout->addLayout(lineEditLayout);
-        layout->addLayout(buttonLayout);
+	QVBoxLayout *layout = new QVBoxLayout;
+	layout->addWidget(explanation);
+	layout->addLayout(lineEditLayout);
+	layout->addLayout(buttonLayout);
 
-        setLayout(layout);
+	setLayout(layout);
 
-        connect(folderButton_, SIGNAL(clicked()), this, SLOT(getFilePath()));
-        connect(okButton_, SIGNAL(clicked()), this, SLOT(accept()));
-        connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
-        connect(pathComboBox_, SIGNAL(editTextChanged(QString)), this, SLOT(onTextChanged(QString)));
+	connect(folderButton_, SIGNAL(clicked()), this, SLOT(getFilePath()));
+	connect(okButton_, SIGNAL(clicked()), this, SLOT(accept()));
+	connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+	connect(pathComboBox_, SIGNAL(editTextChanged(QString)), this, SLOT(onTextChanged(QString)));
 
-        onTextChanged(pathComboBox_->currentText());
+	onTextChanged(pathComboBox_->currentText());
 }
 
 bool AMChooseDataFolderDialog::isFullPath() const
 {
-        return folder_.contains("/");
+	return folder_.contains("/");
 }
 
 void AMChooseDataFolderDialog::onTextChanged(const QString &text)
 {
-        QPalette palette(this->palette());
-        QPalette pathPalette(this->palette());
-        QString pathStatusString = pathStatus(text);
+	QPalette palette(this->palette());
+	QPalette pathPalette(this->palette());
+	QString pathStatusString = pathStatus(text);
 
-        okButton_->setDisabled(text.isEmpty() || pathStatusString == "Absolute path does not exist!");
+	okButton_->setDisabled(text.isEmpty() || pathStatusString == "Absolute path does not exist!");
 
-        if (pathStatusString.contains("does not exist", Qt::CaseInsensitive)){
+	if (pathStatusString.contains("does not exist", Qt::CaseInsensitive)){
 
-                palette.setColor(QPalette::Text, Qt::red);
-                pathPalette.setColor(QPalette::WindowText, Qt::darkRed);
-        }
+		palette.setColor(QPalette::Text, Qt::red);
+		pathPalette.setColor(QPalette::WindowText, Qt::darkRed);
+	}
 
-        else if (pathStatusString.contains("Valid") || pathStatusString.contains("okay"))
-                pathPalette.setColor(QPalette::WindowText, Qt::darkGreen);
+	else if (pathStatusString.contains("Valid") || pathStatusString.contains("okay"))
+		pathPalette.setColor(QPalette::WindowText, Qt::darkGreen);
 
-        pathStatusLabel_->setText(pathStatusString);
-        pathStatusLabel_->setPalette(pathPalette);
-        pathComboBox_->setPalette(palette);
-        folder_ = text;
+	pathStatusLabel_->setText(pathStatusString);
+	pathStatusLabel_->setPalette(pathPalette);
+	pathComboBox_->setPalette(palette);
+	folder_ = text;
 }
 
 QString AMChooseDataFolderDialog::pathStatus(const QString &path) const
 {
-        bool isPath = path.contains("/");
-        bool pathExists = QFileInfo(path).exists();
+	bool isPath = path.contains("/");
+	bool pathExists = QFileInfo(path).exists();
 
-        if (path.isEmpty())
-                return "Does not exist!";
+	if (path.isEmpty())
+		return "Does not exist!";
 
-        else if (isPath && pathExists)
-                return "Absolute path okay!";
+	else if (isPath && pathExists)
+		return "Absolute path okay!";
 
-        else if (isPath && !pathExists)
-                return "Absolute path does not exist!";
+	else if (isPath && !pathExists)
+		return "Absolute path does not exist!";
 
-        else if (isProposalNumber(path))
-                return "Valid proposal number!";
+	else if (isProposalNumber(path))
+		return "Valid proposal number!";
 
-        else if (directories_.contains(path))
-                return "Valid existing experiment!";
+	else if (directories_.contains(path))
+		return "Valid existing experiment!";
 
-        else
-                return "New experiment!";
+	else
+		return "New experiment!";
 }
 
 bool AMChooseDataFolderDialog::isProposalNumber(const QString &path) const
 {
-        return path.contains(QRegExp("^\\d{2,2}-\\d{4,4}$"));
+	return path.contains(QRegExp("^\\d{2,2}-\\d{4,4}$"));
 }
 
 void AMChooseDataFolderDialog::getFilePath()
 {
-        QString path = folder_;
-        path.chop(1);
-        path = path.remove("/userData");
-        QString dir = QFileDialog::getExistingDirectory(this, "Choose a destination folder for your data.", path, QFileDialog::ShowDirsOnly);
+	QString path = folder_;
+	path.chop(1);
+	path = path.remove("/userData");
+	QString dir = QFileDialog::getExistingDirectory(this, "Choose a destination folder for your data.", path, QFileDialog::ShowDirsOnly);
 
-        if (!dir.isEmpty())
-                pathComboBox_->setEditText(dir);
+	if (!dir.isEmpty())
+		pathComboBox_->setEditText(dir);
 }

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -28,12 +28,17 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
 
 		QString dialogInput = dialog.filePath();
 
-		if (!dialog.isFullPath()){
+                if (!dialog.isFullPath()){
 
 			QFileInfo remoteFullPath(QString("%1/%2/%3").arg(remoteRootDirectory).arg(dataDirectory).arg(dialogInput));
 
 			bool isFirstTimeUser = !remoteFullPath.exists();
-			if (isFirstTimeUser){
+                        QFileInfo testLocalRootPath(localRootDirectory);
+                        QFileInfo testRemoteRootPath(remoteRootDirectory);
+
+                        //In the case that the startup procedure is interupted local and remote may not both exist.
+                        //If local does not exist and remote does, run startup again.
+                        if (isFirstTimeUser || (!testLocalRootPath.exists() && testRemoteRootPath.exists())){
 
 				QDir newPath(QString("%1/%2").arg(remoteRootDirectory).arg(dataDirectory));
 				newPath.mkpath(QString("%1/userData").arg(dialogInput));


### PR DESCRIPTION
First run sets the userDataFolder to the remote location on first run, and the local location for subsequent runs. The local location is not made since the wizard did not run with the first settings and the wizard tries to run at a non-existent location on the second. I adjusted the conditional logic so that: It checks if it is the first run, if not, it checks that the local location was made successfully, otherwise treat it like a first run.

I fixed another issue I noticed in testing where if a data folder is made with only the folder name in the dialog, then the user switches to a full path project, or specifies a previous data folder by the full path, the remoteDataFolder in the .ini is not updated and it attempts to sync the selected data folder with the previous remote data folder. 

Edited logic so that if the data folder name does not exist in the remote data path, delete the remoteDataFolder config entry. This avoids attempts to sync to the wrong folder. For full path data folders, remote is set by the network synchronizer. In the worst case, remoteDataFolder is deleted in error, and the user will be prompted if they want to use local storage with their project and it will be setup to the right location by the synchronizer again.

Resolves #2341