### PR TITLE
Pull Request for Issue 2377: Add additional functionality to PGM scan configuration view.

### DIFF
--- a/PGMAcquaman_internal.pro
+++ b/PGMAcquaman_internal.pro
@@ -21,12 +21,12 @@ HEADERS +=	\
 	source/ui/PGM/PGMBeamStatusView.h \
 	source/ui/PGM/PGMBPMStatusView.h \
 	source/ui/PGM/PGMBladeCurrentView.h \
-    source/ui/PGM/PGMPicoAmmeterView.h \
-    source/ui/PGM/PGMXASScanConfigurationView.h \
+	source/ui/PGM/PGMPicoAmmeterView.h \
+	source/ui/PGM/PGMXASScanConfigurationView.h \
 	source/ui/PGM/PGMGratingView.h \
-    source/ui/PGM/PGMUndulatorView.h \
-    source/ui/PGM/PGMVariableApertureMaskView.h \
-    source/beamline/PGM/PGMMonoGratingSelectionControl.h
+	source/ui/PGM/PGMUndulatorView.h \
+	source/ui/PGM/PGMVariableApertureMaskView.h \
+	source/beamline/PGM/PGMMonoGratingSelectionControl.h
 
 SOURCES +=	\
 	source/application/PGM/PGMMain.cpp \
@@ -45,9 +45,9 @@ SOURCES +=	\
 	source/ui/PGM/PGMBeamStatusView.cpp \
 	source/ui/PGM/PGMBPMStatusView.cpp \
 	source/ui/PGM/PGMBladeCurrentView.cpp \
-    source/ui/PGM/PGMPicoAmmeterView.cpp \
-    source/ui/PGM/PGMXASScanConfigurationView.cpp \
+	source/ui/PGM/PGMPicoAmmeterView.cpp \
+	source/ui/PGM/PGMXASScanConfigurationView.cpp \
 	source/ui/PGM/PGMGratingView.cpp \
-    source/ui/PGM/PGMUndulatorView.cpp \
-    source/ui/PGM/PGMVariableApertureMaskView.cpp \
-    source/beamline/PGM/PGMMonoGratingSelectionControl.cpp
+	source/ui/PGM/PGMUndulatorView.cpp \
+	source/ui/PGM/PGMVariableApertureMaskView.cpp \
+	source/beamline/PGM/PGMMonoGratingSelectionControl.cpp

--- a/PGMAcquaman_internal.pro
+++ b/PGMAcquaman_internal.pro
@@ -25,7 +25,6 @@ HEADERS +=	\
     source/ui/PGM/PGMXASScanConfigurationView.h \
 	source/ui/PGM/PGMGratingView.h \
     source/ui/PGM/PGMUndulatorView.h \
-    source/beamline/PGM/PGMBranchSelectionControl.h \
     source/ui/PGM/PGMVariableApertureMaskView.h \
     source/beamline/PGM/PGMMonoGratingSelectionControl.h
 

--- a/PGMAcquaman_internal.pro
+++ b/PGMAcquaman_internal.pro
@@ -21,12 +21,12 @@ HEADERS +=	\
 	source/ui/PGM/PGMBeamStatusView.h \
 	source/ui/PGM/PGMBPMStatusView.h \
 	source/ui/PGM/PGMBladeCurrentView.h \
-    source/ui/PGM/PGMPicoAmmeterView.h \
-    source/ui/PGM/PGMXASScanConfigurationView.h \
+	source/ui/PGM/PGMPicoAmmeterView.h \
+	source/ui/PGM/PGMXASScanConfigurationView.h \
 	source/ui/PGM/PGMGratingView.h \
 	source/ui/PGM/PGMUndulatorView.h \
 	source/ui/PGM/PGMVariableApertureMaskView.h \
-    source/beamline/PGM/PGMMonoGratingSelectionControl.h
+	source/beamline/PGM/PGMMonoGratingSelectionControl.h
 
 SOURCES +=	\
 	source/application/PGM/PGMMain.cpp \

--- a/PGMAcquaman_internal.pro
+++ b/PGMAcquaman_internal.pro
@@ -21,12 +21,12 @@ HEADERS +=	\
 	source/ui/PGM/PGMBeamStatusView.h \
 	source/ui/PGM/PGMBPMStatusView.h \
 	source/ui/PGM/PGMBladeCurrentView.h \
-	source/ui/PGM/PGMPicoAmmeterView.h \
-	source/ui/PGM/PGMXASScanConfigurationView.h \
+    source/ui/PGM/PGMPicoAmmeterView.h \
+    source/ui/PGM/PGMXASScanConfigurationView.h \
 	source/ui/PGM/PGMGratingView.h \
-	source/ui/PGM/PGMUndulatorView.h \
-	source/ui/PGM/PGMVariableApertureMaskView.h \
-	source/beamline/PGM/PGMMonoGratingSelectionControl.h
+    source/ui/PGM/PGMUndulatorView.h \
+    source/ui/PGM/PGMVariableApertureMaskView.h \
+    source/beamline/PGM/PGMMonoGratingSelectionControl.h
 
 SOURCES +=	\
 	source/application/PGM/PGMMain.cpp \

