### PR TITLE
Pull Request for Issue2400: Minor tweaks to BioXAS beamline status

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -362,61 +362,61 @@ void BioXASAppController::createPersistentView()
 
 	mw_->addRightWidget(persistentView);
 
-	connect( persistentView, SIGNAL(beamlineStatusSelectedComponentChanged(AMControl*)), this, SLOT(goToBeamlineStatusView(AMControl*)) );
+	connect( persistentView, SIGNAL(beamlineStatusControlClicked(AMControl*)), this, SLOT(goToBeamlineStatusView(AMControl*)) );
 }
 
 void BioXASAppController::createGeneralPanes()
 {
 	QWidget* beamlineConfigurationView = createComponentView(BioXASBeamline::bioXAS());
-	addMainWindowViewToPane( beamlineConfigurationView, "Configuration", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView( beamlineConfigurationView, "Configuration", generalPaneCategeryName_, generalPaneIcon_);
 
 	beamlineStatusView_ = new CLSBeamlineStatusView(BioXASBeamline::bioXAS()->beamStatus(), false);
-	addMainWindowViewToPane( beamlineStatusView_, "Beamline status", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView( beamlineStatusView_, "Beamline status", generalPaneCategeryName_, generalPaneIcon_);
 }
 
 void BioXASAppController::createDetectorPanes()
 {
 	QWidget* scalerView = createComponentView(BioXASBeamline::bioXAS()->scaler());
-	addMainWindowViewToPane( scalerView, "Scaler", detectorPaneCategoryName_, detectorPaneIcon_);
+	addMainWindowView( scalerView, "Scaler", detectorPaneCategoryName_, detectorPaneIcon_);
 
 	QWidget* fourElementDetectorView = createComponentView(BioXASBeamline::bioXAS()->fourElementVortexDetector());
-	addMainWindowViewToPane( fourElementDetectorView, "Four element", detectorPaneCategoryName_, detectorPaneIcon_);
+	addMainWindowView( fourElementDetectorView, "Four element", detectorPaneCategoryName_, detectorPaneIcon_);
 }
 
 void BioXASAppController::createScanConfigurationPanes()
 {
 	xasConfigurationView_ = createScanConfigurationViewWithHolder(xasConfiguration_);
 	if (xasConfigurationView_)
-		addMainWindowViewToPane(xasConfigurationView_, "XAS Scan", scanPaneCategoryName_, scanPaneIcon_);
+		addMainWindowView(xasConfigurationView_, "XAS Scan", scanPaneCategoryName_, scanPaneIcon_);
 
 	genericConfigurationView_ = createScanConfigurationViewWithHolder(genericConfiguration_);
 	if (genericConfigurationView_)
-		addMainWindowViewToPane(genericConfigurationView_, "Generic Scan", scanPaneCategoryName_, scanPaneIcon_);
+		addMainWindowView(genericConfigurationView_, "Generic Scan", scanPaneCategoryName_, scanPaneIcon_);
 
 	energyCalibrationConfigurationView_ = createScanConfigurationViewWithHolder(energyCalibrationConfiguration_);
 	if (energyCalibrationConfigurationView_)
-		addMainWindowViewToPane(energyCalibrationConfigurationView_, "Energy Calibration", scanPaneCategoryName_, scanPaneIcon_);
+		addMainWindowView(energyCalibrationConfigurationView_, "Energy Calibration", scanPaneCategoryName_, scanPaneIcon_);
 }
 
 void BioXASAppController::createComponentsPane()
 {
 	BioXASBeamline *bioXASBL = BioXASBeamline::bioXAS();
 
-	addMainWindowViewToPane( createComponentView(bioXASBL->carbonFilterFarm()), "Carbon Filter Farm", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->m1Mirror()), "M1 Mirror", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->mono()), "Monochromator", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->m2Mirror()), "M2 Mirror", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->beWindow()), "Be Window", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->endstationTable()), "Endstation Table", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->dbhrMirrors()), "DBHR Mirrors", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->jjSlits()), "JJ Slits", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->xiaFilters()), "XIA Filters", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->standardsWheel()), "Standards Wheel", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->cryostatStage()), "Cryostat Stage", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->filterFlipper()), "Filter Flipper", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->sollerSlit()), "Soller slits", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->detectorStageLateralMotors()), "Ge 32-el Stage", componentPaneCategoryName_, componentPaneIcon_);
-	addMainWindowViewToPane( createComponentView(bioXASBL->zebra()), "Zebra", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->carbonFilterFarm()), "Carbon Filter Farm", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->m1Mirror()), "M1 Mirror", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->mono()), "Monochromator", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->m2Mirror()), "M2 Mirror", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->beWindow()), "Be Window", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->endstationTable()), "Endstation Table", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->dbhrMirrors()), "DBHR Mirrors", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->jjSlits()), "JJ Slits", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->xiaFilters()), "XIA Filters", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->standardsWheel()), "Standards Wheel", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->cryostatStage()), "Cryostat Stage", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->filterFlipper()), "Filter Flipper", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->sollerSlit()), "Soller slits", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->detectorStageLateralMotors()), "Ge 32-el Stage", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView( createComponentView(bioXASBL->zebra()), "Zebra", componentPaneCategoryName_, componentPaneIcon_);
 
 }
 
