### PR TITLE
Pull Request for Issue2322: Addressing build warnings for non-existent class files.

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -466,9 +466,6 @@ HEADERS += \
 	source/ui/beamline/AMSlitView.h  \
 	source/beamline/AMSlits.h \
 	source/ui/beamline/AMSlitsView.h \
-	source/beamline/AMTemperatureMonitor.h \
-	source/beamline/AMTemperatureMonitorGroup.h \
-	source/beamline/AMTemperatureMonitorGroupStatus.h \
     source/util/AMGeometry.h \
     source/beamline/AMBeamlineControlGroupStatus.h \
     source/beamline/AMBeamlineControlGroup.h \


### PR DESCRIPTION
Removed entries for the following class files from acquamanCommon.pri:
- AMTemperatureMonitor.h
- AMTemperatureMonitorGroup.h
- AMTemperatureMonitorGroupStatus.h

The build warnings don't appear anymore.