### PR TITLE
Pull Request for Issue2388: Adding button index information to AMDeadTimeButton

### DIFF
--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -195,14 +195,19 @@ void AMDeadTimeButton::updateToolTip()
 	if (canDisplayIndex())
 		toolTip.append(QString("%1").arg(index_));
 
+	// Add separator, if needed.
+
+	if (canDisplayIndex() && isEnabled() && (canDisplayPercentage() || canDisplayCounts() || canDisplayCountRate()))
+		toolTip.append(": ");
+
 	// Add the counts information.
 
 	if (countsMode_ == Percent && canDisplayPercentage())
-		toolTip.append(QString(": %1%").arg(getPercent(), 0, 'f', 0));
+		toolTip.append(QString("%1%").arg(getPercent(), 0, 'f', 0));
 	else if (countsMode_ == Counts && canDisplayCounts())
-		toolTip.append(QString(": %1 counts").arg(getCounts()));
+		toolTip.append(QString("%1 counts").arg(getCounts()));
 	else if (countsMode_ == CountRate && canDisplayCountRate())
-		toolTip.append(QString(": %1 counts/s").arg(getCountRate()));
+		toolTip.append(QString("%1 counts/s").arg(getCountRate()));
 
 	setToolTip(toolTip);
 }

--- a/source/ui/beamline/AMDeadTimeButton.cpp
+++ b/source/ui/beamline/AMDeadTimeButton.cpp
@@ -31,6 +31,9 @@ AMDeadTimeButton::AMDeadTimeButton(QWidget *parent)
 	badReferencePoint_ = 0;
 	countsMode_ = Percent;
 	acquireTimeControl_ = 0;
+
+	index_ = 0;
+	indexSet_ = false;
 }
 
 AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource *outputCountSource, double goodReferencePoint, double badReferencePoint, CountsMode countsMode, QWidget *parent)
@@ -42,6 +45,9 @@ AMDeadTimeButton::AMDeadTimeButton(AMDataSource *inputCountSource, AMDataSource 
 	badReferencePoint_ = badReferencePoint;
 	countsMode_ = countsMode;
 	acquireTimeControl_ = 0;
+
+	index_ = 0;
+	indexSet_ = false;
 
 	setDeadTimeSources(inputCountSource, outputCountSource);
 }
@@ -64,6 +70,11 @@ bool AMDeadTimeButton::canDisplayCounts() const
 bool AMDeadTimeButton::canDisplayCountRate() const
 {
 	return hasICRDataSource() && hasAcquireTime();
+}
+
+bool AMDeadTimeButton::canDisplayIndex() const
+{
+	return indexSet_;
 }
 
 void AMDeadTimeButton::setDeadTimeSources(AMDataSource *inputCountSource, AMDataSource *outputCountSource)
@@ -134,6 +145,17 @@ void AMDeadTimeButton::setAcquireTimeControl(AMControl *newControl)
 	}
 }
 
+void AMDeadTimeButton::setIndex(int newIndex)
+{
+	if (index_ != newIndex || !indexSet_) {
+		index_ = newIndex;
+		indexSet_ = true;
+
+		updateToolTip();
+	}
+
+}
+
 void AMDeadTimeButton::updateColorState()
 {
 	ColorState newState = AMToolButton::None;
@@ -168,12 +190,19 @@ void AMDeadTimeButton::updateToolTip()
 {
 	QString toolTip = "";
 
+	// Add the index, if we can display index information.
+
+	if (canDisplayIndex())
+		toolTip.append(QString("%1").arg(index_));
+
+	// Add the counts information.
+
 	if (countsMode_ == Percent && canDisplayPercentage())
-		toolTip = QString("%1%").arg(getPercent(), 0, 'f', 0);
+		toolTip.append(QString(": %1%").arg(getPercent(), 0, 'f', 0));
 	else if (countsMode_ == Counts && canDisplayCounts())
-		toolTip = QString("%1 counts").arg(getCounts());
+		toolTip.append(QString(": %1 counts").arg(getCounts()));
 	else if (countsMode_ == CountRate && canDisplayCountRate())
-		toolTip = QString("%1 counts/s").arg(getCountRate());
+		toolTip.append(QString(": %1 counts/s").arg(getCountRate()));
 
 	setToolTip(toolTip);
 }

--- a/source/ui/beamline/AMDeadTimeButton.h
+++ b/source/ui/beamline/AMDeadTimeButton.h
@@ -49,6 +49,8 @@ public:
 	bool canDisplayCounts() const;
 	/// Returns true if this button can display counts information as a count rate.
 	bool canDisplayCountRate() const;
+	/// Returns true if this button can display the element index.
+	bool canDisplayIndex() const;
 
 	/// Returns the input count source.
 	AMDataSource* inputCountSource() const { return inputCountSource_; }
@@ -74,6 +76,8 @@ public slots:
 	void setCountsMode(CountsMode newMode);
 	/// Sets the acquire time control.
 	void setAcquireTimeControl(AMControl *newControl);
+	/// Sets the element index.
+	void setIndex(int newIndex);
 
 protected slots:
 	/// Updates the color state.
@@ -111,6 +115,10 @@ protected:
 	CountsMode countsMode_;
 	/// The acquire time control.
 	AMControl *acquireTimeControl_;
+	/// The button index.
+	int index_;
+	/// Flag for whether the button index is set.
+	bool indexSet_;
 };
 
 #endif // AMDEADTIMEBUTTON_H

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -134,6 +134,7 @@ void AMXRFDetailedDetectorView::buildDeadTimeView()
 			deadTimeButton->setAcquireTimeControl(detector_->acquireTimeControl());
 			deadTimeButton->setChecked(detector_->isElementDisabled(i)); // Elements are disabled by checking the corresponding toolbutton.
 			deadTimeButton->setEnabled(detector_->canEnableElement(i)); // Elements that are not enabled initially will always be disabled (ie. permanently disabled elements).
+			deadTimeButton->setIndex(i+1);
 			if (!detector_->canEnableElement(i))
 				deadTimeButton->setCountsMode(AMDeadTimeButton::None);
 


### PR DESCRIPTION
- Modified the AMDeadTimeButton class to include a button index variable and a flag tracking whether that button index has been set. If it is set, the button index will be displayed in the button tooltip along with the rest of the counts information. 
- Modified the dead time button instances that are used on BioXAS to include the button index.