### PR TITLE
Pull Request for Issue2387: Add basic Ge detector functionality to BioXAS generic scans.

### DIFF
--- a/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
@@ -11,6 +11,16 @@ BioXASGenericStepScanController::BioXASGenericStepScanController(BioXASGenericSt
 {
 	useFeedback_ = true;
 
+	// Setup exporter option.
+
+	if (configuration_) {
+
+		AMExporterOptionXDIFormat *bioXASDefaultXDI = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", "", "", true);
+
+		if (bioXASDefaultXDI->id() > 0)
+			AMAppControllerSupport::registerClass<BioXASGenericStepScanConfiguration, AMExporterXDIFormat, AMExporterOptionXDIFormat>(bioXASDefaultXDI->id());
+	}
+
 	// Add the Ge detectors spectra, if a Ge detector is being used.
 
 	AMDetectorSet *geDetectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();
@@ -20,14 +30,17 @@ BioXASGenericStepScanController::BioXASGenericStepScanController(BioXASGenericSt
 		for (int i = 0, detectorsCount = geDetectors->count(); i < detectorsCount; i++) {
 			BioXAS32ElementGeDetector *geDetector = qobject_cast<BioXAS32ElementGeDetector*>(geDetectors->at(i));
 
-			if (geDetector && configuration_->detectorConfigurations().contains(geDetector->name())) {
+			if (geDetector && BioXASBeamlineSupport::usingDetector(configuration_, geDetector)) {
+
+				// Add spectra.
+
 				AMDetectorSet *elements = BioXASBeamline::bioXAS()->elementsForDetector(geDetector);
 
 				if (elements) {
 					for (int j = 0, elementsCount = elements->count(); j < elementsCount; j++) {
 						AMDetector *element = elements->at(j);
 
-						if (element)
+						if (element && element->isConnected())
 							configuration_->addDetector(element->toInfo());
 					}
 				}

--- a/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
@@ -4,6 +4,7 @@
 #include "dataman/export/AMExporterOptionXDIFormat.h"
 #include "application/BioXAS/BioXAS.h"
 #include "beamline/BioXAS/BioXASBeamline.h"
+#include "analysis/AMNormalizationAB.h"
 
 BioXASGenericStepScanController::BioXASGenericStepScanController(BioXASGenericStepScanConfiguration *configuration, QObject *parent) :
 	AMGenericStepScanController(configuration, parent)
@@ -109,8 +110,113 @@ void BioXASGenericStepScanController::buildScanControllerImplementation()
 	if (i2DetectorSource)
 		genericExporterOption->addDataSource(i2DetectorSource->name(), true);
 
+	// Create analyzed data source for each Ge 32-el detector.
+
+	AMDetectorSet *ge32Detectors = BioXASBeamline::bioXAS()->ge32ElementDetectors();
+
+	for (int i = 0, count = ge32Detectors->count(); i < count; i++) {
+
+		BioXAS32ElementGeDetector *ge32Detector = qobject_cast<BioXAS32ElementGeDetector*>(ge32Detectors->at(i));
+
+		if (BioXASBeamlineSupport::usingGeDetector(scan_, ge32Detector)) {
+
+			// Clear any previous regions.
+
+			ge32Detector->removeAllRegionsOfInterest();
+
+			// Iterate through each region in the configuration.
+			// Create analysis block for each region, add ge32Detector spectra source as input source for each.
+			// Add analysis block to the scan and to the ge32Detector.
+			// Create normalized analysis block for each region, add to scan.
+
+			AMDataSource *spectraSource = BioXASBeamlineSupport::geDetectorSource(scan_, ge32Detector);
+			AMDetectorSet *elements = BioXASBeamline::bioXAS()->elementsForDetector(ge32Detector);
+			AMDataSource *normalizationSource = i0DetectorSource;
+
+			foreach (AMRegionOfInterest *region, configuration_->regionsOfInterest()){
+
+				ge32Detector->addRegionOfInterest(region);
+
+				AMAnalysisBlock *newRegion = createRegionOfInterestAB(region->name().remove(' '), region, spectraSource);
+
+				if (newRegion){
+
+					scan_->addAnalyzedDataSource(newRegion, false, true);
+
+					if (normalizationSource) {
+
+						AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1").arg(newRegion->name()), newRegion, normalizationSource);
+
+						if (normalizedRegion) {
+							scan_->addAnalyzedDataSource(normalizedRegion, false, false);
+							genericExporterOption->addDataSource(normalizedRegion->name(), true);
+						}
+					}
+				}
+
+				if (elements){
+
+					for (int i = 0, size = elements->count(); i < size; i++){
+
+						newRegion = createRegionOfInterestAB(QString("%1_%2").arg(region->name().remove(' ')).arg(elements->at(i)->description()),
+											 region,
+											 scan_->dataSourceAt(scan_->indexOfDataSource(elements->at(i)->name())));
+
+						if (newRegion){
+
+							scan_->addAnalyzedDataSource(newRegion, false, true);
+
+							if (normalizationSource) {
+
+								AMAnalysisBlock *normalizedRegion = createNormalizationAB(QString("norm_%1_%2").arg(newRegion->name()).arg(elements->at(i)->description()),
+															  newRegion,
+															  normalizationSource);
+
+								if (normalizedRegion) {
+									scan_->addAnalyzedDataSource(normalizedRegion, true, false);
+									genericExporterOption->addDataSource(normalizedRegion->name(), true);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// Save changes to the exporter option.
 
 	if (genericExporterOption)
 		genericExporterOption->storeToDb(AMDatabase::database("user"));
 }
+
+AMAnalysisBlock *BioXASGenericStepScanController::createRegionOfInterestAB(const QString &name, AMRegionOfInterest *region, AMDataSource *spectrumSource) const
+{
+	if (region && region->isValid() && spectrumSource && ((spectrumSource->rank()-scan_->scanRank()) == 1)){
+
+		AMRegionOfInterestAB *regionAB = (AMRegionOfInterestAB *)region->valueSource();
+		AMRegionOfInterestAB *newRegion = new AMRegionOfInterestAB(name);
+		newRegion->setBinningRange(regionAB->binningRange());
+		newRegion->setInputDataSources(QList<AMDataSource *>() << spectrumSource);
+
+		return newRegion;
+	}
+
+	return 0;
+}
+
+AMAnalysisBlock *BioXASGenericStepScanController::createNormalizationAB(const QString &name, AMDataSource *source, AMDataSource *normalizer) const
+{
+	if (source && normalizer && source->rank() == normalizer->rank()){
+
+		AMNormalizationAB *normalizedSource = new AMNormalizationAB(name);
+		normalizedSource->setInputDataSources(QList<AMDataSource *>() << source << normalizer);
+		normalizedSource->setDataName(source->name());
+		normalizedSource->setNormalizationName(normalizer->name());
+
+		return normalizedSource;
+	}
+
+	return 0;
+}
+

--- a/source/acquaman/BioXAS/BioXASGenericStepScanController.h
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanController.h
@@ -17,6 +17,11 @@ public:
 protected:
 	/// Adds anything extra (eg: analysis blocks) to the scan before it's started.
 	virtual void buildScanControllerImplementation();
+
+	/// Creates a region of interest analysis block from the given AMRegionOfInterest and 1D spectrum source.
+	AMAnalysisBlock *createRegionOfInterestAB(const QString &name, AMRegionOfInterest *region, AMDataSource *spectrumSource) const;
+	/// Creates a normalized analysis block from a source and normalizer source.
+	AMAnalysisBlock *createNormalizationAB(const QString &name, AMDataSource *source, AMDataSource *normalizer) const;
 };
 
 #endif // BIOXASGENERICSTEPSCANCONTROLLER_H

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -28,6 +28,8 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 
 	useFeedback_ = true;
 
+	// Setup exporter option.
+
 	if (bioXASConfiguration_) {
 
 		AMExporterOptionXDIFormat *bioXASDefaultXAS = BioXAS::buildStandardXDIFormatExporterOption("BioXAS XAS (XDI Format)", bioXASConfiguration_->edge().split(" ").first(), bioXASConfiguration_->edge().split(" ").last(), true);
@@ -56,7 +58,7 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 						AMDetector *element = elements->at(j);
 
 						if (element && element->isConnected())
-							configuration_->addDetector(element->toInfo());
+							bioXASConfiguration_->addDetector(element->toInfo());
 					}
 				}
 
@@ -70,7 +72,7 @@ BioXASXASScanActionController::BioXASXASScanActionController(BioXASXASScanConfig
 						AMDetector *icrDetector = icrDetectors->at(j);
 
 						if (icrDetector && icrDetector->isConnected())
-							configuration_->addDetector(icrDetector->toInfo());
+							bioXASConfiguration_->addDetector(icrDetector->toInfo());
 					}
 				}
 			}

--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -167,25 +167,48 @@ void BioXASAppController::onRegionOfInterestAdded(AMRegionOfInterest *region)
 
 		if (xasConfiguration_ && !containsRegionOfInterest(xasConfiguration_->regionsOfInterest(), region))
 			xasConfiguration_->addRegionOfInterest(region);
+
+		// Add the region of interest to the generic step scan configuration, if it doesn't have it already.
+
+		if (genericConfiguration_ && !containsRegionOfInterest(genericConfiguration_->regionsOfInterest(), region))
+			genericConfiguration_->addRegionOfInterest(region);
 	}
 }
 
 void BioXASAppController::onRegionOfInterestRemoved(AMRegionOfInterest *region)
 {
-	if (userConfiguration_ && userConfiguration_->regionsOfInterest().contains(region))
+	// Remove region of interest from the user configuration.
+
+	if (userConfiguration_)
 		userConfiguration_->removeRegionOfInterest(region);
+
+	// Remove region of interest from the XAS scan configuration.
 
 	if (xasConfiguration_)
 		xasConfiguration_->removeRegionOfInterest(region);
+
+	// Remove region of interest from the generic step scan configuration.
+
+	if (genericConfiguration_)
+		genericConfiguration_->removeRegionOfInterest(region);
 }
 
 void BioXASAppController::onRegionOfInterestBoundingRangeChanged(AMRegionOfInterest *region)
 {
-	if (userConfiguration_ && userConfiguration_->regionsOfInterest().contains(region))
+	// Update the bounding range for the region of interest in the user configuration.
+
+	if (userConfiguration_)
 		userConfiguration_->setRegionOfInterestBoundingRange(region);
+
+	// Update the bounding range for the region of interest in the XAS scan configuration.
 
 	if (xasConfiguration_)
 		xasConfiguration_->setRegionOfInterestBoundingRange(region);
+
+	// Update the bounding range for the region of interest in the generic step scan configuration.
+
+	if (genericConfiguration_)
+		genericConfiguration_->setRegionOfInterestBoundingRange(region);
 }
 
 void BioXASAppController::goToBeamlineStatusView(AMControl *control)

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -431,6 +431,8 @@ bool BioXASBeamline::addGe32Detector(BioXAS32ElementGeDetector *newDetector)
 		addExposedDetector(newDetector);
 		addDefaultXASScanDetector(newDetector);
 		addDefaultXASScanDetectorOption(newDetector);
+		addDefaultGenericScanDetector(newDetector);
+		addDefaultGenericScanDetectorOption(newDetector);
 
 		addSynchronizedXRFDetector(newDetector);
 
@@ -486,6 +488,8 @@ bool BioXASBeamline::removeGe32Detector(BioXAS32ElementGeDetector *detector)
 		removeExposedDetector(detector);
 		removeDefaultXASScanDetector(detector);
 		removeDefaultXASScanDetectorOption(detector);
+		removeDefaultGenericScanDetector(detector);
+		removeDefaultGenericScanDetectorOption(detector);
 
 		// Remove each detector element.
 


### PR DESCRIPTION
- Added Ge detector to the list of detectors for generic scans in BioXASBeamline.
- Added code to BioXASAppController that updates the generic scan configuration's regions of interest.
- Added Ge detector setup to the generic scan controller, virtually identical to the XAS scan controller code.