--- a/PGMAcquaman_internal.pro
+++ b/PGMAcquaman_internal.pro
@@ -24,8 +24,8 @@ HEADERS +=	\
     source/ui/PGM/PGMPicoAmmeterView.h \
     source/ui/PGM/PGMXASScanConfigurationView.h \
 	source/ui/PGM/PGMGratingView.h \
-    source/ui/PGM/PGMUndulatorView.h \
-    source/ui/PGM/PGMVariableApertureMaskView.h \
+	source/ui/PGM/PGMUndulatorView.h \
+	source/ui/PGM/PGMVariableApertureMaskView.h \
     source/beamline/PGM/PGMMonoGratingSelectionControl.h
 
 SOURCES +=	\

--- a/source/acquaman/PGM/PGMXASScanConfiguration.cpp
+++ b/source/acquaman/PGM/PGMXASScanConfiguration.cpp
@@ -34,5 +34,5 @@ AMScanController *PGMXASScanConfiguration::createController()
 
 AMScanConfigurationView *PGMXASScanConfiguration::createView()
 {
-        return new PGMXASScanConfigurationView(this, AMBeamline::bl()->exposedScientificDetectors());
+        return new PGMXASScanConfigurationView(this);
 }

--- a/source/acquaman/PGM/PGMXASScanConfiguration.cpp
+++ b/source/acquaman/PGM/PGMXASScanConfiguration.cpp
@@ -34,5 +34,5 @@ AMScanController *PGMXASScanConfiguration::createController()
 
 AMScanConfigurationView *PGMXASScanConfiguration::createView()
 {
-        return new PGMXASScanConfigurationView(this);
+	return new PGMXASScanConfigurationView(this);
 }

--- a/source/acquaman/PGM/PGMXASScanConfiguration.cpp
+++ b/source/acquaman/PGM/PGMXASScanConfiguration.cpp
@@ -1,6 +1,7 @@
 #include "PGMXASScanConfiguration.h"
 
 #include "ui/PGM/PGMXASScanConfigurationView.h"
+#include "beamline/PGM/PGMBeamline.h"
 #include "acquaman/PGM/PGMXASScanController.h"
 
 PGMXASScanConfiguration::PGMXASScanConfiguration(QObject *parent)
@@ -33,5 +34,5 @@ AMScanController *PGMXASScanConfiguration::createController()
 
 AMScanConfigurationView *PGMXASScanConfiguration::createView()
 {
-	return new PGMXASScanConfigurationView(this);
+        return new PGMXASScanConfigurationView(this, AMBeamline::bl()->exposedScientificDetectors());
 }

--- a/source/acquaman/PGM/PGMXASScanController.cpp
+++ b/source/acquaman/PGM/PGMXASScanController.cpp
@@ -1,8 +1,17 @@
 #include "PGMXASScanController.h"
 
+#include "dataman/export/AMExporterXDIFormat.h"
+
+#include "application/AMAppControllerSupport.h"
+#include "application/PGM/PGM.h"
+
 PGMXASScanController::PGMXASScanController(PGMXASScanConfiguration *configuration, QObject *parent)
 	: AMGenericStepScanController(configuration, parent)
 {
 	configuration_ = configuration;
+
+	AMExporterOptionXDIFormat *pgmXASExportOptions = PGM::buildXDIFormatExporterOption("PGMXASDefault", true);
+	if(pgmXASExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<PGMXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(pgmXASExportOptions->id());
 }
 

--- a/source/application/PGM/PGM.h
+++ b/source/application/PGM/PGM.h
@@ -1,5 +1,8 @@
-#ifndef PGM_H
-#define PGM_H
+#ifndef PGM
+#define PGM
+
+#include "dataman/database/AMDbObjectSupport.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
 
 namespace PGM
 {
@@ -7,7 +10,36 @@ namespace PGM
 	enum FluorescenceDetector {
 		NoneXRFDetector = 0,
 		OceanOpticsDetector = 1
-	};
+        };
+
+        inline AMExporterOptionXDIFormat *buildXDIFormatExporterOption(const QString &name, bool includeHigherOrderSources)
+        {
+            QList<int> matchIDs = AMDatabase::database("user")->objectsMatching(AMDbObjectSupport::s()->tableNameForClass<AMExporterOptionXDIFormat>(), "name", name);
+
+            AMExporterOptionXDIFormat *option = new AMExporterOptionXDIFormat();
+
+            if(matchIDs.count() != 0)
+                option->loadFromDb(AMDatabase::database("user"), matchIDs.at(0));
+
+            option->setName(name);
+            option->setFileName("$name_$number.dat");
+            option->setHeaderText("Scan: $name #$number\nDate: $dateTime\nFacility: $facilityDescription\n\n$scanConfiguration[header]\n\n$notes\n\n");
+            option->setHeaderIncluded(true);
+            option->setColumnHeader("$dataSetName $dataSetInfoDescription");
+            option->setColumnHeaderIncluded(true);
+            option->setColumnHeaderDelimiter("");
+            option->setSectionHeader("");
+            option->setSectionHeaderIncluded(true);
+            option->setIncludeAllDataSources(true);
+            option->setFirstColumnOnly(true);
+            option->setIncludeHigherDimensionSources(includeHigherOrderSources);
+            option->setSeparateHigherDimensionalSources(true);
+            option->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
+            option->setHigherDimensionsInRows(true);
+            option->storeToDb(AMDatabase::database("user"));
+
+            return option;
+        }
 }
 
 #endif // PGM_H

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -222,9 +222,9 @@ void PGMAppController::createDetectorPanes()
 
 void PGMAppController::createScanConfigurationPanes()
 {
-        xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_);
-        xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
-        mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
+	xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_);
+	xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
+	mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
 }
 
 

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -31,6 +31,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "actions3/AMListAction3.h"
 
 #include "application/AMAppControllerSupport.h"
