### PR TITLE
Pull Request for Issue2356: Show/hide sidebar panes

### DIFF
--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -472,7 +472,8 @@ HEADERS += \
     source/util/AMGeometry.h \
     source/beamline/AMBeamlineControlGroupStatus.h \
     source/beamline/AMBeamlineControlGroup.h \
-    source/beamline/AMBeamlineControl.h
+    source/beamline/AMBeamlineControl.h \
+    source/ui/AMWindowPaneProxyModel.h
 
 FORMS += \
 
@@ -904,7 +905,8 @@ SOURCES += \
 	source/ui/beamline/AMSlitsView.cpp \
     source/beamline/AMBeamlineControlGroupStatus.cpp \
     source/beamline/AMBeamlineControlGroup.cpp \
-    source/beamline/AMBeamlineControl.cpp
+    source/beamline/AMBeamlineControl.cpp \
+    source/ui/AMWindowPaneProxyModel.cpp
 
 RESOURCES *= \
 	source/icons/icons.qrc \
@@ -924,3 +926,5 @@ contains(DEFINES, AM_BUILD_REPORTER_ENABLED){
 
 	SOURCES *= source/util/AMRunTimeBuildInfo.cpp
 }
+
+

--- a/acquamanCommon.pri
+++ b/acquamanCommon.pri
@@ -926,5 +926,3 @@ contains(DEFINES, AM_BUILD_REPORTER_ENABLED){
 
 	SOURCES *= source/util/AMRunTimeBuildInfo.cpp
 }
-
-

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -101,22 +101,6 @@ void BioXASAppController::onRegionOfInterestBoundingRangeChanged(AMRegionOfInter
 		xasConfiguration_->setRegionOfInterestBoundingRange(region);
 }
 
