### PR TITLE
Pull Request for Issue2359: Fixing Zebra output controls connected signal

### DIFF
--- a/source/beamline/BioXAS/BioXASZebra.cpp
+++ b/source/beamline/BioXAS/BioXASZebra.cpp
@@ -129,30 +129,45 @@ BioXASZebraOutputControl* BioXASZebra::outputControlAt(int index) const
 
 	return result;
 }
-
+#include <QDebug>
 void BioXASZebra::onConnectedChanged()
 {
+
+    qDebug() << "\n\nUpdating Zebra connected state...";
+
 	bool connected = true;
 
 	foreach(BioXASZebraPulseControl *pulseControl, pulseControls_)
 		connected &= pulseControl->isConnected();
 
+	qDebug() << "\tPulse controls connected:" << (connected ? "Yes" : "No");
+
 	foreach (AMControl *control, softInputControls_)
 		connected &= control->isConnected();
+
+	qDebug() << "\tSoft input controls connected:" << (connected ? "Yes" : "No");
 
 	foreach (AMControl *andBlock, andBlocks_)
 		connected &= andBlock->isConnected();
 
+	qDebug() << "\tAND block controls connected:" << (connected ? "Yes" : "No");
+
 	foreach (AMControl *orBlock, orBlocks_)
 		connected &= orBlock->isConnected();
 
+	qDebug() << "\tOR block controls connected:" << (connected ? "Yes" : "No");
+
 	foreach (AMControl *outputControl, outputControls_)
 		connected &= outputControl->isConnected();
+
+	qDebug() << "\tOutput controls connected:" << (connected ? "Yes" : "No");
 
 	if (connected_ != connected){
 		connected_ = connected;
 		emit connectedChanged(connected_);
 	}
+
+	qDebug() << "Zebra connected:" << (connected ? "Yes" : "No");
 
 	// Add the appropriate pulse controls to the list of synchronized
 	// pulse controls. This must happen only after they are connected,
@@ -169,6 +184,8 @@ bool BioXASZebra::addSynchronizedPulseControl(BioXASZebraPulseControl *newContro
 	bool result = false;
 
 	if (newControl && !synchronizedPulseControls_.contains(newControl)) {
+
+	    qDebug() << "\n\nAdding synchronized pulse control" << newControl->name();
 
 		// Add control to the list of synchronized pulse controls.
 

--- a/source/beamline/BioXAS/BioXASZebra.cpp
+++ b/source/beamline/BioXAS/BioXASZebra.cpp
@@ -129,45 +129,30 @@ BioXASZebraOutputControl* BioXASZebra::outputControlAt(int index) const
 
 	return result;
 }
-#include <QDebug>
+
 void BioXASZebra::onConnectedChanged()
 {
-
-    qDebug() << "\n\nUpdating Zebra connected state...";
-
 	bool connected = true;
 
 	foreach(BioXASZebraPulseControl *pulseControl, pulseControls_)
 		connected &= pulseControl->isConnected();
 
-	qDebug() << "\tPulse controls connected:" << (connected ? "Yes" : "No");
-
 	foreach (AMControl *control, softInputControls_)
 		connected &= control->isConnected();
-
-	qDebug() << "\tSoft input controls connected:" << (connected ? "Yes" : "No");
 
 	foreach (AMControl *andBlock, andBlocks_)
 		connected &= andBlock->isConnected();
 
-	qDebug() << "\tAND block controls connected:" << (connected ? "Yes" : "No");
-
 	foreach (AMControl *orBlock, orBlocks_)
 		connected &= orBlock->isConnected();
 
-	qDebug() << "\tOR block controls connected:" << (connected ? "Yes" : "No");
-
 	foreach (AMControl *outputControl, outputControls_)
 		connected &= outputControl->isConnected();
-
-	qDebug() << "\tOutput controls connected:" << (connected ? "Yes" : "No");
 
 	if (connected_ != connected){
 		connected_ = connected;
 		emit connectedChanged(connected_);
 	}
-
-	qDebug() << "Zebra connected:" << (connected ? "Yes" : "No");
 
 	// Add the appropriate pulse controls to the list of synchronized
 	// pulse controls. This must happen only after they are connected,
@@ -184,8 +169,6 @@ bool BioXASZebra::addSynchronizedPulseControl(BioXASZebraPulseControl *newContro
 	bool result = false;
 
 	if (newControl && !synchronizedPulseControls_.contains(newControl)) {
-
-	    qDebug() << "\n\nAdding synchronized pulse control" << newControl->name();
 
 		// Add control to the list of synchronized pulse controls.
 

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -69,12 +69,10 @@ void BioXASZebraOutputControl::setOutputValuePreference(int newValue)
 		emit outputValuePreferenceChanged(outputValuePreference_);
 	}
 }
-#include <QDebug>
+
 void BioXASZebraOutputControl::onControlSetConnectedChanged()
 {
 	updateOutputValueControl();
-
-	qDebug() << "\n\nControl" << name() << "connected:" << (isConnected() ? "Yes" : "No");
 
 	emit connected(allControls_->isConnected());
 }

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.cpp
@@ -69,12 +69,14 @@ void BioXASZebraOutputControl::setOutputValuePreference(int newValue)
 		emit outputValuePreferenceChanged(outputValuePreference_);
 	}
 }
-
+#include <QDebug>
 void BioXASZebraOutputControl::onControlSetConnectedChanged()
 {
 	updateOutputValueControl();
 
-	emit connectedChanged(allControls_->isConnected());
+	qDebug() << "\n\nControl" << name() << "connected:" << (isConnected() ? "Yes" : "No");
+
+	emit connected(allControls_->isConnected());
 }
 
 void BioXASZebraOutputControl::onOutputValueChanged()

--- a/source/beamline/BioXAS/BioXASZebraOutputControl.h
+++ b/source/beamline/BioXAS/BioXASZebraOutputControl.h
@@ -39,8 +39,6 @@ public:
 	AMReadOnlyPVControl* outputStatusControl() const { return outputStatusControl_; }
 
 signals:
-	/// Notifier that the connected state has changed.
-	void connectedChanged(bool);
 	/// Notifier that the output value has changed.
 	void outputValueChanged(int);
 	/// Notifier that the output value string has changed.


### PR DESCRIPTION
The Zebra output controls were using the wrong signal to announce changes in their connected state. Modified the control to use the appropriate signal.