### PR TITLE
Pull request for Issue2335: Visualization for endstation kill switch status

### DIFF
--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -124,6 +124,8 @@ public:
 	/// Returns the SOE shutter.
 	virtual CLSExclusiveStatesControl* soeShutter() const { return soeShutter_; }
 
+        /// Returns the end station kill switch.
+        virtual AMReadOnlyPVControl* endStationKillSwitch() const { return 0; }
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return 0; }
 	/// Returns the JJ slits.

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -37,7 +37,7 @@ bool BioXASMainBeamline::isConnected() const
 				mono_ && mono_->isConnected() &&
 				m2Mirror_ && m2Mirror_->isConnected() &&
 
-                                endStationKillSwitch_ && endStationKillSwitch_->isConnected() &&
+				endStationKillSwitch_ && endStationKillSwitch_->isConnected() &&
 				beWindow_ && beWindow_->isConnected() &&
 				jjSlits_ && jjSlits_->isConnected() &&
 				xiaFilters_ && xiaFilters_->isConnected() &&
@@ -306,7 +306,7 @@ void BioXASMainBeamline::setupComponents()
 
         // Kill switch status.
 
-        endStationKillSwitch_ = new AMReadOnlyPVControl("BioXASEndStationKillSwitch", "SWES1607-7-01:Em:Off", this);
+		endStationKillSwitch_ = new AMReadOnlyPVControl("BioXASMainEndStationKillSwitch", "SWES1607-7-01:Em:Off", this);
         connect(endStationKillSwitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()));
 
 	// Be window.

--- a/source/beamline/BioXAS/BioXASMainBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASMainBeamline.cpp
@@ -37,6 +37,7 @@ bool BioXASMainBeamline::isConnected() const
 				mono_ && mono_->isConnected() &&
 				m2Mirror_ && m2Mirror_->isConnected() &&
 
+                                endStationKillSwitch_ && endStationKillSwitch_->isConnected() &&
 				beWindow_ && beWindow_->isConnected() &&
 				jjSlits_ && jjSlits_->isConnected() &&
 				xiaFilters_ && xiaFilters_->isConnected() &&
@@ -302,6 +303,11 @@ void BioXASMainBeamline::setupComponents()
 
 	beamStatus_->addComponent(m1Mirror_->mask()->state(), BioXASM1MirrorMaskState::Open);
 	beamStatus_->addComponent(mono_->maskState(), BioXASSSRLMonochromatorMaskState::Open);
+
+        // Kill switch status.
+
+        endStationKillSwitch_ = new AMReadOnlyPVControl("BioXASEndStationKillSwitch", "SWES1607-7-01:Em:Off", this);
+        connect(endStationKillSwitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()));
 
 	// Be window.
 

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -170,8 +170,8 @@ protected:
 	/// The SOE shutter.
 	CLSExclusiveStatesControl *soeShutter_;
 
-        AMReadOnlyPVControl *endStationKillSwitch_;
-
+	/// The end station kill switch
+	AMReadOnlyPVControl *endStationKillSwitch_;
 	/// The Be window motor.
 	CLSMAXvMotor *beWindow_;
 	/// JJ slits

--- a/source/beamline/BioXAS/BioXASMainBeamline.h
+++ b/source/beamline/BioXAS/BioXASMainBeamline.h
@@ -69,6 +69,8 @@ public:
 	/// Returns the beamline M2 mirror.
 	virtual BioXASM2Mirror *m2Mirror() const { return m2Mirror_; }
 
+        /// Returns the end station kill switch.
+        virtual AMReadOnlyPVControl* endStationKillSwitch() const { return endStationKillSwitch_; }
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return beWindow_; }
 	/// Returns the JJ slits.
@@ -167,6 +169,8 @@ protected:
 	BioXASMainM2Mirror *m2Mirror_;
 	/// The SOE shutter.
 	CLSExclusiveStatesControl *soeShutter_;