-//void BioXASAppController::updateComponentsViewsVisibility()
-//{
-//    for (int i = 0, count = componentViewMapping_.keys().count(); i < count; i++) {
-//	AMControl *control = qobject_cast<AMControl*>(componentViewMapping_.keys().at(i));
-//	QWidget *view = componentViewMapping_.value(control, 0);
-//	QWidget *viewPane = viewPaneMapping_.value(view, 0);
-
-//	if (control && view && viewPane) {
-//	    if (control->isConnected())
-//		mw_->showPane(viewPane);
-//	    else
-//		mw_->hidePane(viewPane);
-//	}
-//    }
-//}
-
 void BioXASAppController::goToBeamStatusView(AMControl *control)
 {
 	if (beamStatusView_) {

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -128,6 +128,22 @@ void BioXASAppController::onRegionOfInterestBoundingRangeChanged(AMRegionOfInter
 		xasConfiguration_->setRegionOfInterestBoundingRange(region);
 }
 
+//void BioXASAppController::updateComponentsViewsVisibility()
+//{
+//    for (int i = 0, count = componentViewMapping_.keys().count(); i < count; i++) {
+//	AMControl *control = qobject_cast<AMControl*>(componentViewMapping_.keys().at(i));
+//	QWidget *view = componentViewMapping_.value(control, 0);
+//	QWidget *viewPane = viewPaneMapping_.value(view, 0);
+
+//	if (control && view && viewPane) {
+//	    if (control->isConnected())
+//		mw_->showPane(viewPane);
+//	    else
+//		mw_->hidePane(viewPane);
+//	}
+//    }
+//}
+
 void BioXASAppController::goToBeamStatusView(AMControl *control)
 {
 	if (beamStatusView_) {
@@ -328,7 +344,7 @@ void BioXASAppController::setupUserInterface()
 	addComponentView(BioXASBeamline::bioXAS()->cryostatStage(), "Cryostat Stage");
 	addComponentView(BioXASBeamline::bioXAS()->filterFlipper(), "Filter Flipper");
 	addComponentView(BioXASBeamline::bioXAS()->sollerSlit(), "Soller slits");
-	addComponentView(BioXASBeamline::bioXAS()->detectorStageLateralMotors(), "Ge 32-el Stage");
+//	addComponentView(BioXASBeamline::bioXAS()->detectorStageLateralMotors(), "Ge 32-el Stage");
 	addComponentView(BioXASBeamline::bioXAS()->zebra(), "Zebra");
 
 	addDetectorView(BioXASBeamline::bioXAS()->scaler(), "Scaler");
@@ -734,12 +750,26 @@ void BioXASAppController::addGeneralView(QObject *component, const QString &comp
 
 void BioXASAppController::addComponentView(QObject *component, const QString &componentName)
 {
-	addViewToComponentsPane( createComponentView(component), componentName );
+    if (component) {
+	QWidget *view = createComponentView(component);
+
+	if (view) {
+	    componentViewMapping_.insert(component, view);
+	    addViewToComponentsPane(view, componentName);
+	}
+    }
 }
 
 void BioXASAppController::addDetectorView(QObject *detector, const QString &detectorName)
 {
-	addViewToDetectorsPane( createComponentView(detector), detectorName );
+    if (detector) {
+	QWidget *view = createComponentView(detector);
+
+	if (view) {
+	    componentViewMapping_.insert(detector, view);
+	    addViewToDetectorsPane(view, detectorName);
+	}
+    }
 }
 
 void BioXASAppController::addScanConfigurationView(AMScanConfiguration *configuration, const QString &viewName)

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -102,6 +102,9 @@ protected slots:
 	/// Handles updating the regions of interest to all the configurations that would care.
 	virtual void onRegionOfInterestBoundingRangeChanged(AMRegionOfInterest *region);
 
+//	/// Handles updating the visibility of the view for the given component.
+//	virtual void updateComponentsViewsVisibility();
+
 	/// Sets the beam status view as the current view, with the given control as the selected control.
 	void goToBeamStatusView(AMControl *control);
 	/// Sets the monochromator energy calibration scan configuration view as the current pane.
@@ -198,6 +201,9 @@ protected:
 protected:
 	/// Holds the user configuration used for automatically setting up some simple aspects of the user interface.
 	BioXASUserConfiguration *userConfiguration_;
+
+	/// Mapping between components and views.
+	QMap<QObject*, QWidget*> componentViewMapping_;
 	/// Mapping between views and window panes. Used for switching the current pane.
 	QMap<QWidget*, QWidget*> viewPaneMapping_;
 

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -44,10 +44,31 @@ bool BioXASSideAppController::startup()
 
 	return result;
 }
+#include <QDebug>
+void BioXASSideAppController::onGeDetectorConnectedChanged()
+{
+    BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
+    QWidget *detectorView = componentViewMapping_.value(detector, 0);
+    QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
+
+    if (detector && detectorView && detectorPane) {
+	qDebug() << "\n\nSide Ge detector connected changed.";
+	qDebug() << "Detector connected:" << (detector->isConnected() ? "Yes" : "No");
+
+	if (detector->isConnected()) {
+	    mw_->showPane(detectorPane);
+	} else {
+	    mw_->hidePane(detectorPane);
+	}
+    }
+}
 
 void BioXASSideAppController::initializeBeamline()
 {
 	BioXASSideBeamline::bioXAS();
+
+	connect( BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(connected(bool)), this, SLOT(onGeDetectorConnectedChanged()) );
+	onGeDetectorConnectedChanged();
 
 	setupScanConfigurations();
 }

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -34,7 +34,7 @@ BioXASSideAppController::~BioXASSideAppController()
 
 }
 
-void BioXASSideAppController::onGeDetectorConnectedChanged()
+void BioXASSideAppController::updateGeDetectorView()
 {
     BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
     QWidget *detectorView = componentViewMapping_.value(detector, 0);
@@ -59,10 +59,6 @@ bool BioXASSideAppController::setupDataFolder()
 void BioXASSideAppController::initializeBeamline()
 {
 	BioXASSideBeamline::bioXAS();
-	connect( BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(connected(bool)), this, SLOT(onGeDetectorConnectedChanged()) );
-	onGeDetectorConnectedChanged();
-
-	setupScanConfigurations();
 }
 
 void BioXASSideAppController::setupUserInterfaceImplementation()
@@ -70,7 +66,11 @@ void BioXASSideAppController::setupUserInterfaceImplementation()
 	BioXASAppController::setupUserInterfaceImplementation();
 
 	// Side specific setup.
+
 	mw_->setWindowTitle("Acquaman - BioXAS Side");
+
+	connect( BioXASSideBeamline::bioXAS()->ge32ElementDetector(), SIGNAL(connected(bool)), this, SLOT(updateGeDetectorView()) );
+	onGeDetectorConnectedChanged();
 }
 
 void BioXASSideAppController::createDetectorPanes()

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -34,7 +34,6 @@ BioXASSideAppController::~BioXASSideAppController()
 
 }
 
-#include <QDebug>
 void BioXASSideAppController::onGeDetectorConnectedChanged()
 {
     BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
@@ -42,14 +41,10 @@ void BioXASSideAppController::onGeDetectorConnectedChanged()
     QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
 
     if (detector && detectorView && detectorPane) {
-	qDebug() << "\n\nSide Ge detector connected changed.";
-	qDebug() << "Detector connected:" << (detector->isConnected() ? "Yes" : "No");
-
-	if (detector->isConnected()) {
+	if (detector->isConnected())
 	    mw_->showPane(detectorPane);
-	} else {
+	else
 	    mw_->hidePane(detectorPane);
-	}
     }
 }
 

--- a/source/application/BioXAS/BioXASSideAppController.h
+++ b/source/application/BioXAS/BioXASSideAppController.h
@@ -35,8 +35,8 @@ public:
 	virtual ~BioXASSideAppController();
 
 protected slots:
-    /// testing.
-    void onGeDetectorConnectedChanged();
+	/// Updates the Ge detector view, showing or hiding the pane according to the detector's connected state.
+	void updateGeDetectorView();
 
 protected:
 	/// Sets up local and remote data paths.

--- a/source/application/BioXAS/BioXASSideAppController.h
+++ b/source/application/BioXAS/BioXASSideAppController.h
@@ -37,6 +37,10 @@ public:
 	/// Create and setup all of the application windows, widgets, communication connections, and data objects that are needed on program startup. Returns true on success, false otherwise.
 	virtual bool startup();
 
+protected slots:
+    /// testing.
+    void onGeDetectorConnectedChanged();
+
 protected:
 	/// Initializes the beamline object.
 	virtual void initializeBeamline();

--- a/source/application/CLS/CLSAppController.cpp
+++ b/source/application/CLS/CLSAppController.cpp
@@ -104,6 +104,9 @@ void CLSAppController::setupUserInterface()
 	// create the persistent view
 	createPersistentView();
 
+	// By default, the main headings are sidebar panes are expanded.
+	mw_->expandAllHeadings();
+
 	// customized user interface implementation for beamline
 	setupUserInterfaceImplementation();
 

--- a/source/ui/AMMainWindow.cpp
+++ b/source/ui/AMMainWindow.cpp
@@ -192,8 +192,6 @@ void AMMainWindow::onModelRowsInserted(const QModelIndex &parent, int start, int
 			}
 		}
 	}