+#include "application/PGM/PGM.h"
 
 #include "dataman/AMRun.h"
 #include "dataman/AMScan.h"
@@ -39,6 +40,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "dataman/export/AMExporterOptionGeneralAscii.h"
 #include "dataman/export/AMExporterGeneralAscii.h"
 #include "dataman/export/AMExporterAthena.h"
+#include "dataman/export/AMExporterXDIFormat.h"
+#include "dataman/export/AMExporterOptionXDIFormat.h"
 #include "dataman/export/AMSMAKExporter.h"
 #include "dataman/export/AMExporterOptionSMAK.h"
 
@@ -150,7 +153,9 @@ void PGMAppController::registerDBClasses()
 
 void PGMAppController::registerExporterOptions()
 {
-
+        AMExporterOptionXDIFormat *pgmXASExportOptions = PGM::buildXDIFormatExporterOption("PGMXASDefault", true);
+        if(pgmXASExportOptions->id() > 0)
+            AMAppControllerSupport::registerClass<PGMXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(pgmXASExportOptions->id());
 }
 
 void PGMAppController::setupScanConfigurations()

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -204,6 +204,7 @@ void PGMAppController::createGeneralPanes()
 {
 	// create beamline status view
 	beamlineStatusView_ = new CLSBeamlineStatusView(PGMBeamline::pgm()->beamlineStatus(), false);
+        beamlineStatusView_->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 	addMainWindowViewToPane( beamlineStatusView_, "Beamline status", generalPaneCategeryName_, generalPaneIcon_);
 
 	CLSSynchronizedDwellTime *synchronizedDwellTime = qobject_cast<CLSSynchronizedDwellTime *>(AMBeamline::bl()->synchronizedDwellTime());
@@ -222,12 +223,13 @@ void PGMAppController::createDetectorPanes()
 {
 	AMXRFDetailedDetectorView *oceanOpticsDetectorView = new AMXRFDetailedDetectorView(PGMBeamline::pgm()->oceanOpticsDetector());
 	oceanOpticsDetectorView->buildDetectorView();
-	mw_->addPane(oceanOpticsDetectorView, detectorPaneCategoryName_, "Ocean Optics", detectorPaneIcon_);
+        oceanOpticsDetectorView->show();
+//        mw_->addPane(oceanOpticsDetectorView, detectorPaneCategoryName_, "Ocean Optics", detectorPaneIcon_);
 }
 
 void PGMAppController::createScanConfigurationPanes()
 {
-	xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_);
+        xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_, PGMBeamline::pgm()->exposedDetectors());
 	xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
 	mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
 }

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -234,7 +234,7 @@ void PGMAppController::createDetectorPanes()
 
 void PGMAppController::createScanConfigurationPanes()
 {
-        xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_, PGMBeamline::pgm()->exposedDetectors());
+        xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_);
 	xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
 	mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
 }

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -141,9 +141,9 @@ void PGMAppController::registerDBClasses()
 
 void PGMAppController::registerExporterOptions()
 {
-        AMExporterOptionXDIFormat *pgmXASExportOptions = PGM::buildXDIFormatExporterOption("PGMXASDefault", true);
-        if(pgmXASExportOptions->id() > 0)
-            AMAppControllerSupport::registerClass<PGMXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(pgmXASExportOptions->id());
+	AMExporterOptionXDIFormat *pgmXASExportOptions = PGM::buildXDIFormatExporterOption("PGMXASDefault", true);
+	if(pgmXASExportOptions->id() > 0)
+		AMAppControllerSupport::registerClass<PGMXASScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(pgmXASExportOptions->id());
 }
 
 void PGMAppController::setupScanConfigurations()
@@ -217,7 +217,7 @@ void PGMAppController::createDetectorPanes()
 {
 	AMXRFDetailedDetectorView *oceanOpticsDetectorView = new AMXRFDetailedDetectorView(PGMBeamline::pgm()->oceanOpticsDetector());
 	oceanOpticsDetectorView->buildDetectorView();
-        mw_->addPane(oceanOpticsDetectorView, detectorPaneCategoryName_, "Ocean Optics", detectorPaneIcon_);
+	mw_->addPane(oceanOpticsDetectorView, detectorPaneCategoryName_, "Ocean Optics", detectorPaneIcon_);
 }
 
 void PGMAppController::createScanConfigurationPanes()

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -228,8 +228,7 @@ void PGMAppController::createDetectorPanes()
 {
 	AMXRFDetailedDetectorView *oceanOpticsDetectorView = new AMXRFDetailedDetectorView(PGMBeamline::pgm()->oceanOpticsDetector());
 	oceanOpticsDetectorView->buildDetectorView();
-        oceanOpticsDetectorView->show();
-//        mw_->addPane(oceanOpticsDetectorView, detectorPaneCategoryName_, "Ocean Optics", detectorPaneIcon_);
+        mw_->addPane(oceanOpticsDetectorView, detectorPaneCategoryName_, "Ocean Optics", detectorPaneIcon_);
 }
 
 void PGMAppController::createScanConfigurationPanes()

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -197,7 +197,7 @@ void PGMAppController::createGeneralPanes()
 {
 	// create beamline status view
 	beamlineStatusView_ = new CLSBeamlineStatusView(PGMBeamline::pgm()->beamlineStatus(), false);
-        beamlineStatusView_->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+	beamlineStatusView_->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 	addMainWindowViewToPane( beamlineStatusView_, "Beamline status", generalPaneCategeryName_, generalPaneIcon_);
 
 	CLSSynchronizedDwellTime *synchronizedDwellTime = qobject_cast<CLSSynchronizedDwellTime *>(AMBeamline::bl()->synchronizedDwellTime());

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -223,8 +223,8 @@ void PGMAppController::createDetectorPanes()
 void PGMAppController::createScanConfigurationPanes()
 {
         xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_);
-	xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
-	mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
+        xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
+        mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
 }
 
 

