### PR TITLE
Pull Request for Issue2373: Show window items by default.

### DIFF
--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -989,7 +989,7 @@ bool AMDatamanAppController::startupCreateUserInterface()
 	dataViewItem->setFont(font);
 	dataViewItem->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
 	dataViewItem->setData(true, AMWindowPaneModel::DockStateRole);
-	dataViewItem->setData(true, AMWindowPaneModel::IsVisibleRole);
+	//dataViewItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 	mw_->windowPaneModel()->appendRow(dataViewItem);
 
@@ -1523,7 +1523,7 @@ AMGenericScanEditor *AMDatamanAppController::createNewScanEditor(bool use2DScanV
 {
 	AMGenericScanEditor* editor = new AMGenericScanEditor(use2DScanView);
 	AMScanEditorModelItem *newItem = new AMScanEditorModelItem(editor, this);
-	newItem->setData(true, AMWindowPaneModel::IsVisibleRole);
+	//newItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 	scanEditorsParentItem_->appendRow(newItem);
 	emit scanEditorCreated(editor);
 	return editor;
@@ -1963,7 +1963,7 @@ void AMDatamanAppController::onOpenOtherDatabaseClicked()
 		dataViewItem->setFont(font);
 		dataViewItem->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
 		dataViewItem->setData(true, AMWindowPaneModel::DockStateRole);
-		dataViewItem->setData(true, AMWindowPaneModel::IsVisibleRole);
+		//dataViewItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 		mw_->windowPaneModel()->appendRow(dataViewItem);
 

--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -1523,7 +1523,6 @@ AMGenericScanEditor *AMDatamanAppController::createNewScanEditor(bool use2DScanV
 {
 	AMGenericScanEditor* editor = new AMGenericScanEditor(use2DScanView);
 	AMScanEditorModelItem *newItem = new AMScanEditorModelItem(editor, this);
-	//newItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 	scanEditorsParentItem_->appendRow(newItem);
 	emit scanEditorCreated(editor);
 	return editor;
@@ -1963,7 +1962,6 @@ void AMDatamanAppController::onOpenOtherDatabaseClicked()
 		dataViewItem->setFont(font);
 		dataViewItem->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
 		dataViewItem->setData(true, AMWindowPaneModel::DockStateRole);
-		//dataViewItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 		mw_->windowPaneModel()->appendRow(dataViewItem);
 

--- a/source/ui/AMWindowPaneModel.cpp
+++ b/source/ui/AMWindowPaneModel.cpp
@@ -50,7 +50,6 @@ QStandardItem* AMWindowPaneModel::headingItem(const QString& text, QModelIndex p
 	font.setCapitalization(QFont::AllUppercase);
 	newHeading->setFont(font);
 	newHeading->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
-	//newHeading->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 	QStandardItem* parent = itemFromIndex(parentIndex);
 	if(parent) {
@@ -273,8 +272,6 @@ void AMWindowPaneModel::initAliasItem(QStandardItem *newAliasItem, QStandardItem
 	newAliasItem->setData(aliasKey, AMWindowPaneModel::AliasKeyRole);
 	newAliasItem->setData(aliasValue, AMWindowPaneModel::AliasValueRole);
 	newAliasItem->setData(QVariant(), AM::WidgetRole);
-	//newAliasItem->setData(true, AMWindowPaneModel::IsVisibleRole);
-
 	newAliasItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
 }

--- a/source/ui/AMWindowPaneModel.cpp
+++ b/source/ui/AMWindowPaneModel.cpp
@@ -50,7 +50,7 @@ QStandardItem* AMWindowPaneModel::headingItem(const QString& text, QModelIndex p
 	font.setCapitalization(QFont::AllUppercase);
 	newHeading->setFont(font);
 	newHeading->setData(QBrush(QColor::fromRgb(100, 109, 125)), Qt::ForegroundRole);
-	newHeading->setData(true, AMWindowPaneModel::IsVisibleRole);
+	//newHeading->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 	QStandardItem* parent = itemFromIndex(parentIndex);
 	if(parent) {
@@ -132,7 +132,10 @@ QVariant AMWindowPaneModel::data(const QModelIndex &index, int role) const {
 		break;
 
 	case AMWindowPaneModel::IsVisibleRole:
-	    return AMDragDropItemModel::data(index, role);
+		if (AMDragDropItemModel::data(index, role).isValid())
+			return AMDragDropItemModel::data(index, role);
+		else
+			return true;
 	    break;
 
 	default:
@@ -214,11 +217,11 @@ bool AMWindowPaneModel::setData(const QModelIndex &index, const QVariant &value,
 
 	case AMWindowPaneModel::IsVisibleRole:
 	    if (AMDragDropItemModel::setData(index, value, role)) {
-		QWidget *pane = internalPane(index);
-		emit visibilityChanged(pane, value.toBool());
-		return true;
+			QWidget *pane = internalPane(index);
+			emit visibilityChanged(pane, value.toBool());
+			return true;
 	    } else {
-		return false;
+			return false;
 	    }
 
 	    break;
@@ -270,7 +273,7 @@ void AMWindowPaneModel::initAliasItem(QStandardItem *newAliasItem, QStandardItem
 	newAliasItem->setData(aliasKey, AMWindowPaneModel::AliasKeyRole);
 	newAliasItem->setData(aliasValue, AMWindowPaneModel::AliasValueRole);
 	newAliasItem->setData(QVariant(), AM::WidgetRole);
-	newAliasItem->setData(true, AMWindowPaneModel::IsVisibleRole);
+	//newAliasItem->setData(true, AMWindowPaneModel::IsVisibleRole);
 
 	newAliasItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 


### PR DESCRIPTION
Made a small modification to AMWindowPaneModel. When queried for the visibility of a particular window item, the model will return true if there is no visibility setting specified for the item, instead of returning an invalid QVariant. This should ensure that items with no visibility set should show up, but the setting is obeyed for others.