-
-	sidebar_->expand(parent);
 }
 
 void AMMainWindow::onModelRowsAboutToBeRemoved(const QModelIndex &parent, int start, int end) {
@@ -238,6 +236,11 @@ void AMMainWindow::onItemRightClickDetected(const QModelIndex &index, const QPoi
 void AMMainWindow::collapseHeadingIndex(const QModelIndex &index)
 {
 	sidebar_->collapse(proxyModel_->mapFromSource(index));
+}
+
+void AMMainWindow::expandHeadingIndex(const QModelIndex &index)
+{
+    sidebar_->expand(proxyModel_->mapFromSource(index));
 }
 
 void AMMainWindow::onDockStateChanged(QWidget* pane, bool isDocked, bool shouldResize) {
@@ -303,6 +306,16 @@ void AMMainWindow::setCurrentIndex(const QModelIndex &i) {
 void AMMainWindow::collapseHeading(const QString &name)
 {
 	collapseHeadingIndex(model_->indexFromItem(model_->headingItem(name)));
+}
+
+void AMMainWindow::expandHeading(const QString &name)
+{
+    expandHeadingIndex(model_->indexFromItem(model_->headingItem(name)));
+}
+
+void AMMainWindow::expandAllHeadings()
+{
+    sidebar_->expandAll();
 }
 
 

--- a/source/ui/AMMainWindow.cpp
+++ b/source/ui/AMMainWindow.cpp
@@ -149,19 +149,16 @@ void AMMainWindow::showPane(QWidget *pane)
 {
     QModelIndex i = model_->indexForPane(pane);
 
-    if(i.isValid()) {
+    if(i.isValid())
 	model_->show(i);
-    }
 }
-#include <QDebug>
+
 void AMMainWindow::hidePane(QWidget *pane)
 {
     QModelIndex i = model_->indexForPane(pane);
 
-    if(i.isValid()) {
-	qDebug() << "Hiding pane.";
+    if(i.isValid())
 	model_->hide(i);
-    }
 }
 
 
@@ -266,10 +263,12 @@ void AMMainWindow::onDockStateChanged(QWidget* pane, bool isDocked, bool shouldR
 		pane->show();
 	}
 }
-#include <QDebug>
+
 void AMMainWindow::onVisibilityChanged(QWidget *pane, bool isVisible)
 {
-    qDebug() << "\n\nAMMainWindow: Visibility for a widget has changed:" << (isVisible ? "Visible" : "NOT visible");
+    // If a widget is no longer visible and at widget is the current widget
+    // for the stacked views, we need to change the current widget to
+    // something else--the stacked views' previousy visible widget.
 
     if (pane && stackWidget_->currentWidget() == pane && !isVisible)
 	sidebar_->setCurrentIndex(proxyModel_->mapFromSource(getPreviousSelection(model_->indexForPane(pane))));

--- a/source/ui/AMMainWindow.h
+++ b/source/ui/AMMainWindow.h
@@ -135,6 +135,10 @@ public slots:
 
 	/// Collapses the heading with the given name.
 	void collapseHeading(const QString &name);
+	/// Expands the heading with the given name.
+	void expandHeading(const QString &name);
+	/// Expands all headings.
+	void expandAllHeadings();
 
 signals:
 	/// advertises when a new widget was selected as the current widget. \note This is only emitted for widgets that are docked within the main window itself. It is not emitted when undocked widgets become current or raised by the user.
@@ -182,6 +186,8 @@ protected slots:
 
 	/// Collapses the heading at the given index.
 	void collapseHeadingIndex(const QModelIndex &index);
+	/// Expands the heading at the given index.
+	void expandHeadingIndex(const QModelIndex &index);
 
 protected:
 	QStackedWidget* stackWidget_;

--- a/source/ui/AMMainWindow.h
+++ b/source/ui/AMMainWindow.h
@@ -32,6 +32,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QTreeView>
 #include "ui/AMWindowPaneModel.h"
+#include "ui/AMWindowPaneProxyModel.h"
 
 #include <QQueue>
 
@@ -73,7 +74,7 @@ public:
 
 	/// Add a new \c pane to manage.  It will show up in the sidebar under category \c categoryName, with a \c title and an icon from \c iconFileName.  The \c resizeOnUndock is used to tell the manager to resize the pane to its sizeHint when it undocks. Returns a pointer to the newly-created window pane item in the model.
 	/*! \note Don't use this to add the same pane more than once. If you want to add an alias entry to an existing pane, use the model() directly. You can call AMWindowPaneModel::initAliasItem() to setup an item suitable for adding to the model as an alias. */
-	QStandardItem* addPane(QWidget* pane, const QString& categoryName, const QString& title, const QString& iconFileName, bool resizeOnUndock = false);
+	QStandardItem* addPane(QWidget* pane, const QString& categoryName, const QString& title, const QString& iconFileName, bool resizeOnUndock = false, bool visible = true);
 
 
 	/// Remove and delete a pane widget (whether docked or undocked)
@@ -81,6 +82,11 @@ public:
 
 	/// Remove a pane widget but do not delete it.  Ownership is now the responsibility of the caller. The pane becomes a top-level window.
 	void removePane(QWidget* pane);
+
+	/// Shows a pane.
+	void showPane(QWidget *pane);
+	/// Hides a pane.
+	void hidePane(QWidget *pane);
 
 
 	/// Insert a new heading item at a given index.  This can be used in situations where you want a pane added using addPane() to appear at a given \c position (from top to bottom).  Call insertHeading() first, with the top-level position and name of the heading, and then call addPane() with the same heading name.
@@ -162,6 +168,9 @@ protected slots:
 	/// Catches when the dock state of a widget changes in the model, and handles the actual docking/undocking of it. Also handles resizing if necessary.
 	void onDockStateChanged(QWidget* pane, bool isDocked, bool shouldResize);
 
+	/// Catches when the visibility of a pane widget changes in the model, and handles changing the current widget if appropriate.
+	void onVisibilityChanged(QWidget *pane, bool isVisible);
+
 	/// Catches when an item has been 'closed' by clicking on it's 'X' in the sidebar
 	void onItemCloseButtonClicked(const QModelIndex& index);
 
@@ -182,7 +191,10 @@ protected:
 	// addition for usability: when undocking or removing the current widget, we can use this to go back to the user's previous one. (Includes only docked selections)
 	QQueue<QPersistentModelIndex> previousSelections_;
 
+	/// The window pane model.
 	AMWindowPaneModel* model_;
+	/// The window pane proxy model. Allows for panes to be filtered.
+	AMWindowPaneProxyModel *proxyModel_;
 
 
 	void removeFromPreviousSelectionsQueue(const QModelIndex& removed);

--- a/source/ui/AMWindowPaneModel.cpp
+++ b/source/ui/AMWindowPaneModel.cpp
@@ -50,6 +50,7 @@ QStandardItem* AMWindowPaneModel::headingItem(const QString& text, QModelIndex p
 	font.setCapitalization(QFont::AllUppercase);
 	newHeading->setFont(font);
 	newHeading->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
+	newHeading->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 	QStandardItem* parent = itemFromIndex(parentIndex);
 	if(parent) {
@@ -109,6 +110,10 @@ QVariant AMWindowPaneModel::data(const QModelIndex &index, int role) const {
 	case AMWindowPaneModel::UndockResizeRole:
 		return AMDragDropItemModel::data(index, role);
 		break;
+
+	case AMWindowPaneModel::IsVisibleRole:
+	    return AMDragDropItemModel::data(index, role);
+	    break;
 
 	default:
 		return AMDragDropItemModel::data(index, role);
@@ -187,17 +192,29 @@ bool AMWindowPaneModel::setData(const QModelIndex &index, const QVariant &value,
 		return AMDragDropItemModel::setData(index, value, role);
 		break;
 
+	case AMWindowPaneModel::IsVisibleRole:
+	    if (AMDragDropItemModel::setData(index, value, role)) {
+		QWidget *pane = internalPane(index);
+		emit visibilityChanged(pane, value.toBool());
+		return true;
+	    } else {
+		return false;
+	    }
+
+	    break;
+
 	default:
 		return AMDragDropItemModel::setData(index, value, role);
 	}
 }
 
-QStandardItem* AMWindowPaneModel::addPane(QWidget* pane, const QString& headingText, bool resizeOnUndock) {
+QStandardItem* AMWindowPaneModel::addPane(QWidget* pane, const QString& headingText, bool resizeOnUndock, bool visible) {
 
 	QStandardItem* newItem = new QStandardItem();
 	newItem->setData(qVariantFromValue(pane), AM::WidgetRole);
 	newItem->setData(true, AMWindowPaneModel::DockStateRole);
 	newItem->setData(resizeOnUndock, AMWindowPaneModel::UndockResizeRole);
+	newItem->setData(visible, AMWindowPaneModel::IsVisibleRole);
 
 	newItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
@@ -206,12 +223,12 @@ QStandardItem* AMWindowPaneModel::addPane(QWidget* pane, const QString& headingT
 	return newItem;
 }
 
-QStandardItem* AMWindowPaneModel::addPane(QWidget *pane, const QString &headingText, const QString& windowTitle, const QIcon& windowIcon, bool resizeOnUndock) {
+QStandardItem* AMWindowPaneModel::addPane(QWidget *pane, const QString &headingText, const QString& windowTitle, const QIcon& windowIcon, bool resizeOnUndock, bool visible) {
 
 	pane->setWindowTitle(windowTitle);
 	pane->setWindowIcon(windowIcon);
 
-	return addPane(pane, headingText, resizeOnUndock);
+	return addPane(pane, headingText, resizeOnUndock, visible);
 }
 
 
@@ -233,6 +250,7 @@ void AMWindowPaneModel::initAliasItem(QStandardItem *newAliasItem, QStandardItem
 	newAliasItem->setData(aliasKey, AMWindowPaneModel::AliasKeyRole);
 	newAliasItem->setData(aliasValue, AMWindowPaneModel::AliasValueRole);
 	newAliasItem->setData(QVariant(), AM::WidgetRole);
+	newAliasItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 	newAliasItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
@@ -272,6 +290,11 @@ QStandardItem* AMWindowPaneModel::aliasTarget(const QModelIndex& index) const {
 /// Convenience function to check if this window pane is currently docked.
 bool AMWindowPaneModel::isDocked(const QModelIndex& index) const {
 	return data(index, AMWindowPaneModel::DockStateRole).toBool();
+}
+
+bool AMWindowPaneModel::isVisible(const QModelIndex &index) const
+{
+    return data(index, AMWindowPaneModel::IsVisibleRole).toBool();
 }
 
 /// Convenience function to return a pointer to an item's QWidget window pane. For alias items, will return the window pane of the target. \warning Might be 0 if an invalid item has been added to the model, or if this index is a heading item.

--- a/source/ui/AMWindowPaneModel.h
+++ b/source/ui/AMWindowPaneModel.h
@@ -77,7 +77,7 @@ class AMWindowPaneModel : public AMDragDropItemModel
 
 public:
 
-	enum DataRoles { DockStateRole = AM::UserRole + 1, IsHeadingRole, IsAliasRole, AliasTargetRole, AliasKeyRole, AliasValueRole, UndockResizeRole };
+	enum DataRoles { DockStateRole = AM::UserRole + 1, IsHeadingRole, IsAliasRole, AliasTargetRole, AliasKeyRole, AliasValueRole, UndockResizeRole, IsVisibleRole };
 
  	virtual ~AMWindowPaneModel();
 	AMWindowPaneModel(QObject* parent = 0);
@@ -96,9 +96,9 @@ public:
 	/// Insert a new window pane widget \c pane into the model, under the heading \c headingText. The \c resizeOnUndock is used to tell the manager to resize the pane to its sizeHint when it undocks. It returns the newly-created model item representing that pane.
 	/*! This is a convenience function. Alternatively, you can set the AM::WidgetRole pointer on any QStandardItem and add it using the conventional QStandardItemModel::addRow() interface.
 	\note \c pane must be a valid widget until this item is removed from the model */
-	QStandardItem* addPane(QWidget* pane, const QString& headingText = QString(), bool resizeOnUndock = false);
+	QStandardItem* addPane(QWidget* pane, const QString& headingText = QString(), bool resizeOnUndock = false, bool visible = true);
 	/// This is an overloaded function to allow setting the window title and icon while calling addPane().
-	QStandardItem* addPane(QWidget *pane, const QString &headingText, const QString& windowTitle, const QIcon& windowIcon, bool resizeOnUndock = false);
+	QStandardItem* addPane(QWidget *pane, const QString &headingText, const QString& windowTitle, const QIcon& windowIcon, bool resizeOnUndock = false, bool visible = true);
 
 	/// This convenience function can be used to initialize any QStandardItem as a proper "alias" item, pointing to the existing window pane widget \c targetWindowPane.  Returns true on success, and false if the \c targetWindowPane was not found in the model.  It modifies \c newAliasItem to set the IsAliasRole, AliasTargetRole, AliasKeyRole, and AliasValueRole, but does not add the item to the model. (You should follow up by inserting it anywhere you want.)
 	bool initAliasItem(QStandardItem* newAliasItem, QWidget* targetWindowPane, const QString& aliasKey = QString(), const QVariant& aliasValue = QVariant());
@@ -133,6 +133,9 @@ public:
 	/// Convenience function to check if this window pane is currently docked.
 	bool isDocked(const QModelIndex& index) const;
 
+	/// Returns true if the window pane is currently visible.
+	bool isVisible(const QModelIndex &index) const;
+
 	/// Convenience function to return a pointer to an item's QWidget window pane. For alias items, will return the window pane of the target. \warning Might be 0 if an invalid item has been added to the model, or if this index is a heading item.
 	QWidget* pane(const QModelIndex& index) const;
 
@@ -144,10 +147,18 @@ public:
 	void dock(const QModelIndex& index) { setDocked(index, true); }
 	void undock(const QModelIndex& index) { setDocked(index, false); }
 
+	/// Sets a pane's visibility.
+	void setVisibility(const QModelIndex &index, bool isVisible) { setData(index, isVisible, IsVisibleRole); }
+	/// Shows a pane.
+	void show(const QModelIndex &index) { setVisibility(index, true); }
+	/// Hides a pane.
+	void hide(const QModelIndex &index) { setVisibility(index, false); }
+
 signals:
 	/// Emitted when the dock state changes for an item (ie: true emitted when docked, false emitted when undocked) and whether or not a resize is desired
 	void dockStateChanged(QWidget* pane, bool isDocked, bool shouldResize);
-
+	/// Emitted when the visibility changes for an item.
+	void visibilityChanged(QWidget *pane, bool isVisible);
 	/// The default rowsAboutToBeRemoved() signal gets delivered to Qt views before any programmer-created connections are called. This can be a problem because the attached view will change its selection in response to the removal BEFORE the programmer can respond.  If this unacceptable to you (ie: you want to change the selection yourself, and just once to avoid flicker) then you can watch for this signal instead.  Both this and the normal signal will be delivered.
 	void rowsAboutToBeAboutToBeRemoved(const QModelIndex& parent, int first, int last);
 

--- a/source/ui/AMWindowPaneProxyModel.cpp
+++ b/source/ui/AMWindowPaneProxyModel.cpp
@@ -28,7 +28,6 @@ void AMWindowPaneProxyModel::setSourceModel(QAbstractItemModel *sourceModel)
     }
 }
 
-#include <QDebug>
 bool AMWindowPaneProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
 {
     bool result = false;
@@ -40,8 +39,6 @@ bool AMWindowPaneProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &
 
 	if (data.isValid())
 	    result = data.toBool();
-
-	qDebug() << "\n\nWindow pane for index" << sourceRow << "is visible:" << (result ? "Yes" : "No");
     }
 
     return result;

--- a/source/ui/AMWindowPaneProxyModel.cpp
+++ b/source/ui/AMWindowPaneProxyModel.cpp
@@ -1,0 +1,48 @@
+#include "AMWindowPaneProxyModel.h"
+#include "ui/AMWindowPaneModel.h"
+
+AMWindowPaneProxyModel::AMWindowPaneProxyModel(QObject *parent) :
+    QSortFilterProxyModel(parent)
+{
+
+}
+
+AMWindowPaneProxyModel::~AMWindowPaneProxyModel()
+{
+
+}
+
+void AMWindowPaneProxyModel::setSourceModel(QAbstractItemModel *sourceModel)
+{
+    QSortFilterProxyModel::setSourceModel(sourceModel);
+
+    AMWindowPaneModel *windowPaneModel = qobject_cast<AMWindowPaneModel*>(sourceModel);
+
+    if (windowPaneModel) {
+	connect( windowPaneModel, SIGNAL(visibilityChanged(QWidget*,bool)), this, SLOT(invalidate()) );
+	connect( windowPaneModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)), this, SLOT(invalidate()) );
+	connect( windowPaneModel, SIGNAL(rowsInserted(QModelIndex,int,int)), this, SLOT(invalidate()) );
+	connect( windowPaneModel, SIGNAL(rowsRemoved(QModelIndex,int,int)), this, SLOT(invalidate()) );
+
+	invalidate();
+    }
+}
+
+#include <QDebug>
+bool AMWindowPaneProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    bool result = false;
+
+    AMWindowPaneModel *windowPaneModel = qobject_cast<AMWindowPaneModel*>(sourceModel());
+
+    if (windowPaneModel) {
+	QVariant data = windowPaneModel->data(windowPaneModel->index(sourceRow, 0, sourceParent), AMWindowPaneModel::IsVisibleRole);
+
+	if (data.isValid())
+	    result = data.toBool();
+
+	qDebug() << "\n\nWindow pane for index" << sourceRow << "is visible:" << (result ? "Yes" : "No");
+    }
+
+    return result;
+}

--- a/source/ui/AMWindowPaneProxyModel.h
+++ b/source/ui/AMWindowPaneProxyModel.h
@@ -1,0 +1,26 @@
+#ifndef AMWINDOWPANEPROXYMODEL_H
+#define AMWINDOWPANEPROXYMODEL_H
+
+#include <QSortFilterProxyModel>
+
+class AMWindowPaneProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    /// Constructor.
+    explicit AMWindowPaneProxyModel(QObject *parent = 0);
+    /// Destructor.
+    virtual ~AMWindowPaneProxyModel();
+
+public slots:
+    /// Sets the proxy model's source. Reimplemented to invalidate the current sort/filter when the source's data changes.
+    virtual void setSourceModel(QAbstractItemModel *sourceModel);
+
+protected:
+    /// Returns true if the item with the given parent and row should be included in the model.
+    virtual bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
+
+};
+
+#endif // AMWINDOWPANEPROXYMODEL_H


### PR DESCRIPTION
Created a new class AMWindowPaneProxyModel, a subclass of QSortFilterProxyModel. This class basically will reassign QModelIndexes based on given sort or filter rules. In this case, the proxy model will ignore window pane items that have the AMWindowPaneModel::IsVisibleRole set to false and include all others. The proxy model replaces AMWindowPaneModel as the model for the sidebar. By default, all panes are visible, but can use new methods in AMMainWindow to show or hide panes as appropriate. Modified BioXASSideAppController to only show the Ge detector view if the detector is connected.