--- a/source/beamline/PGM/PGMBeamline.cpp
+++ b/source/beamline/PGM/PGMBeamline.cpp
@@ -32,9 +32,9 @@ PGMBeamline::PGMBeamline()
 	setupDiagnostics();
 	setupSampleStage();
 	setupDetectors();
-	setupControlSets();
 	setupMono();
 	setupMotorGroup();
+        setupControlSets();
 	setupControlsAsDetectors();
 	setupHVControls();
 	setupExposedControls();

--- a/source/beamline/PGM/PGMBeamline.cpp
+++ b/source/beamline/PGM/PGMBeamline.cpp
@@ -34,7 +34,7 @@ PGMBeamline::PGMBeamline()
 	setupDetectors();
 	setupMono();
 	setupMotorGroup();
-        setupControlSets();
+	setupControlSets();
 	setupControlsAsDetectors();
 	setupHVControls();
 	setupExposedControls();
@@ -304,7 +304,7 @@ void PGMBeamline::setupExposedControls()
 
 void PGMBeamline::setupExposedDetectors()
 {
-        // Setup all exposed detectors.
+	// Setup all exposed detectors.
 	addExposedDetector(exitSlitLowerBladeCurrentADetector_);
 	addExposedDetector(exitSlitUpperBladeCurrentADetector_);
 	addExposedDetector(exitSlitLowerBladeCurrentBDetector_);
@@ -321,8 +321,8 @@ void PGMBeamline::setupExposedDetectors()
 
 	addExposedDetector(oceanOpticsDetector_);
 
-        // Setup scientific exposed detectors. I picked random ones for testing.
-        addExposedScientificDetector(oceanOpticsDetector_);
-        addExposedScientificDetector(teyBladeCurrentDetector_);
-        addExposedScientificDetector(flyBladeCurrentDetector_);
+	// Setup scientific exposed detectors. I picked random ones for testing.
+	addExposedScientificDetector(oceanOpticsDetector_);
+	addExposedScientificDetector(teyBladeCurrentDetector_);
+	addExposedScientificDetector(flyBladeCurrentDetector_);
 }

--- a/source/beamline/PGM/PGMBeamline.cpp
+++ b/source/beamline/PGM/PGMBeamline.cpp
@@ -265,6 +265,7 @@ void PGMBeamline::setupExposedControls()
 
 void PGMBeamline::setupExposedDetectors()
 {
+        // Setup all exposed detectors.
 	addExposedDetector(exitSlitLowerBladeCurrentADetector_);
 	addExposedDetector(exitSlitUpperBladeCurrentADetector_);
 	addExposedDetector(exitSlitLowerBladeCurrentBDetector_);
@@ -280,4 +281,9 @@ void PGMBeamline::setupExposedDetectors()
 	addExposedDetector(photodiodeBladeCurrentDetector_);
 
 	addExposedDetector(oceanOpticsDetector_);
+
+        // Setup scientific exposed detectors. I picked random ones for testing.
+        addExposedScientificDetector(oceanOpticsDetector_);
+        addExposedScientificDetector(teyBladeCurrentDetector_);
+        addExposedScientificDetector(flyBladeCurrentDetector_);
 }

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -1,8 +1,8 @@
 #include "PGMXASScanConfigurationView.h"
 
+#include "util/AMDateTimeUtils.h"
 #include <QVBoxLayout>
 #include <QGroupBox>
-#include <QCheckBox>
 
 PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, AMDetectorSet *detectors, QWidget *parent)
 	: AMScanConfigurationView(parent)
@@ -20,36 +20,35 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
         QGroupBox *regionsGroupBox = new QGroupBox("Regions");
         regionsGroupBox->setLayout(regionsView_->layout());
 
-        // Dwell time.
-
-        // The estimated scan time.
-
         // Detector selection.
-
         QGroupBox *detectorGroupBox = new QGroupBox("Detectors");
         detectorGroup_ = new QButtonGroup;
         detectorGroup_->setExclusive(false);
         detectorLayout_ = new QVBoxLayout;
 
