### PR TITLE
Pull request for Issue 2416: Side UI too tall

### DIFF
--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -36,11 +36,11 @@ BioXASSideAppController::~BioXASSideAppController()
 
 void BioXASSideAppController::updateGeDetectorView()
 {
-    BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
-    QWidget *detectorView = componentViewMapping_.value(detector, 0);
-    QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
+	BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
+	QWidget *detectorView = componentViewMapping_.value(detector, 0);
+	QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
 
-    if (detector && detectorView && detectorPane) {
+	if (detector && detectorView && detectorPane) {
 		if (detector->isConnected())
 			mw_->showPane(detectorPane);
 		else
@@ -77,7 +77,7 @@ void BioXASSideAppController::createDetectorPanes()
 {
 	BioXASAppController::createDetectorPanes();
 
-	addMainWindowView( createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
+	addMainWindowPane( createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
 }
 
 void BioXASSideAppController::createComponentsPane()

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -36,11 +36,11 @@ BioXASSideAppController::~BioXASSideAppController()
 
 void BioXASSideAppController::updateGeDetectorView()
 {
-	BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
-	QWidget *detectorView = componentViewMapping_.value(detector, 0);
-	QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
+    BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
+    QWidget *detectorView = componentViewMapping_.value(detector, 0);
+    QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
 
-	if (detector && detectorView && detectorPane) {
+    if (detector && detectorView && detectorPane) {
 		if (detector->isConnected())
 			mw_->showPane(detectorPane);
 		else
@@ -77,7 +77,7 @@ void BioXASSideAppController::createDetectorPanes()
 {
 	BioXASAppController::createDetectorPanes();
 
-	addMainWindowPane( createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
+	addMainWindowView( createComponentPane(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
 }
 
 void BioXASSideAppController::createComponentsPane()


### PR DESCRIPTION
I had to modify BioXASSideAppController::createDetectorPanes slightly so that the view for ge32ElementDetector was instantiated with addMainWindowPane function rather the the addMainWindowView function.

This seems to have resolved the tall view issue.

#2416 