@@ -425,7 +425,7 @@ void BioXASAppController::createCalibrationPane()
 	if (BioXASBeamline::bioXAS()->mono()) {
 		energyCalibrationView_ = new BioXASSSRLMonochromatorEnergyCalibrationView(BioXASBeamline::bioXAS()->mono(), 0);
 
-		addMainWindowViewToPane(energyCalibrationView_, "Energy", calibrationPaneCategoryName_, calibrationPaneIcon_);
+		addMainWindowView(energyCalibrationView_, "Energy", calibrationPaneCategoryName_, calibrationPaneIcon_);
 		connect( energyCalibrationView_, SIGNAL(energyCalibrationScanRequested()), this, SLOT(goToEnergyCalibrationScanConfigurationView()) );
 	}
 }

--- a/source/application/BioXAS/BioXASMainAppController.cpp
+++ b/source/application/BioXAS/BioXASMainAppController.cpp
@@ -58,5 +58,5 @@ void BioXASMainAppController::createDetectorPanes()
 {
 	BioXASAppController::createDetectorPanes();
 
-	addViewToPane(createComponentView(BioXASMainBeamline::bioXAS()->ge32DetectorInboard()), "Ge 32-el 1", detectorPaneCategoryName_, detectorPaneIcon_ );
+	addMainWindowPane(createComponentView(BioXASMainBeamline::bioXAS()->ge32DetectorInboard()), "Ge 32-el 1", detectorPaneCategoryName_, detectorPaneIcon_ );
 }

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -41,10 +41,10 @@ void BioXASSideAppController::updateGeDetectorView()
     QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
 
     if (detector && detectorView && detectorPane) {
-	if (detector->isConnected())
-	    mw_->showPane(detectorPane);
-	else
-	    mw_->hidePane(detectorPane);
+		if (detector->isConnected())
+			mw_->showPane(detectorPane);
+		else
+			mw_->hidePane(detectorPane);
     }
 }
 
@@ -77,14 +77,14 @@ void BioXASSideAppController::createDetectorPanes()
 {
 	BioXASAppController::createDetectorPanes();
 
-	addViewToPane( createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
+	addMainWindowView( createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
 }
 
 void BioXASSideAppController::createComponentsPane()
 {
 	BioXASAppController::createComponentsPane();
 
-	addMainWindowViewToPane(createComponentView(BioXASSideBeamline::bioXAS()->detectorStageLateralMotor()), "Ge 32-el Stage", componentPaneCategoryName_, componentPaneIcon_);
+	addMainWindowView(createComponentView(BioXASSideBeamline::bioXAS()->detectorStageLateralMotor()), "Ge 32-el Stage", componentPaneCategoryName_, componentPaneIcon_);
 
 	// Collapse the 'Components' heading, by default.
 	mw_->collapseHeading(componentPaneCategoryName_);

--- a/source/application/CLS/CLSAppController.cpp
+++ b/source/application/CLS/CLSAppController.cpp
@@ -119,19 +119,18 @@ void CLSAppController::setupUserInterfaceImplementation()
 	AMErrorMon::debug(this, CLS_APPCONTROLLER_INFO_UNIMPLEMENTED_METHOD, "Looks like there is no special implementation for setupUserInterface(). ");
 }
 
-void CLSAppController::addViewToPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon)
+void CLSAppController::addMainWindowPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon)
 {
-	if (view) {
+	if (view)
 		mw_->addPane(view, paneCategoryName, viewName, paneIcon);
-		viewPaneMapping_.insert(view, view);
-	}
 }
 