-        connect(detectorGroup_, SIGNAL(buttonClick(QAbstractButton*)), this, SLOT(onDecectorSelectionChanged(QAbstractButton*)));
+        connect(detectorGroup_, SIGNAL(buttonClick(QAbstractButton*)), this, SLOT(onDetectorSelectionChanged(QAbstractButton*)));
 
         detectorGroupBox->setLayout(detectorLayout_);
 
-        //AMDetectorSet detectors = new AMDetectorSet;
-
-
-       //detectors.addDetector(
-
         setDetectors(detectors);
 
-        QVBoxLayout *mainHorizontalLayout = new QVBoxLayout;
-        mainHorizontalLayout->addWidget( regionsGroupBox );
-        mainHorizontalLayout->addWidget(scanName_);
+        // Export option
+        exportSpectraCheckBox_ = new QCheckBox("Export Spectra");
+        connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
+
+
+        QVBoxLayout *scanRegionsVerticalLayout = new QVBoxLayout;
+        scanRegionsVerticalLayout->addWidget( regionsGroupBox );
+        scanRegionsVerticalLayout->addWidget(scanName_);
+
+        QVBoxLayout *sideVerticalLayout = new QVBoxLayout;
+        sideVerticalLayout->addWidget(detectorGroupBox);
+        sideVerticalLayout->setAlignment(Qt::AlignTop);
+        sideVerticalLayout->addWidget(exportSpectraCheckBox_);
 
         QHBoxLayout *mainLayout = new QHBoxLayout;
-        //mainLayout->addWidget(regionsView_);
-        mainLayout->addLayout(mainHorizontalLayout);
-        mainLayout->addWidget(detectorGroupBox);
+        mainLayout->addLayout(scanRegionsVerticalLayout);
+        mainLayout->addLayout(sideVerticalLayout);
 
 
 
@@ -106,8 +105,12 @@ void PGMXASScanConfigurationView::onScanNameEdited()
         configuration_->setUserScanName(scanName_->text());
 }
 
-void PGMXASScanConfigurationView::onDecectorSelectionChanged(QAbstractButton *button)
+void PGMXASScanConfigurationView::onDetectorSelectionChanged(QAbstractButton *button)
 {
 
 }
 
+void PGMXASScanConfigurationView::onExportSelectionChanged(QAbstractButton *button)
+{
+
+}

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -16,75 +16,75 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 
 	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_);
 
-        QGroupBox *regionsGroupBox = new QGroupBox("Regions");
-        regionsGroupBox->setLayout(regionsView_->layout());
+	QGroupBox *regionsGroupBox = new QGroupBox("Regions");
+	regionsGroupBox->setLayout(regionsView_->layout());
 
-        // Setup export option.
-        exportSpectraCheckBox_ = new QCheckBox("Export Spectra");
-        exportSpectraCheckBox_->setChecked(configuration_->autoExportEnabled());
+	// Setup export option.
+	exportSpectraCheckBox_ = new QCheckBox("Export Spectra");
+	exportSpectraCheckBox_->setChecked(configuration_->autoExportEnabled());
 
-        // Setup primary (scientific) detector options.
-        scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedScientificDetectors());
+	// Setup primary (scientific) detector options.
+	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedScientificDetectors());
 
-        QVBoxLayout *scientificDetectorsWidgetLayout = new QVBoxLayout();
-        scientificDetectorsWidgetLayout->addWidget(scientificDetectorsView_);
-        scientificDetectorsWidgetLayout->addStretch();
+	QVBoxLayout *scientificDetectorsWidgetLayout = new QVBoxLayout();
+	scientificDetectorsWidgetLayout->addWidget(scientificDetectorsView_);
+	scientificDetectorsWidgetLayout->addStretch();
 
-        QWidget *scientificDetectorsWidget = new QWidget();
-        scientificDetectorsWidget->setLayout(scientificDetectorsWidgetLayout);
+	QWidget *scientificDetectorsWidget = new QWidget();
+	scientificDetectorsWidget->setLayout(scientificDetectorsWidgetLayout);
 
-        // Setup options for all detectors.
-        allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedDetectors());
+	// Setup options for all detectors.
+	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedDetectors());
 
-        QVBoxLayout *allDetectorsWidgetLayout = new QVBoxLayout();
-        allDetectorsWidgetLayout->addWidget(allDetectorsView_);
-        allDetectorsWidgetLayout->addStretch();
+	QVBoxLayout *allDetectorsWidgetLayout = new QVBoxLayout();
+	allDetectorsWidgetLayout->addWidget(allDetectorsView_);
+	allDetectorsWidgetLayout->addStretch();
 
-        QWidget *allDetectorsWidget = new QWidget();
-        allDetectorsWidget->setLayout(allDetectorsWidgetLayout);
+	QWidget *allDetectorsWidget = new QWidget();
+	allDetectorsWidget->setLayout(allDetectorsWidgetLayout);
 
-        // Setup the tabbed detectors view and add detectors to tabs.
-        QTabWidget *detectorsView = new QTabWidget();
-        detectorsView->addTab(scientificDetectorsWidget, "Scientific");
-        detectorsView->addTab(allDetectorsWidget, "All");
+	// Setup the tabbed detectors view and add detectors to tabs.
+	QTabWidget *detectorsView = new QTabWidget();
+	detectorsView->addTab(scientificDetectorsWidget, "Scientific");
+	detectorsView->addTab(allDetectorsWidget, "All");
 
