### PR TITLE
Pull request for Issue 1476: Change default print location to exportData

### DIFF
--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -556,10 +556,7 @@ void AM2DScanView::exportGraphicsFile(const QString& fileName)
 		if(fileName.contains("userData"))
 				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 		else
-			if(fileName.endsWith("/"))
 				printer.setOutputFileName(fileName);
-			else
-				printer.setOutputFileName(fileName + "/");
 
 		QPainter painter(&printer);
 		gExclusiveView_->render(&painter);

--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -542,10 +542,7 @@ void AM2DScanView::removeSingleSpectrumCombinationPileUpPeakNameFilter(const QRe
 
 #include <QPrinter>
 #include <QFileInfo>
-#include <QDir>
 #include <QMessageBox>
-#include <QDesktopServices>
-#include <QDebug>
 
 void AM2DScanView::exportGraphicsFile(const QString& fileName)
 {

--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -556,10 +556,10 @@ void AM2DScanView::exportGraphicsFile(const QString& fileName)
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
 
-                if(fileName.contains("userData"))
-                        printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
-                else
-                        printer.setOutputFileName(fileName);
+		if(fileName.contains("userData"))
+				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
+		else
+				printer.setOutputFileName(fileName);
 
 		QPainter painter(&printer);
 		gExclusiveView_->render(&painter);
@@ -578,24 +578,23 @@ void AM2DScanView::exportGraphicsFile(const QString& fileName)
 		gExclusiveView_->render(&painter);
 		painter.end();
 
-                if(fileName.contains("userData"))
-                        image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
-                else
-                        image.save(fileName);
+		if(fileName.contains("userData"))
+				image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
+		else
+				image.save(fileName);
 	}
 }
 
 void AM2DScanView::printGraphics()
 {
-                QPrinter printer(QPrinter::HighResolution);
+		QPrinter printer(QPrinter::HighResolution);
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
-                printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
+		printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 
 		QPrintDialog *dialog = new QPrintDialog(&printer, this);
 			dialog->setWindowTitle(tr("Print Spectra"));
-                        if (dialog->)
 			if (dialog->exec() != QDialog::Accepted)
 			return;
 

--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -542,17 +542,24 @@ void AM2DScanView::removeSingleSpectrumCombinationPileUpPeakNameFilter(const QRe
 
 #include <QPrinter>
 #include <QFileInfo>
+#include <QDir>
 #include <QMessageBox>
+#include <QDesktopServices>
+#include <QDebug>
 
 void AM2DScanView::exportGraphicsFile(const QString& fileName)
 {
 	if (fileName.endsWith(".pdf")){
-
 		QPrinter printer(QPrinter::HighResolution);
-		printer.setOutputFileName(fileName);
+
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
+
+                if(fileName.contains("userData"))
+                        printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
+                else
+                        printer.setOutputFileName(fileName);
 
 		QPainter painter(&printer);
 		gExclusiveView_->render(&painter);
@@ -570,19 +577,25 @@ void AM2DScanView::exportGraphicsFile(const QString& fileName)
 		QPainter painter(&image);
 		gExclusiveView_->render(&painter);
 		painter.end();
-		image.save(fileName);
+
+                if(fileName.contains("userData"))
+                        image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
+                else
+                        image.save(fileName);
 	}
 }
 
 void AM2DScanView::printGraphics()
 {
-		QPrinter printer(QPrinter::HighResolution);
+                QPrinter printer(QPrinter::HighResolution);
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
+                printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
 
 		QPrintDialog *dialog = new QPrintDialog(&printer, this);
 			dialog->setWindowTitle(tr("Print Spectra"));
+                        if (dialog->)
 			if (dialog->exec() != QDialog::Accepted)
 			return;
 

--- a/source/ui/dataman/AM2DScanView.cpp
+++ b/source/ui/dataman/AM2DScanView.cpp
@@ -556,7 +556,10 @@ void AM2DScanView::exportGraphicsFile(const QString& fileName)
 		if(fileName.contains("userData"))
 				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 		else
+			if(fileName.endsWith("/"))
 				printer.setOutputFileName(fileName);
+			else
+				printer.setOutputFileName(fileName + "/");
 
 		QPainter painter(&printer);
 		gExclusiveView_->render(&painter);

--- a/source/ui/dataman/AMGenericScanEditor.cpp
+++ b/source/ui/dataman/AMGenericScanEditor.cpp
@@ -908,8 +908,12 @@ void AMGenericScanEditor::exportGraphicsToFile()
 
 	QFileDialog dialog(this, "Save Graphics As...", QString(), filters);
 	dialog.setAcceptMode(QFileDialog::AcceptSave);
+	dialog.setFileMode(QFileDialog::ExistingFiles);
 	dialog.exec();
-	QString fileName = dialog.selectedFiles().first();
+
+	QString fileName;
+	if(!dialog.selectedFiles().isEmpty())
+			fileName = dialog.selectedFiles().first();
 
 	if(!fileName.isEmpty()) {
 

--- a/source/ui/dataman/AMGenericScanEditor.cpp
+++ b/source/ui/dataman/AMGenericScanEditor.cpp
@@ -908,14 +908,11 @@ void AMGenericScanEditor::exportGraphicsToFile()
 
 	QFileDialog dialog(this, "Save Graphics As...", QString(), filters);
 	dialog.setAcceptMode(QFileDialog::AcceptSave);
-	dialog.setFileMode(QFileDialog::ExistingFiles);
 	dialog.exec();
 
-	QString fileName;
-	if(!dialog.selectedFiles().isEmpty())
-			fileName = dialog.selectedFiles().first();
+	if(!dialog.selectedFiles().isEmpty() && dialog.directory() != dialog.selectedFiles().first()){
 
-	if(!fileName.isEmpty()) {
+		QString fileName = dialog.selectedFiles().first();
 
 		if(dialog.selectedNameFilter().contains("PDF") && !fileName.endsWith(".pdf", Qt::CaseInsensitive))
 			fileName.append(".pdf");

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2415,7 +2415,10 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 		if(fileName.contains("userData"))
 				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
 		else
+			if(fileName.endsWith("/"))
 				printer.setOutputFileName(fileName);
+			else
+				printer.setOutputFileName(fileName + "/");
 
 		QPainter painter(&printer);
 		gview_->render(&painter);

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2413,9 +2413,9 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 		printer.setOrientation(QPrinter::Landscape);
 
 		if(fileName.contains("userData"))
-				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
+			printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
 		else
-				printer.setOutputFileName(fileName);
+			printer.setOutputFileName(fileName);
 
 		QPainter painter(&printer);
 		gview_->render(&painter);
@@ -2435,10 +2435,10 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 		painter.end();
 
 		if(fileName.contains("userData"))
-				image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
+			image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 		else
-				image.save(fileName);;
-	}		
+			image.save(fileName);;
+	}
 }
 
 void AMScanView::printGraphics()

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2415,10 +2415,7 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 		if(fileName.contains("userData"))
 				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
 		else
-			if(fileName.endsWith("/"))
 				printer.setOutputFileName(fileName);
-			else
-				printer.setOutputFileName(fileName + "/");
 
 		QPainter painter(&printer);
 		gview_->render(&painter);

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2450,7 +2450,7 @@ void AMScanView::printGraphics()
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
-				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
+		printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 
 		QPrintDialog *dialog = new QPrintDialog(&printer, this);
 			dialog->setWindowTitle(tr("Print Spectra"));

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2406,19 +2406,17 @@ void AMScanViewMultiSourcesView::setDataRangeConstraint(int id)
 
 void AMScanView::exportGraphicsFile(const QString& fileName)
 {
-        QDir exportLocation(fileName);
-
-        if (fileName.contains("userData")){
-            exportLocation.cdUp();
-            exportLocation.cd("exportData");
-        }
 	if (fileName.endsWith(".pdf")){
-
 		QPrinter printer(QPrinter::HighResolution);
-                printer.setOutputFileName(exportLocation.absolutePath());
+
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
+
+		if(fileName.contains("userData"))
+				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy_[hh:mm:ss]"));
+		else
+				printer.setOutputFileName(fileName);
 
 		QPainter painter(&printer);
 		gview_->render(&painter);
@@ -2436,21 +2434,21 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 		QPainter painter(&image);
 		gview_->render(&painter);
 		painter.end();
-		image.save(fileName);
+
+		if(fileName.contains("userData"))
+				image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
+		else
+				image.save(fileName);;
 	}
 }
 
 void AMScanView::printGraphics()
 {
-                QDir exportLocation(AMUserSettings::userDataFolder);
-                exportLocation.cdUp();
-                exportLocation.cd("exportData");
-
 		QPrinter printer(QPrinter::HighResolution);
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
-                printer.setOutputFileName(exportLocation.absolutePath());
+				printer.setOutputFileName(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 
 		QPrintDialog *dialog = new QPrintDialog(&printer, this);
 			dialog->setWindowTitle(tr("Print Spectra"));

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2401,14 +2401,21 @@ void AMScanViewMultiSourcesView::setDataRangeConstraint(int id)
 
 #include <QPrinter>
 #include <QFileInfo>
+#include <QDir>
 #include <QMessageBox>
 
 void AMScanView::exportGraphicsFile(const QString& fileName)
 {
+        QDir exportLocation(fileName);
+
+        if (fileName.contains("userData")){
+            exportLocation.cdUp();
+            exportLocation.cd("exportData");
+        }
 	if (fileName.endsWith(".pdf")){
 
 		QPrinter printer(QPrinter::HighResolution);
-		printer.setOutputFileName(fileName);
+                printer.setOutputFileName(exportLocation.absolutePath());
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
@@ -2435,11 +2442,15 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 
 void AMScanView::printGraphics()
 {
+                QDir exportLocation(AMUserSettings::userDataFolder);
+                exportLocation.cdUp();
+                exportLocation.cd("exportData");
 
 		QPrinter printer(QPrinter::HighResolution);
 		printer.setPageSize(QPrinter::Letter);
 		printer.setOutputFormat(QPrinter::PdfFormat);
 		printer.setOrientation(QPrinter::Landscape);
+                printer.setOutputFileName(exportLocation.absolutePath());
 
 		QPrintDialog *dialog = new QPrintDialog(&printer, this);
 			dialog->setWindowTitle(tr("Print Spectra"));

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2401,7 +2401,6 @@ void AMScanViewMultiSourcesView::setDataRangeConstraint(int id)
 
 #include <QPrinter>
 #include <QFileInfo>
-#include <QDir>
 #include <QMessageBox>
 
 void AMScanView::exportGraphicsFile(const QString& fileName)

--- a/source/ui/dataman/AMScanView.cpp
+++ b/source/ui/dataman/AMScanView.cpp
@@ -2438,7 +2438,7 @@ void AMScanView::exportGraphicsFile(const QString& fileName)
 				image.save(AMUserSettings::defaultAbsoluteExportFolder() + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd--hh-mm-ss"));
 		else
 				image.save(fileName);;
-	}
+	}		
 }
 
 void AMScanView::printGraphics()

--- a/source/util/AMSettings.cpp
+++ b/source/util/AMSettings.cpp
@@ -86,20 +86,20 @@ QString AMUserSettings::relativePathFromUserDataFolder(const QString &absolutePa
 		*wasInUserDataFolder = wasOK;
 	}
 
-        return rv;
+	return rv;
 }
 
 QString AMUserSettings::defaultAbsoluteExportFolder()
 {
-        QDir userDataDirectory(userDataFolder);
-        userDataDirectory.cdUp();
+	QDir userDataDirectory(userDataFolder);
+	userDataDirectory.cdUp();
 
-        //If the export folder exists (as it always should) then return the path to exportData.
-        //Otherwise, have exports go to Desktop so the problem is obvious without compromising data based actions.
-        if(userDataDirectory.cd("exportData"))
-                return userDataDirectory.absolutePath();
-        else
-                return QDesktopServices::storageLocation(QDesktopServices::DesktopLocation);
+	//If the export folder exists (as it always should) then return the path to exportData.
+	//Otherwise, have exports go to Desktop so the problem is obvious without compromising data based actions.
+	if(userDataDirectory.cd("exportData"))
+		return userDataDirectory.absolutePath();
+	else
+		return QDesktopServices::storageLocation(QDesktopServices::DesktopLocation);
 }
 
 

--- a/source/util/AMSettings.cpp
+++ b/source/util/AMSettings.cpp
@@ -24,6 +24,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDir>
 #include <QDateTime>
 #include <QStringBuilder>
+#include <QDesktopServices>
 
 #include <QMutexLocker>
 #include <QReadLocker>
@@ -85,7 +86,20 @@ QString AMUserSettings::relativePathFromUserDataFolder(const QString &absolutePa
 		*wasInUserDataFolder = wasOK;
 	}
 
-	return rv;
+        return rv;
+}
+
+QString AMUserSettings::defaultAbsoluteExportFolder()
+{
+        QDir userDataDirectory(userDataFolder);
+        userDataDirectory.cdUp();
+
+        //If the export folder exists (as it always should) then return the path to exportData.
+        //Otherwise, have exports go to Desktop so the problem is obvious without compromising data based actions.
+        if(userDataDirectory.cd("exportData"))
+                return userDataDirectory.absolutePath();
+        else
+                return QDesktopServices::storageLocation(QDesktopServices::DesktopLocation);
 }
 
 

--- a/source/util/AMSettings.h
+++ b/source/util/AMSettings.h
@@ -74,6 +74,9 @@ public:
 	/// Takes an absolute file path, and if it can be expressed relative to the userDataFolder, returns it as that relative path. (Example: /Users/mboots/acquamanUserData/2010/03/foo.txt becomes 2010/03/foo.txt, if my userDataFolder is /User/mboots/acquamanUserData).  If provided, \c wasInUserDataFolder is set to true if \c absolutePath could be expressed within the userDataFolder, and false if it was outside of that.
 	static QString relativePathFromUserDataFolder(const QString& absolutePath, bool* wasInUserDataFolder = 0);
 
+        /// Returns the absolute export folder path based on the current data folder location.
+        static QString defaultAbsoluteExportFolder();
+
 	/// Removes the remote data folder entry.
 	static void removeRemoteDataFolderEntry();
 

--- a/source/util/AMSettings.h
+++ b/source/util/AMSettings.h
@@ -74,8 +74,8 @@ public:
 	/// Takes an absolute file path, and if it can be expressed relative to the userDataFolder, returns it as that relative path. (Example: /Users/mboots/acquamanUserData/2010/03/foo.txt becomes 2010/03/foo.txt, if my userDataFolder is /User/mboots/acquamanUserData).  If provided, \c wasInUserDataFolder is set to true if \c absolutePath could be expressed within the userDataFolder, and false if it was outside of that.
 	static QString relativePathFromUserDataFolder(const QString& absolutePath, bool* wasInUserDataFolder = 0);
 
-        /// Returns the absolute export folder path based on the current data folder location.
-        static QString defaultAbsoluteExportFolder();
+	/// Returns the absolute export folder path based on the current data folder location.
+	static QString defaultAbsoluteExportFolder();
 
 	/// Removes the remote data folder entry.
 	static void removeRemoteDataFolderEntry();


### PR DESCRIPTION
The default print and export locations will some times be userData instead of exportData. Added in-method checks to insure paths do not contain userData and to use a default path option if that is the case.

Adjusted file naming so that print-to-file scans are set to a default name scheme, based on date and time, to avoid name conflicts or overwrites.

Fixed a bug in the AMGenericScanEditor that would save an exported file with the parent's directory name in the parent's folder. This occurs when the export window is opened, no name is specified and the user selected cancel. QFileDialog with no name entry or selection would return the window directory path by default and AMGenericScanEditor would tag on an extension.

#1476 