+
+        AMReadOnlyPVControl *endStationKillSwitch_;
 
 	/// The Be window motor.
 	CLSMAXvMotor *beWindow_;

--- a/source/beamline/BioXAS/BioXASSideBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASSideBeamline.cpp
@@ -44,6 +44,7 @@ bool BioXASSideBeamline::isConnected() const
 				mono_ && mono_->isConnected() &&
 				m2Mirror_ && m2Mirror_->isConnected() &&
 
+				endStationKillSwitch_ && endStationKillSwitch_->isConnected() &&
 				beWindow_ && beWindow_->isConnected() &&
 				jjSlits_ && jjSlits_->isConnected() &&
 				xiaFilters_ && xiaFilters_->isConnected() &&
@@ -304,6 +305,11 @@ void BioXASSideBeamline::setupComponents()
 
 	beamStatus_->addComponent(m1Mirror_->mask()->state(), BioXASM1MirrorMaskState::Open);
 	beamStatus_->addComponent(mono_->maskState(), BioXASSSRLMonochromatorMaskState::Open);
+
+	// End Station Kill Switch
+
+	endStationKillSwitch_ = new AMReadOnlyPVControl("BioXASSideEndStationKillSwitch", "SWES1607-6-01:Em:Off", this);
+	connect( endStationKillSwitch_, SIGNAL(connected(bool)), this, SLOT(updateConnected()) );
 
 	// Be window.
 

--- a/source/beamline/BioXAS/BioXASSideBeamline.h
+++ b/source/beamline/BioXAS/BioXASSideBeamline.h
@@ -70,6 +70,8 @@ public:
 	/// Returns the m2 mirror.
 	virtual BioXASSideM2Mirror* m2Mirror() const { return m2Mirror_; }
 
+	/// Returns the end station kill switch
+	virtual AMReadOnlyPVControl* endStationKillSwitch() const { return endStationKillSwitch_; }
 	/// Returns the Be window motor.
 	virtual CLSMAXvMotor* beWindow() const { return beWindow_; }
 	/// Returns the JJ slits.
@@ -179,6 +181,8 @@ protected:
 	/// The SOE shutter.
 	CLSExclusiveStatesControl *soeShutter_;
 
+	/// The end station kill switch
+	AMReadOnlyPVControl *endStationKillSwitch_;
 	/// The Be window motor.
 	CLSMAXvMotor *beWindow_;
 	/// The JJ slits

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -65,14 +65,14 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 		layout->addWidget(beamStatusBox);
 	}
 
-        // Create kill switch status view.
+	 // Create kill switch status view.
 
         AMReadOnlyPVControl *endStationKillSwitchStatus = BioXASBeamline::bioXAS()->endStationKillSwitch();
 
         if(endStationKillSwitchStatus){
 
             BioXASControlEditor *killSwitchEditor = new BioXASControlEditor(endStationKillSwitchStatus);
-
+			killSwitchEditor->setTitle("Endstation Motors Disabled");
             layout->addWidget(killSwitchEditor);
         }
 

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -65,6 +65,17 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 		layout->addWidget(beamStatusBox);
 	}
 
+        // Create kill switch status view.
+
+        AMReadOnlyPVControl *endStationKillSwitchStatus = BioXASBeamline::bioXAS()->endStationKillSwitch();
+
+        if(endStationKillSwitchStatus){
+
+            BioXASControlEditor *killSwitchEditor = new BioXASControlEditor(endStationKillSwitchStatus);
+
+            layout->addWidget(killSwitchEditor);
+        }
+
 	// Create mono view.
 
 	BioXASSSRLMonochromator *mono = BioXASBeamline::bioXAS()->mono();


### PR DESCRIPTION
Added a control for the end station kill switch in both BioXAS side and main. Added instances, connections and getters for the PV instances within their beamline classes. Added a control editor for the persistent view to view kill switch status. 

Testing complete BioXAS side, awaiting testing for main. 