-        // Combine detectors and export widgets in single view.
-        QVBoxLayout *sideVerticalLayout = new QVBoxLayout;
-        sideVerticalLayout->addWidget(detectorsView);
-        sideVerticalLayout->setAlignment(Qt::AlignTop);
-        sideVerticalLayout->addWidget(exportSpectraCheckBox_);
-        sideVerticalLayout->addStretch();
+	// Combine detectors and export widgets in single view.
+	QVBoxLayout *sideVerticalLayout = new QVBoxLayout;
+	sideVerticalLayout->addWidget(detectorsView);
+	sideVerticalLayout->setAlignment(Qt::AlignTop);
+	sideVerticalLayout->addWidget(exportSpectraCheckBox_);
+	sideVerticalLayout->addStretch();
 
-        QGroupBox *detectorBox = new QGroupBox("Detectors");
-        detectorBox->setLayout(sideVerticalLayout);
+	QGroupBox *detectorBox = new QGroupBox("Detectors");
+	detectorBox->setLayout(sideVerticalLayout);
 
-        // Add layouts to main.
-        QHBoxLayout *topHorizontalLayout = new QHBoxLayout;
-        topHorizontalLayout->addWidget(regionsGroupBox);
-        topHorizontalLayout->addWidget(detectorBox);
+	// Add layouts to main.
+	QHBoxLayout *topHorizontalLayout = new QHBoxLayout;
+	topHorizontalLayout->addWidget(regionsGroupBox);
+	topHorizontalLayout->addWidget(detectorBox);
 
-        QVBoxLayout *mainLayout = new QVBoxLayout;
-        mainLayout->addStretch();
-        mainLayout->addLayout(topHorizontalLayout);
-        mainLayout->addWidget(scanName_);
-        mainLayout->addStretch();
+	QVBoxLayout *mainLayout = new QVBoxLayout;
+	mainLayout->addStretch();
+	mainLayout->addLayout(topHorizontalLayout);
+	mainLayout->addWidget(scanName_);
+	mainLayout->addStretch();
 
-        setLayout(mainLayout);
+	setLayout(mainLayout);
 
-        // Setup connections
-        connect(scanName_, SIGNAL(editingFinished()), this, SLOT(onScanNameEdited()));
-        connect(configuration_, SIGNAL(nameChanged(QString)), scanName_, SLOT(setText(QString)));
-        connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
+	// Setup connections
+	connect(scanName_, SIGNAL(editingFinished()), this, SLOT(onScanNameEdited()));
+	connect(configuration_, SIGNAL(nameChanged(QString)), scanName_, SLOT(setText(QString)));
+	connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
 
 }
 
 void PGMXASScanConfigurationView::onScanNameEdited()
 {
 	configuration_->setName(scanName_->text());
-        configuration_->setUserScanName(scanName_->text());
+	configuration_->setUserScanName(scanName_->text());
 }
 
 void PGMXASScanConfigurationView::onExportSelectionChanged(QAbstractButton *button)
 {
-        configuration_->setAutoExportEnabled(button->isChecked());
+	configuration_->setAutoExportEnabled(button->isChecked());
 }

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -64,8 +64,10 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
         topHorizontalLayout->addWidget(detectorBox);
 
         QVBoxLayout *mainLayout = new QVBoxLayout;
+        mainLayout->addStretch();
         mainLayout->addLayout(topHorizontalLayout);
         mainLayout->addWidget(scanName_);
+        mainLayout->addStretch();
 
         setLayout(mainLayout);
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -36,7 +36,7 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
         exportSpectraCheckBox_ = new QCheckBox("Export Spectra");
         connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
 
-
+        // Setup sub layouts and add to main.
         QVBoxLayout *scanRegionsVerticalLayout = new QVBoxLayout;
         scanRegionsVerticalLayout->addWidget( regionsGroupBox );
         scanRegionsVerticalLayout->addWidget(scanName_);
@@ -107,10 +107,19 @@ void PGMXASScanConfigurationView::onScanNameEdited()
 
 void PGMXASScanConfigurationView::onDetectorSelectionChanged(QAbstractButton *button)
 {
+        if (button) {
+                AMDetector *detector = detectorButtonMap_.key(button, 0);
 
+                if (detector) {
+                        if (button->isChecked())
+                                configuration_->addDetector(detector->toInfo());
+                        else
+                                configuration_->removeDetector(detector->toInfo());
+                }
+        }
 }
 
 void PGMXASScanConfigurationView::onExportSelectionChanged(QAbstractButton *button)
 {
-
+        configuration_->setAutoExportEnabled(button->isChecked());
 }

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -1,8 +1,10 @@
 #include "PGMXASScanConfigurationView.h"
 
 #include <QVBoxLayout>
+#include <QGroupBox>
+#include <QCheckBox>
 
-PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, QWidget *parent)
+PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, AMDetectorSet *detectors, QWidget *parent)
 	: AMScanConfigurationView(parent)
 {
 	configuration_ = configuration;
@@ -15,16 +17,97 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 
 	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_);
 
-	QVBoxLayout *mainLayout = new QVBoxLayout;
-	mainLayout->addWidget(regionsView_);
-	mainLayout->addWidget(scanName_);
+        QGroupBox *regionsGroupBox = new QGroupBox("Regions");
+        regionsGroupBox->setLayout(regionsView_->layout());
 