-void CLSAppController::addMainWindowViewToPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon)
+void CLSAppController::addMainWindowView(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon)
 {
 	if (view) {
-		QWidget *mainWindowView = AMMainWindow::buildMainWindowPane(viewName, paneIcon, view);
-		addViewToPane(mainWindowView, viewName, paneCategoryName, paneIcon);
+		QWidget *pane = AMMainWindow::buildMainWindowPane(viewName, paneIcon, view);
+		viewPaneMapping_.insert(view, pane);
+		addMainWindowPane(pane, viewName, paneCategoryName, paneIcon);
 	}
 }
 

--- a/source/application/CLS/CLSAppController.h
+++ b/source/application/CLS/CLSAppController.h
@@ -61,9 +61,9 @@ protected:
 	virtual void createScanConfigurationPanes() = 0;
 
 	/// helper function to add a given view directly to the given main window pane, with the given name.
-	void addViewToPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon);
+	void addMainWindowPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon);
 	/// helper function to add a given view (and create a squeeze layout) to the given main window pane, with the given name.
-	void addMainWindowViewToPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon);
+	void addMainWindowView(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon);
 
 	/// Returns a string representation of the stylesheet to be applied application-wide on startup.
 	virtual QString getStylesheet() const;

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -191,19 +191,19 @@ void PGMAppController::createGeneralPanes()
 {
 	// create beamline status view
 	beamlineStatusView_ = new CLSBeamlineStatusView(PGMBeamline::pgm()->beamlineStatus(), false);
-	addMainWindowViewToPane( beamlineStatusView_, "Beamline status", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView( beamlineStatusView_, "Beamline status", generalPaneCategeryName_, generalPaneIcon_);
 
 	CLSSynchronizedDwellTime *synchronizedDwellTime = qobject_cast<CLSSynchronizedDwellTime *>(AMBeamline::bl()->synchronizedDwellTime());
 	CLSSynchronizedDwellTimeView *synchronizedDwellTimeView = new CLSSynchronizedDwellTimeView(synchronizedDwellTime);
 	synchronizedDwellTimeView->setAdvancedViewVisible(true);
-	addMainWindowViewToPane(synchronizedDwellTimeView, "Synchronized Dwell", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(synchronizedDwellTimeView, "Synchronized Dwell", generalPaneCategeryName_, generalPaneIcon_);
 
-	addMainWindowViewToPane(new PGMBladeCurrentView, "Blade Currents", generalPaneCategeryName_, generalPaneIcon_);
-	addMainWindowViewToPane(new PGMSlitControlView, "Slits", generalPaneCategeryName_, generalPaneIcon_);
-	addMainWindowViewToPane(new PGMGratingView, "Mono Grating", generalPaneCategeryName_, generalPaneIcon_);
-	addMainWindowViewToPane(new PGMUndulatorView, "Undulator", generalPaneCategeryName_, generalPaneIcon_);
-	addMainWindowViewToPane(new PGMVariableApertureMaskView(PGMBeamline::pgm()->vam()), "Variable Aperture Mask", generalPaneCategeryName_, generalPaneIcon_);
-	addMainWindowViewToPane(new CLSHVControlGroupView(PGMBeamline::pgm()->branchAHVControlSet(), PGMBeamline::pgm()->branchBHVControlSet(), false), "HV Conrols", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(new PGMBladeCurrentView, "Blade Currents", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(new PGMSlitControlView, "Slits", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(new PGMGratingView, "Mono Grating", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(new PGMUndulatorView, "Undulator", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(new PGMVariableApertureMaskView(PGMBeamline::pgm()->vam()), "Variable Aperture Mask", generalPaneCategeryName_, generalPaneIcon_);
+	addMainWindowView(new CLSHVControlGroupView(PGMBeamline::pgm()->branchAHVControlSet(), PGMBeamline::pgm()->branchBHVControlSet(), false), "HV Conrols", generalPaneCategeryName_, generalPaneIcon_);
 }
 
 void PGMAppController::createDetectorPanes()

--- a/source/ui/AMMainWindow.cpp
+++ b/source/ui/AMMainWindow.cpp
@@ -387,11 +387,11 @@ QWidget * AMMainWindow::currentPane() const
 	return stackWidget_->currentWidget();
 }
 
-QWidget *AMMainWindow::buildMainWindowPane(const QString &name, const QString &iconPath, QWidget *appWidget)
+QWidget *AMMainWindow::buildMainWindowPane(const QString &name, const QString &iconPath, QWidget *view)
 {
 	QHBoxLayout *horizontalLayout = new QHBoxLayout();
 	horizontalLayout->addStretch();
-	horizontalLayout->addWidget(appWidget);
+	horizontalLayout->addWidget(view);
 	horizontalLayout->addStretch();
 
 	QVBoxLayout *verticalLayout = new QVBoxLayout();

--- a/source/ui/AMMainWindow.h
+++ b/source/ui/AMMainWindow.h
@@ -107,7 +107,7 @@ public:
 	QWidget* currentPane() const;
 
 	/// Returns a widget pane that has been squished and fitted to be placed in a mainwindow
-	static QWidget *buildMainWindowPane(const QString &name, const QString &iconPath, QWidget *appWidget);
+	static QWidget *buildMainWindowPane(const QString &name, const QString &iconPath, QWidget *view);
 
 	/// Returns a widget composed of the Top Frame and Configuration View
 	static QWidget *buildMainWindowConfigurationPane(const QString &topFrameName, AMScanConfigurationView *configView, bool enableLoopAction = false, bool squeezeWidget = true);

--- a/source/ui/BioXAS/BioXASPersistentView.cpp
+++ b/source/ui/BioXAS/BioXASPersistentView.cpp
@@ -51,7 +51,7 @@ BioXASPersistentView::BioXASPersistentView(QWidget *parent) :
 
 	if (beamlineStatus) {
 		QWidget * beamlineStatusView = new CLSBeamlineStatusView(beamlineStatus, true);
-		connect(beamlineStatusView, SIGNAL(selectedComponentChanged(AMControl*)), this, SIGNAL(beamlineStatusSelectedComponentChanged(AMControl*)) );
+		connect(beamlineStatusView, SIGNAL(controlClicked(AMControl*)), this, SIGNAL(beamlineStatusControlClicked(AMControl*)) );
 
 		mainViewLayout->addWidget(beamlineStatusView);
 	}

--- a/source/ui/BioXAS/BioXASPersistentView.h
+++ b/source/ui/BioXAS/BioXASPersistentView.h
@@ -20,7 +20,7 @@ public:
 
 signals:
 	/// Notifier that the selected control in the beam status buttons view has changed.
-	void beamlineStatusSelectedComponentChanged(AMControl *control);
+	void beamlineStatusControlClicked(AMControl *control);
 
 public slots:
 	/// Refreshes the view.

--- a/source/ui/CLS/CLSBeamlineStatusButtonBar.cpp
+++ b/source/ui/CLS/CLSBeamlineStatusButtonBar.cpp
@@ -2,8 +2,8 @@
 
 #include "beamline/CLS/CLSBeamlineStatus.h"
 
-CLSBeamlineStatusButtonBar::CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, QWidget *parent) :
-	CLSControlButtonBar(parent)
+CLSBeamlineStatusButtonBar::CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, CLSButtonBar::SelectionMode selectionMode, QWidget *parent) :
+	CLSControlButtonBar(selectionMode, parent)
 {
 	// Initialize class variables.
 

--- a/source/ui/CLS/CLSBeamlineStatusButtonBar.cpp
+++ b/source/ui/CLS/CLSBeamlineStatusButtonBar.cpp
@@ -2,8 +2,8 @@
 
 #include "beamline/CLS/CLSBeamlineStatus.h"
 
-CLSBeamlineStatusButtonBar::CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, CLSButtonBar::SelectionMode selectionMode, QWidget *parent) :
-	CLSControlButtonBar(selectionMode, parent)
+CLSBeamlineStatusButtonBar::CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, QWidget *parent) :
+	CLSControlButtonBar(parent)
 {
 	// Initialize class variables.
 

--- a/source/ui/CLS/CLSBeamlineStatusButtonBar.h
+++ b/source/ui/CLS/CLSBeamlineStatusButtonBar.h
@@ -11,7 +11,7 @@ class CLSBeamlineStatusButtonBar : public CLSControlButtonBar
 
 public:
 	/// Constructor.
-	CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, QWidget *parent = 0);
+	CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, CLSButtonBar::SelectionMode selectionMode = CLSButtonBar::ClickTogglesSelection, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~CLSBeamlineStatusButtonBar();
 

--- a/source/ui/CLS/CLSBeamlineStatusButtonBar.h
+++ b/source/ui/CLS/CLSBeamlineStatusButtonBar.h
@@ -11,7 +11,7 @@ class CLSBeamlineStatusButtonBar : public CLSControlButtonBar
 
 public:
 	/// Constructor.
-	CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, CLSButtonBar::SelectionMode selectionMode = CLSButtonBar::ClickTogglesSelection, QWidget *parent = 0);
+	CLSBeamlineStatusButtonBar(CLSBeamlineStatus *beamlineStatus, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~CLSBeamlineStatusButtonBar();
 

--- a/source/ui/CLS/CLSBeamlineStatusView.cpp
+++ b/source/ui/CLS/CLSBeamlineStatusView.cpp
@@ -167,6 +167,7 @@ QLayout* CLSBeamlineStatusView::createBeamlineStatusButtonBarLayout()
 	componentBarLayout->addStretch();
 
 	connect( componentButtonBar_, SIGNAL(selectedControlChanged(AMControl*)), this, SLOT(setSelectedComponent(AMControl*)) );
+	connect( componentButtonBar_, SIGNAL(controlClicked(AMControl*)), this, SIGNAL(controlClicked(AMControl*)) );
 
 	return componentBarLayout;
 }

--- a/source/ui/CLS/CLSBeamlineStatusView.h
+++ b/source/ui/CLS/CLSBeamlineStatusView.h
@@ -31,6 +31,8 @@ signals:
 	void beamStatusChanged(CLSBeamlineStatus *newStatus);
 	/// Notifier that the selected component has changed.
 	void selectedComponentChanged(AMControl *newControl);
+	/// Notifier that a component has been clicked.
+	void controlClicked(AMControl *control);
 
 public slots:
 	/// Refreshes the view.

--- a/source/ui/CLS/CLSButtonBar.cpp
+++ b/source/ui/CLS/CLSButtonBar.cpp
@@ -1,11 +1,10 @@
 #include "CLSButtonBar.h"
 
-CLSButtonBar::CLSButtonBar(SelectionMode selectionMode, QWidget *parent) :
+CLSButtonBar::CLSButtonBar(QWidget *parent) :
 	QWidget(parent)
 {
 	// Initialize class variables.
 
-	selectionMode_ = selectionMode;
 	selectedButton_ = 0;
 
 	buttonsGroup_ = new QButtonGroup(this);
@@ -30,14 +29,6 @@ CLSButtonBar::~CLSButtonBar()
 QList<QAbstractButton*> CLSButtonBar::buttons() const
 {
 	return buttonsGroup_->buttons();
-}
-
-void CLSButtonBar::setSelectionMode(SelectionMode newMode)
-{
-	if (selectionMode_ != newMode) {
-		selectionMode_ = newMode;
-		emit selectionModeChanged(selectionMode_);
-	}
 }
 
 void CLSButtonBar::setSelectedButton(QAbstractButton *button)
@@ -107,7 +98,7 @@ void CLSButtonBar::onButtonClicked(QAbstractButton *clickedButton)
 	// Otherwise, the clicked button should become the new
 	// selection.
 
-	if (selectedButton_ == clickedButton && selectionMode_ == ClickTogglesSelection)
+	if (selectedButton_ == clickedButton)
 		setSelectedButton(0);
 	else if (selectedButton_ != clickedButton)
 		setSelectedButton(clickedButton);

--- a/source/ui/CLS/CLSButtonBar.h
+++ b/source/ui/CLS/CLSButtonBar.h
@@ -15,22 +15,41 @@ class CLSButtonBar : public QWidget
 {
 	Q_OBJECT
 
+	Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
+	Q_ENUMS(SelectionMode)
+
 public:
+	/// Enumeration of the different click-selection modes.
+	enum SelectionMode { ClickTogglesSelection = 0, ClickAlwaysSelects = 1 };
+
 	/// Constructor.
-	explicit CLSButtonBar(QWidget *parent = 0);
+	explicit CLSButtonBar(SelectionMode mode = ClickTogglesSelection, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~CLSButtonBar();
 
+	/// Returns the selection mode.
+	SelectionMode selectionMode() const { return selectionMode_; }
 	/// Returns the selected button.
 	QAbstractButton* selectedButton() const { return selectedButton_; }
+	/// Returns the buttons.
+	QList<QAbstractButton*> buttons() const;
 
 signals:
-	/// Notifier that the buttons have changed.
-	void buttonsChanged();
+	/// Notifier that the selection mode has changed.
+	void selectionModeChanged(SelectionMode newMode);
 	/// Notifier that the button was selected.
 	void selectedButtonChanged(QAbstractButton *newButton);
+	/// Notifier that the buttons have changed.
+	void buttonsChanged();
+	/// Notifier that a button has been clicked.
+	void buttonClicked(QAbstractButton *button);
 
-protected slots:
+public slots:
+	/// Sets the selection mode.
+	void setSelectionMode(SelectionMode newMode);
+	/// Sets the selected button.
+	void setSelectedButton(QAbstractButton *button);
+
 	/// Adds a button.
 	void addButton(QAbstractButton *newButton);
 	/// Removes a button.
@@ -38,15 +57,16 @@ protected slots:
 	/// Clears all buttons.
 	void clearButtons();
 
-	/// Sets the selected button.
-	void setSelectedButton(QAbstractButton *button);
-
+protected slots:
 	/// Handles updating the selected button, in response to a button being clicked.
-	void onButtonClicked(QAbstractButton *clickedButton);
+	virtual void onButtonClicked(QAbstractButton *clickedButton);
 
 protected:
+	/// The selection mode.
+	SelectionMode selectionMode_;
 	/// The selected button.
 	QAbstractButton *selectedButton_;
+
 	/// The buttons group.
 	QButtonGroup *buttonsGroup_;
 	/// The buttons layout.

--- a/source/ui/CLS/CLSButtonBar.h
+++ b/source/ui/CLS/CLSButtonBar.h
@@ -15,28 +15,18 @@ class CLSButtonBar : public QWidget
 {
 	Q_OBJECT
 
-	Q_PROPERTY(SelectionMode selectionMode READ selectionMode WRITE setSelectionMode NOTIFY selectionModeChanged)
-	Q_ENUMS(SelectionMode)
-
 public:
-	/// Enumeration of the different click-selection modes.
-	enum SelectionMode { ClickTogglesSelection = 0, ClickAlwaysSelects = 1 };
-
 	/// Constructor.
-	explicit CLSButtonBar(SelectionMode mode = ClickTogglesSelection, QWidget *parent = 0);
+	explicit CLSButtonBar(QWidget *parent = 0);
 	/// Destructor.
 	virtual ~CLSButtonBar();
 
-	/// Returns the selection mode.
-	SelectionMode selectionMode() const { return selectionMode_; }
 	/// Returns the selected button.
 	QAbstractButton* selectedButton() const { return selectedButton_; }
 	/// Returns the buttons.
 	QList<QAbstractButton*> buttons() const;
 
 signals:
-	/// Notifier that the selection mode has changed.
-	void selectionModeChanged(SelectionMode newMode);
 	/// Notifier that the button was selected.
 	void selectedButtonChanged(QAbstractButton *newButton);
 	/// Notifier that the buttons have changed.
@@ -45,8 +35,6 @@ signals:
 	void buttonClicked(QAbstractButton *button);
 
 public slots:
-	/// Sets the selection mode.
-	void setSelectionMode(SelectionMode newMode);
 	/// Sets the selected button.
 	void setSelectedButton(QAbstractButton *button);
 
@@ -62,8 +50,6 @@ protected slots:
 	virtual void onButtonClicked(QAbstractButton *clickedButton);
 
 protected:
-	/// The selection mode.
-	SelectionMode selectionMode_;
 	/// The selected button.
 	QAbstractButton *selectedButton_;
 

--- a/source/ui/CLS/CLSControlButtonBar.cpp
+++ b/source/ui/CLS/CLSControlButtonBar.cpp
@@ -2,8 +2,8 @@
 
 #include "ui/CLS/CLSControlButton.h"
 
-CLSControlButtonBar::CLSControlButtonBar(CLSButtonBar::SelectionMode selectionMode, QWidget *parent) :
-	CLSButtonBar(selectionMode, parent)
+CLSControlButtonBar::CLSControlButtonBar(QWidget *parent) :
+	CLSButtonBar(parent)
 {
 	selectedControl_ = 0;
 

--- a/source/ui/CLS/CLSControlButtonBar.cpp
+++ b/source/ui/CLS/CLSControlButtonBar.cpp
@@ -2,8 +2,8 @@
 
 #include "ui/CLS/CLSControlButton.h"
 
-CLSControlButtonBar::CLSControlButtonBar(QWidget *parent) :
-	CLSButtonBar(parent)
+CLSControlButtonBar::CLSControlButtonBar(CLSButtonBar::SelectionMode selectionMode, QWidget *parent) :
+	CLSButtonBar(selectionMode, parent)
 {
 	selectedControl_ = 0;
 
@@ -62,4 +62,12 @@ void CLSControlButtonBar::updateSelectedControl()
 {
 	AMControl *selectedControl = controlButtonMap_.key(selectedButton(), 0);
 	setSelectedControl(selectedControl);
+}
+
+void CLSControlButtonBar::onButtonClicked(QAbstractButton *clickedButton)
+{
+	CLSButtonBar::onButtonClicked(clickedButton);
+
+	if (clickedButton && controlButtonMap_.values().contains(clickedButton))
+		emit controlClicked(controlButtonMap_.key(clickedButton, 0));
 }

--- a/source/ui/CLS/CLSControlButtonBar.h
+++ b/source/ui/CLS/CLSControlButtonBar.h
@@ -13,7 +13,7 @@ class CLSControlButtonBar : public CLSButtonBar
 
 public:
 	/// Constructor.
-	explicit CLSControlButtonBar(CLSButtonBar::SelectionMode selectionMode, QWidget *parent = 0);
+	explicit CLSControlButtonBar(QWidget *parent = 0);
 	/// Destructor.
 	virtual ~CLSControlButtonBar();
 

--- a/source/ui/CLS/CLSControlButtonBar.h
+++ b/source/ui/CLS/CLSControlButtonBar.h
@@ -13,7 +13,7 @@ class CLSControlButtonBar : public CLSButtonBar
 
 public:
 	/// Constructor.
-	explicit CLSControlButtonBar(QWidget *parent = 0);
+	explicit CLSControlButtonBar(CLSButtonBar::SelectionMode selectionMode, QWidget *parent = 0);
 	/// Destructor.
 	virtual ~CLSControlButtonBar();
 
@@ -23,6 +23,8 @@ public:
 signals:
 	/// Notifier that the selected control has changed.
 	void selectedControlChanged(AMControl *newControl);
+	/// Notifier that the button corresponding to a component has been clicked.
+	void controlClicked(AMControl *control);
 
 public slots:
 	/// Adds a button for the given control to the button bar.
@@ -38,6 +40,9 @@ public slots:
 protected slots:
 	/// Handles updating the selected control, the control corresponding to the selected button.
 	void updateSelectedControl();
+
+	/// Handles updating the selected button, in response to a button being clicked. Reimplemented to provide notification that a control has been clicked.
+	virtual void onButtonClicked(QAbstractButton *clickedButton);
 
 protected:
 	/// Creates and returns a button for the given control.


### PR DESCRIPTION
- Added `buttonClicked(...)` and `controlClicked(...)` signals to the CLSButtonBar and CLSControlButtonBar classes. This allows the view to announce when controls have been clicked, instead of just when the selection state changes.
- Added signal to the BioXASPersistentView to announce when a beam status bar control is clicked.
- Modified BioXASAppController to switch the current pane to the beam status pane in response to the persistent view's new signal.