-	setLayout(mainLayout);
+        // Dwell time.
+
+        // The estimated scan time.
+
+        // Detector selection.
+
+        QGroupBox *detectorGroupBox = new QGroupBox("Detectors");
+        detectorGroup_ = new QButtonGroup;
+        detectorGroup_->setExclusive(false);
+        detectorLayout_ = new QVBoxLayout;
+
+        connect(detectorGroup_, SIGNAL(buttonClick(QAbstractButton*)), this, SLOT(onDecectorSelectionChanged(QAbstractButton*)));
+
+        detectorGroupBox->setLayout(detectorLayout_);
+
+        //AMDetectorSet detectors = new AMDetectorSet;
+
+
+       //detectors.addDetector(
+
+        setDetectors(detectors);
+
+        QVBoxLayout *mainHorizontalLayout = new QVBoxLayout;
+        mainHorizontalLayout->addWidget( regionsGroupBox );
+        mainHorizontalLayout->addWidget(scanName_);
+
+        QHBoxLayout *mainLayout = new QHBoxLayout;
+        //mainLayout->addWidget(regionsView_);
+        mainLayout->addLayout(mainHorizontalLayout);
+        mainLayout->addWidget(detectorGroupBox);
+
+
+
+
+        setLayout(mainLayout);
+}
+
+void PGMXASScanConfigurationView::setDetectors(AMDetectorSet *newDetectors)
+{
+    if (detectors_ != newDetectors) {
+
+            // Clear previously displayed detectors.
+
+            for (int buttonIndex = 0, buttonCount = detectorGroup_->buttons().count(); buttonIndex < buttonCount; buttonIndex++) {
+                    QAbstractButton *button = detectorGroup_->button(buttonIndex);
+                    detectorLayout_->removeWidget(button);
+                    detectorGroup_->removeButton(button);
+                    button->deleteLater();
+            }
+
+            detectorButtonMap_.clear();
+
+            // Set new detectors.
+
+            detectors_ = newDetectors;
+
+            // Add new detectors.
+
+            for (int detectorIndex = 0, detectorCount = detectors_->count(); detectorIndex < detectorCount; detectorIndex++) {
+                    AMDetector *detector = detectors_->at(detectorIndex);
+
+                    if (detector) {
+                            QCheckBox *checkBox = new QCheckBox(detector->name());
+                            detectorGroup_->addButton(checkBox);
+                            detectorLayout_->addWidget(checkBox);
+
+                            detectorButtonMap_.insert(detector, checkBox);
+
+                            // Update current selection.
+
+                            if (configuration_ && configuration_->detectorConfigurations().contains(detector->name())) {
+                                    checkBox->blockSignals(true);
+                                    checkBox->setChecked(true);
+                                    checkBox->blockSignals(false);
+                            }
+                    }
+            }
+    }
 }
 
 void PGMXASScanConfigurationView::onScanNameEdited()
 {
 	configuration_->setName(scanName_->text());
-	configuration_->setUserScanName(scanName_->text());
+        configuration_->setUserScanName(scanName_->text());
+}
+
+void PGMXASScanConfigurationView::onDecectorSelectionChanged(QAbstractButton *button)
+{
+
 }
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -64,8 +64,8 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
         topHorizontalLayout->addWidget(detectorBox);
 
         QVBoxLayout *mainLayout = new QVBoxLayout;
-        //mainLayout->addLayout(topHorizontalLayout);
-        //mainLayout->addWidget(scanName_);
+        mainLayout->addLayout(topHorizontalLayout);
+        mainLayout->addWidget(scanName_);
 
         setLayout(mainLayout);
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -8,6 +8,8 @@
 #include "ui/dataman/AMStepScanAxisView.h"
 
 #include <QLineEdit>
+#include <QCheckBox>
+#include <QLabel>
 
 /// The scan configuration view for XAS on PGM.
 class PGMXASScanConfigurationView : public AMScanConfigurationView
@@ -37,6 +39,8 @@ protected slots:
         /// Handles the change of the detector
         void onDecectorSelectionChanged(QAbstractButton *button);
 
+        void onExportSelectionChanged(QAbstractButton *button);
+
 protected:
 	/// The configuration.
 	PGMXASScanConfiguration *configuration_;
@@ -52,6 +56,9 @@ protected:
         QButtonGroup *detectorGroup_;
         QVBoxLayout *detectorLayout_;
         QMap<AMDetector*, QAbstractButton*> detectorButtonMap_;
+
+        QCheckBox *exportSpectraCheckBox_;
+
 };
 
 #endif // PGMXASSCANCONFIGURATIONVIEW_H

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -2,10 +2,12 @@
 #define PGMXASSCANCONFIGURATIONVIEW_H
 
 #include "ui/acquaman/AMScanConfigurationView.h"
-#include "acquaman/PGM/PGMXASScanConfiguration.h"
-#include "beamline/AMDetectorSet.h"
-
+#include "ui/acquaman/AMGenericStepScanConfigurationDetectorsView.h"
 #include "ui/dataman/AMStepScanAxisView.h"
+
+#include "acquaman/PGM/PGMXASScanConfiguration.h"
+
+#include "beamline/AMDetectorSet.h"
 
 #include <QLineEdit>
 #include <QCheckBox>
@@ -18,7 +20,7 @@ class PGMXASScanConfigurationView : public AMScanConfigurationView
 
 public:
 	/// Constructor.
-        PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, AMDetectorSet *detectors, QWidget *parent = 0);
+        PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~PGMXASScanConfigurationView(){}
 
@@ -29,15 +31,9 @@ signals:
 
 public slots:
 
-        ///
-        void setDetectors(AMDetectorSet *newDetectors );
-
 protected slots:
 	/// Handles setting the name of the configuration from the line edit.
 	void onScanNameEdited();
-
-        /// Handles the change of the detector
-        void onDetectorSelectionChanged(QAbstractButton *button);
 
         void onExportSelectionChanged(QAbstractButton *button);
 
@@ -52,12 +48,12 @@ protected:
 	QLineEdit *scanName_;
 
         /// Set of dectors to display.
-        AMDetectorSet *detectors_;
-        QButtonGroup *detectorGroup_;
-        QVBoxLayout *detectorLayout_;
-        QMap<AMDetector*, QAbstractButton*> detectorButtonMap_;
 
         QCheckBox *exportSpectraCheckBox_;
+
+        AMGenericStepScanConfigurationDetectorsView *scientificDetectorsView_;
+
+        AMGenericStepScanConfigurationDetectorsView *allDetectorsView_;
 
 };
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -48,11 +48,12 @@ protected:
 	QLineEdit *scanName_;
 
         /// Set of dectors to display.
-
         QCheckBox *exportSpectraCheckBox_;
 
+        /// Set of primary detectors to be configured.
         AMGenericStepScanConfigurationDetectorsView *scientificDetectorsView_;
 
+        /// Set of all detectors to be configured.
         AMGenericStepScanConfigurationDetectorsView *allDetectorsView_;
 
 };

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -37,7 +37,7 @@ protected slots:
 	void onScanNameEdited();
 
         /// Handles the change of the detector
-        void onDecectorSelectionChanged(QAbstractButton *button);
+        void onDetectorSelectionChanged(QAbstractButton *button);
 
         void onExportSelectionChanged(QAbstractButton *button);
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -35,7 +35,8 @@ protected slots:
 	/// Handles setting the name of the configuration from the line edit.
 	void onScanNameEdited();
 
-        void onExportSelectionChanged(QAbstractButton *button);
+	/// Handles changes of the auto export check box.
+	void onExportSelectionChanged(QAbstractButton *button);
 
 protected:
 	/// The configuration.
@@ -47,14 +48,14 @@ protected:
 	/// The scan name.
 	QLineEdit *scanName_;
 
-        /// Set of dectors to display.
-        QCheckBox *exportSpectraCheckBox_;
+	/// Set of dectors to display.
+	QCheckBox *exportSpectraCheckBox_;
 
-        /// Set of primary detectors to be configured.
-        AMGenericStepScanConfigurationDetectorsView *scientificDetectorsView_;
+	/// Set of primary detectors to be configured.
+	AMGenericStepScanConfigurationDetectorsView *scientificDetectorsView_;
 
-        /// Set of all detectors to be configured.
-        AMGenericStepScanConfigurationDetectorsView *allDetectorsView_;
+	/// Set of all detectors to be configured.
+	AMGenericStepScanConfigurationDetectorsView *allDetectorsView_;
 
 };
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -3,6 +3,7 @@
 
 #include "ui/acquaman/AMScanConfigurationView.h"
 #include "acquaman/PGM/PGMXASScanConfiguration.h"
+#include "beamline/AMDetectorSet.h"
 
 #include "ui/dataman/AMStepScanAxisView.h"
 
@@ -15,7 +16,7 @@ class PGMXASScanConfigurationView : public AMScanConfigurationView
 
 public:
 	/// Constructor.
-	PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, QWidget *parent = 0);
+        PGMXASScanConfigurationView(PGMXASScanConfiguration *configuration, AMDetectorSet *detectors, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~PGMXASScanConfigurationView(){}
 
@@ -26,9 +27,15 @@ signals:
 
 public slots:
 
+        ///
+        void setDetectors(AMDetectorSet *newDetectors );
+
 protected slots:
 	/// Handles setting the name of the configuration from the line edit.
 	void onScanNameEdited();
+
+        /// Handles the change of the detector
+        void onDecectorSelectionChanged(QAbstractButton *button);
 
 protected:
 	/// The configuration.
@@ -39,6 +46,12 @@ protected:
 
 	/// The scan name.
 	QLineEdit *scanName_;
+
+        /// Set of dectors to display.
+        AMDetectorSet *detectors_;
+        QButtonGroup *detectorGroup_;
+        QVBoxLayout *detectorLayout_;
+        QMap<AMDetector*, QAbstractButton*> detectorButtonMap_;
 };
 
 #endif // PGMXASSCANCONFIGURATIONVIEW_H


### PR DESCRIPTION
Added in a detector selection component similar to the one used by BioXAS.

Setup the export options and added a check box to enable export, default is enabled.

Adjusted visual components to be cleaner. 

Corrected double entry in pri file.

Corrected component load order in PGMBeamline to load setupControlSets later in the list to resolve a segfault on launch.

#2377 