### PR TITLE
Pull Request for Issue 2157: Export precision.

### DIFF
--- a/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
+++ b/source/acquaman/BioXAS/BioXASGenericStepScanController.cpp
@@ -163,6 +163,9 @@ void BioXASGenericStepScanController::buildScanControllerImplementation()
 						if (normalizedRegion) {
 							scan_->addAnalyzedDataSource(normalizedRegion, false, false);
 							genericExporterOption->addDataSource(normalizedRegion->name(), true);
+
+							genericExporterOption->setExportPrecision(normalizedRegion->name(), 19);
+							genericExporterOption->setExportPrecision(normalizationSource->name(), 19);
 						}
 					}
 				}
@@ -188,6 +191,9 @@ void BioXASGenericStepScanController::buildScanControllerImplementation()
 								if (normalizedRegion) {
 									scan_->addAnalyzedDataSource(normalizedRegion, true, false);
 									genericExporterOption->addDataSource(normalizedRegion->name(), true);
+
+									genericExporterOption->setExportPrecision(normalizedRegion->name(), 19);
+									genericExporterOption->setExportPrecision(normalizationSource->name(), 19);
 								}
 							}
 						}

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -362,6 +362,9 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 						if (normalizedRegion) {
 							scan_->addAnalyzedDataSource(normalizedRegion, false, false);
 							exportXDI->addDataSource(normalizedRegion->name(), true);
+
+							exportXDI->setExportPrecision(normalizedRegion->name(), 19);
+							exportXDI->setExportPrecision(normalizationSource->name(), 19);
 						}
 					}
 				}
@@ -387,6 +390,9 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 								if (normalizedRegion) {
 									scan_->addAnalyzedDataSource(normalizedRegion, newRegion->name().contains(edgeSymbol), !newRegion->name().contains(edgeSymbol));
 									exportXDI->addDataSource(normalizedRegion->name(), true);
+
+									exportXDI->setExportPrecision(normalizedRegion->name(), 19);
+									exportXDI->setExportPrecision(normalizationSource->name(), 19);
 								}
 							}
 						}

--- a/source/application/BioXAS/BioXAS.h
+++ b/source/application/BioXAS/BioXAS.h
@@ -51,6 +51,7 @@ namespace BioXAS
 		xasDefault->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
 		xasDefault->setElementSymbol(elementSymbol);
 		xasDefault->setElementEdge(elementEdge);
+		xasDefault->setExportPrecision(6);
 		xasDefault->storeToDb(AMDatabase::database("user"));
 
 		return xasDefault;

--- a/source/application/IDEAS/IDEAS.h
+++ b/source/application/IDEAS/IDEAS.h
@@ -67,6 +67,7 @@ namespace IDEAS
 		exporterOption->setSeparateHigherDimensionalSources(true);
 		exporterOption->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
 		exporterOption->setHigherDimensionsInRows(exportSpectraInRows);
+		exporterOption->setExportPrecision(6);
 		exporterOption->storeToDb(AMDatabase::database("user"));
 
 		return exporterOption;

--- a/source/application/IDEAS/IDEAS.h
+++ b/source/application/IDEAS/IDEAS.h
@@ -104,6 +104,7 @@ namespace IDEAS
 		exporterOption->setSeparateHigherDimensionalSources(true);
 		exporterOption->setSeparateSectionFileName("$name_$dataSetName_$fsIndex.dat");
 		exporterOption->setHigherDimensionsInRows(exportSpectraInRows);
+		exporterOption->setExportPrecision(6);
 		exporterOption->setRegExpString("^\\w{1,2}Ka1|^\\w{1,2}Kb1|^\\w{1,2}La1|^\\w{1,2}Lb1|^\\w{1,2}Lg1|I_0");
 		exporterOption->storeToDb(AMDatabase::database("user"));
 

--- a/source/application/REIXS/REIXS.h
+++ b/source/application/REIXS/REIXS.h
@@ -34,6 +34,7 @@ namespace REIXS {
 		exporterOption->setSeparateHigherDimensionalSources(true);
 		exporterOption->setSeparateSectionFileName("$name_$dataSetName_$number.dat");
 		exporterOption->setHigherDimensionsInRows(true);
+		exporterOption->setExportPrecision(6);
 		exporterOption->storeToDb(AMDatabase::database("user"));
 
 		return exporterOption;

--- a/source/application/SXRMB/SXRMB.h
+++ b/source/application/SXRMB/SXRMB.h
@@ -106,6 +106,7 @@ namespace SXRMB {
 		sxrmbExporterOption->setSeparateHigherDimensionalSources(true);
 		sxrmbExporterOption->setSeparateSectionFileName("$name_$dataSetName_$fsIndex.dat");
 		sxrmbExporterOption->setHigherDimensionsInRows(exportSpectraInRows);
+		sxrmbExporterOption->setExportPrecision(6);
 		sxrmbExporterOption->storeToDb(AMDatabase::database("user"));
 
 		return sxrmbExporterOption;

--- a/source/application/VESPERS/VESPERS.h
+++ b/source/application/VESPERS/VESPERS.h
@@ -155,6 +155,7 @@ namespace VESPERS {
 		vespersDefault->setSeparateHigherDimensionalSources(true);
 		vespersDefault->setSeparateSectionFileName("$name_$dataSetName_$fsIndex.dat");
 		vespersDefault->setHigherDimensionsInRows(exportSpectraInRows);
+		vespersDefault->setExportPrecision(6);
 		vespersDefault->storeToDb(AMDatabase::database("user"));
 
 		return vespersDefault;
@@ -190,6 +191,7 @@ namespace VESPERS {
 		vespersDefault->setSeparateHigherDimensionalSources(true);
 		vespersDefault->setSeparateSectionFileName("$name_$dataSetName_$fsIndex.dat");
 		vespersDefault->setHigherDimensionsInRows(exportSpectraInRows);
+		vespersDefault->setExportPrecision(6);
 		vespersDefault->setRegExpString("^\\w{1,2}Ka1|^\\w{1,2}Kb1|^\\w{1,2}La1|^\\w{1,2}Lb1|^\\w{1,2}Lg1|SplitIonChamber|PreKBIonChamber|MiniIonChamber");
 		vespersDefault->storeToDb(AMDatabase::database("user"));
 

--- a/source/dataman/AMNumber.cpp
+++ b/source/dataman/AMNumber.cpp
@@ -68,8 +68,6 @@ AMNumber& AMNumber::operator=(int fromInt) {
 	return *this;
 }
 
-#include <QDebug>
-
 QString AMNumber::toString(QChar format, int precision) {
 	if(!isValid())
 		return "[X]";
@@ -81,8 +79,6 @@ QString AMNumber::toString(QChar format, int precision) {
 
 QString AMNumber::toString(int precision)
 {
-	qWarning(QString("Precision specified is :::::").toLocal8Bit());
-	qWarning(QString("%1").arg(precision).toLocal8Bit());
 	QChar format = 'g';
 	return AMNumber::toString(format, precision);
 }

--- a/source/dataman/AMNumber.cpp
+++ b/source/dataman/AMNumber.cpp
@@ -77,8 +77,7 @@ QString AMNumber::toString(QChar format, int precision) {
 		return QString("%1").arg(value_.d, 0, format.toAscii(), precision);
 }
 
-QString AMNumber::toString(int precision)
-{
+const QString AMNumber::toString(int precision) {
 	QChar format = 'g';
 	return AMNumber::toString(format, precision);
 }

--- a/source/dataman/AMNumber.cpp
+++ b/source/dataman/AMNumber.cpp
@@ -68,7 +68,7 @@ AMNumber& AMNumber::operator=(int fromInt) {
 	return *this;
 }
 
-QString AMNumber::toString(QChar format, int precision) {
+QString AMNumber::toString(QChar format, int precision) const {
 	if(!isValid())
 		return "[X]";
 	if(type_ == Integer)
@@ -77,7 +77,7 @@ QString AMNumber::toString(QChar format, int precision) {
 		return QString("%1").arg(value_.d, 0, format.toAscii(), precision);
 }
 
-const QString AMNumber::toString(int precision) {
+QString AMNumber::toString(int precision) const {
 	QChar format = 'g';
 	return AMNumber::toString(format, precision);
 }

--- a/source/dataman/AMNumber.cpp
+++ b/source/dataman/AMNumber.cpp
@@ -76,3 +76,13 @@ QString AMNumber::toString(QChar format, int precision) {
 	else
 		return QString("%1").arg(value_.d, 0, format.toAscii(), precision);
 }
+
+QString AMNumber::toString(int precision)
+{
+	// This may be removed once toString usage is standardized across all exporters.
+	if(precision <= 0)
+		precision = 19;
+
+	QChar format = 'g';
+	return AMNumber::toString(format, precision);
+}

--- a/source/dataman/AMNumber.cpp
+++ b/source/dataman/AMNumber.cpp
@@ -68,6 +68,8 @@ AMNumber& AMNumber::operator=(int fromInt) {
 	return *this;
 }
 
+#include <QDebug>
+
 QString AMNumber::toString(QChar format, int precision) {
 	if(!isValid())
 		return "[X]";
@@ -79,10 +81,8 @@ QString AMNumber::toString(QChar format, int precision) {
 
 QString AMNumber::toString(int precision)
 {
-	// This may be removed once toString usage is standardized across all exporters.
-	if(precision <= 0)
-		precision = 19;
-
+	qWarning(QString("Precision specified is :::::").toLocal8Bit());
+	qWarning(QString("%1").arg(precision).toLocal8Bit());
 	QChar format = 'g';
 	return AMNumber::toString(format, precision);
 }

--- a/source/dataman/AMNumber.h
+++ b/source/dataman/AMNumber.h
@@ -128,6 +128,7 @@ public:
 	/// Print as a string
 	QString toString(QChar format = 'g', int precision = 19);
 
+	QString toString(int precision);
 
 protected:
 	State state_;

--- a/source/dataman/AMNumber.h
+++ b/source/dataman/AMNumber.h
@@ -128,7 +128,7 @@ public:
 	/// Print as a string
 	QString toString(QChar format = 'g', int precision = 19);
 
-	QString toString(int precision);
+	const QString toString(int precision);
 
 protected:
 	State state_;

--- a/source/dataman/AMNumber.h
+++ b/source/dataman/AMNumber.h
@@ -126,9 +126,9 @@ public:
 	}
 
 	/// Print as a string
-	QString toString(QChar format = 'g', int precision = 19);
+	QString toString(QChar format = 'g', int precision = 19) const;
 
-	const QString toString(int precision);
+	QString toString(int precision) const;
 
 protected:
 	State state_;

--- a/source/dataman/export/AMExporter2DAscii.cpp
+++ b/source/dataman/export/AMExporter2DAscii.cpp
@@ -180,17 +180,17 @@ void AMExporter2DAscii::writeMainTable()
 			for(int c=0; c<mainTableDataSources_.count(); c++) {
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
-
+				int precision = option_->exportPrecision(ds->name());
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0, x).toString();
+					ts << ds->axisValue(0, x).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, y).toString();
+					ts << ds->axisValue(1, y).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
-				ts << ds->value(AMnDIndex(x, y)).toString();
+				ts << ds->value(AMnDIndex(x, y)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}
@@ -207,17 +207,18 @@ void AMExporter2DAscii::writeMainTable()
 			for(int c=0; c<mainTableDataSources_.count(); c++) {
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,i).toString();
+					ts << ds->axisValue(0,i).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, yRange_-1).toString();
+					ts << ds->axisValue(1, yRange_-1).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
-				ts << ds->value(AMnDIndex(i, yRange_-1)).toString();
+				ts << ds->value(AMnDIndex(i, yRange_-1)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}

--- a/source/dataman/export/AMExporterAthena.cpp
+++ b/source/dataman/export/AMExporterAthena.cpp
@@ -133,7 +133,7 @@ void AMExporterAthena::writeMainTable()
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					setCurrentColumnIndex(cc);
-					ts << columnText << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+					ts << columnText << "[" << ds->axisValue(1, cc).toString(option_->exportPrecision(ds->name())) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 				}
 			}
 		}
@@ -148,27 +148,28 @@ void AMExporterAthena::writeMainTable()
 		for(int c=0; c<mainTableDataSources_.count(); c++) {
 			setCurrentDataSource(mainTableDataSources_.at(c));
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			bool doPrint = (ds->size(0) > r);
 
 			// print x column?
 			if(mainTableIncludeX_.at(c)) {
 				if(doPrint)
-					ts << ds->axisValue(0,r).toString();
+					ts << ds->axisValue(0,r).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 
 			// 1D data sources:
 			if(ds->rank() == 1) {
 				if(doPrint)
-					ts << ds->value(r).toString();
+					ts << ds->value(r).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 			else if(ds->rank() == 2) {
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					if(doPrint)
-						ts << ds->value(AMnDIndex(r,cc)).toString();
+						ts << ds->value(AMnDIndex(r,cc)).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 			}

--- a/source/dataman/export/AMExporterGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterGeneralAscii.cpp
@@ -443,7 +443,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 					int maxTableColumns = ds->size(0);
 
 					for(int column = 0; column < maxTableColumns; column++)
-						ts << ds->axisValue(0,column).toString() << option_->columnDelimiter();
+						ts << ds->axisValue(0,column).toString(precision) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 
@@ -683,7 +683,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 				for (int cc = 0; cc < ds->size(1); cc++){
 
 					if (option_->columnHeaderIncluded())
-						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString(precision) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 
 					int maxTableColumns = ds->size(0);
 

--- a/source/dataman/export/AMExporterGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterGeneralAscii.cpp
@@ -346,6 +346,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 
 			setCurrentDataSource(separateSectionDataSources_.at(s));	// sets currentDataSourceIndex_
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			// section header?
 			if(option_->sectionHeaderIncluded()) {
@@ -370,7 +371,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 					// need a loop over the second axis columns
 					for(int cc=0; cc<ds->size(1); cc++) {
 						setCurrentColumnIndex(cc);
-						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString(precision) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 					}
 				}
 				ts << option_->newlineDelimiter() << option_->columnHeaderDelimiter() << option_->newlineDelimiter();
@@ -379,13 +380,13 @@ void AMExporterGeneralAscii::writeSeparateSections()
 			// table
 			switch(ds->rank()) {
 			case 0:
-				ts << ds->value(AMnDIndex()).toString() << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(precision) << option_->columnDelimiter() << option_->newlineDelimiter();
 				break;
 			case 1: {
 				int maxTableRows = ds->size(0);
 				for(int r=0; r<maxTableRows; r++) {
 					if(separateSectionIncludeX_.at(s)) {
-						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
+						ts << ds->axisValue(0,r).toString(precision) << option_->columnDelimiter();
 					}
 					ts << ds->value(r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
 				}
@@ -395,10 +396,10 @@ void AMExporterGeneralAscii::writeSeparateSections()
 				int maxTableRows = ds->size(0);
 				for(int r=0; r<maxTableRows; r++) {
 					if(separateSectionIncludeX_.at(s))
-						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
+						ts << ds->axisValue(0,r).toString(precision) << option_->columnDelimiter();
 					// need a loop over the second axis columns
 					for(int cc=0; cc<ds->size(1); cc++) {
-						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(r,cc)).toString(precision) << option_->columnDelimiter();
 					}
 					ts << option_->newlineDelimiter();
 				}
@@ -418,6 +419,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 
 			setCurrentDataSource(separateSectionDataSources_.at(s));	// sets currentDataSourceIndex_
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			// section header?
 			if(option_->sectionHeaderIncluded()) {
@@ -462,7 +464,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 				if(option_->columnHeaderIncluded())
 					ts << parseKeywordString(option_->columnHeader()) << option_->columnDelimiter();
 
-				ts << ds->value(AMnDIndex()).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(precision) << option_->columnDelimiter() << option_->newlineDelimiter();
 
 				break;
 			}
@@ -475,7 +477,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 				int maxTableColumns = ds->size(0);
 
 				for(int column = 0; column < maxTableColumns; column++)
-					ts << ds->value(column).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+					ts << ds->value(column).toString(precision) << option_->columnDelimiter();
 
 				ts << option_->newlineDelimiter();
 
@@ -487,12 +489,12 @@ void AMExporterGeneralAscii::writeSeparateSections()
 				for (int cc = 0; cc < ds->size(1); cc++){
 
 					if (option_->columnHeaderIncluded())
-						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString(precision) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 
 					int maxTableColumns = ds->size(0);
 
 					for (int column = 0; column < maxTableColumns; column++)
-						ts << ds->value(AMnDIndex(column, cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(column, cc)).toString(precision) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 				}
@@ -516,6 +518,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 
 			setCurrentDataSource(separateFileDataSources_.at(s));	// sets currentDataSourceIndex_
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			QFile file;
 			QString separateFileName = parseKeywordString( destinationFolderPath % "/" % option_->separateSectionFileName() );
@@ -551,7 +554,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 					// need a loop over the second axis columns
 					for(int cc=0; cc<ds->size(1); cc++) {
 						setCurrentColumnIndex(cc);
-						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+						ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString(precision) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 					}
 				}
 				ts << option_->newlineDelimiter() << option_->columnHeaderDelimiter() << option_->newlineDelimiter();
@@ -560,15 +563,15 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 			// table
 			switch(ds->rank()) {
 			case 0:
-				ts << ds->value(AMnDIndex()).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(precision) << option_->columnDelimiter() << option_->newlineDelimiter();
 				break;
 			case 1: {
 				int maxTableRows = ds->size(0);
 				for(int r=0; r<maxTableRows; r++) {
 					if(separateFileIncludeX_.at(s)) {
-						ts << ds->axisValue(0,r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+						ts << ds->axisValue(0,r).toString(precision) << option_->columnDelimiter();
 					}
-					ts << ds->value(r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
+					ts << ds->value(r).toString(precision) << option_->columnDelimiter() << option_->newlineDelimiter();
 				}
 			}
 				break;
@@ -576,10 +579,10 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 				int maxTableRows = ds->size(0);
 				for(int r=0; r<maxTableRows; r++) {
 					if(separateFileIncludeX_.at(s))
-						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
+						ts << ds->axisValue(0,r).toString(precision) << option_->columnDelimiter();
 					// need a loop over the second axis columns
 					for(int cc=0; cc<ds->size(1); cc++) {
-						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(r,cc)).toString(precision) << option_->columnDelimiter();
 					}
 					ts << option_->newlineDelimiter();
 				}
@@ -599,6 +602,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 
 			setCurrentDataSource(separateFileDataSources_.at(s));	// sets currentDataSourceIndex_
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			QFile file;
 			QString separateFileName = parseKeywordString( destinationFolderPath % "/" % option_->separateSectionFileName() );
@@ -633,7 +637,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 					int maxTableColumns = ds->size(0);
 
 					for(int column = 0; column < maxTableColumns; column++)
-						ts << ds->axisValue(0,column).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+						ts << ds->axisValue(0,column).toString(precision) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 
@@ -654,7 +658,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 				if(option_->columnHeaderIncluded())
 					ts << parseKeywordString(option_->columnHeader()) << option_->columnDelimiter();
 
-				ts << ds->value(AMnDIndex()).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(precision) << option_->columnDelimiter() << option_->newlineDelimiter();
 
 				break;
 			}
@@ -667,7 +671,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 				int maxTableColumns = ds->size(0);
 
 				for(int column = 0; column < maxTableColumns; column++)
-					ts << ds->value(column).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+					ts << ds->value(column).toString(precision) << option_->columnDelimiter();
 
 				ts << option_->newlineDelimiter();
 
@@ -684,7 +688,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 					int maxTableColumns = ds->size(0);
 
 					for (int column = 0; column < maxTableColumns; column++)
-						ts << ds->value(AMnDIndex(column, cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(column, cc)).toString(precision) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 				}

--- a/source/dataman/export/AMExporterGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterGeneralAscii.cpp
@@ -304,27 +304,28 @@ void AMExporterGeneralAscii::writeMainTable()
 		for(int c=0; c<mainTableDataSources_.count(); c++) {
 			setCurrentDataSource(mainTableDataSources_.at(c));
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			bool doPrint = (ds->size(0) > r);
 
 			// print x column?
 			if(mainTableIncludeX_.at(c)) {
 				if(doPrint)
-					ts << ds->axisValue(0,r).toString();
+					ts << ds->axisValue(0,r).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 
 			// 1D data sources:
 			if(ds->rank() == 1) {
 				if(doPrint)
-					ts << ds->value(r).toString(option_->exportPrecision(ds->name()));
+					ts << ds->value(r).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 			else if(ds->rank() == 2) {
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					if(doPrint)
-						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name()));
+						ts << ds->value(AMnDIndex(r,cc)).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 			}

--- a/source/dataman/export/AMExporterGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterGeneralAscii.cpp
@@ -388,7 +388,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 					if(separateSectionIncludeX_.at(s)) {
 						ts << ds->axisValue(0,r).toString(precision) << option_->columnDelimiter();
 					}
-					ts << ds->value(r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
+					ts << ds->value(r).toString(precision) << option_->columnDelimiter() << option_->newlineDelimiter();
 				}
 			}
 				break;

--- a/source/dataman/export/AMExporterGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterGeneralAscii.cpp
@@ -272,6 +272,7 @@ void AMExporterGeneralAscii::writeMainTable()
 		for(int c=0; c<mainTableDataSources_.count(); c++) {
 			setCurrentDataSource(mainTableDataSources_.at(c));
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			if(ds->size(0) > maxTableRows)
 				maxTableRows = ds->size(0); // convenient... lets figure this out while we're looping through anyway
@@ -288,7 +289,7 @@ void AMExporterGeneralAscii::writeMainTable()
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					setCurrentColumnIndex(cc);
-					ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+					ts << parseKeywordString(option_->columnHeader()) << "[" << ds->axisValue(1, cc).toString(precision) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 				}
 			}
 		}
@@ -316,14 +317,14 @@ void AMExporterGeneralAscii::writeMainTable()
 			// 1D data sources:
 			if(ds->rank() == 1) {
 				if(doPrint)
-					ts << ds->value(r).toString();
+					ts << ds->value(r).toString(option_->exportPrecision(ds->name()));
 				ts << option_->columnDelimiter();
 			}
 			else if(ds->rank() == 2) {
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					if(doPrint)
-						ts << ds->value(AMnDIndex(r,cc)).toString();
+						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name()));
 					ts << option_->columnDelimiter();
 				}
 			}
@@ -385,7 +386,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 					if(separateSectionIncludeX_.at(s)) {
 						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
 					}
-					ts << ds->value(r).toString() << option_->columnDelimiter() << option_->newlineDelimiter();
+					ts << ds->value(r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
 				}
 			}
 				break;
@@ -396,7 +397,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
 					// need a loop over the second axis columns
 					for(int cc=0; cc<ds->size(1); cc++) {
-						ts << ds->value(AMnDIndex(r,cc)).toString() << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 					}
 					ts << option_->newlineDelimiter();
 				}
@@ -460,7 +461,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 				if(option_->columnHeaderIncluded())
 					ts << parseKeywordString(option_->columnHeader()) << option_->columnDelimiter();
 
-				ts << ds->value(AMnDIndex()).toString() << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
 
 				break;
 			}
@@ -473,7 +474,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 				int maxTableColumns = ds->size(0);
 
 				for(int column = 0; column < maxTableColumns; column++)
-					ts << ds->value(column).toString() << option_->columnDelimiter();
+					ts << ds->value(column).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 
 				ts << option_->newlineDelimiter();
 
@@ -490,7 +491,7 @@ void AMExporterGeneralAscii::writeSeparateSections()
 					int maxTableColumns = ds->size(0);
 
 					for (int column = 0; column < maxTableColumns; column++)
-						ts << ds->value(AMnDIndex(column, cc)).toString() << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(column, cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 				}
@@ -558,15 +559,15 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 			// table
 			switch(ds->rank()) {
 			case 0:
-				ts << ds->value(AMnDIndex()).toString() << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
 				break;
 			case 1: {
 				int maxTableRows = ds->size(0);
 				for(int r=0; r<maxTableRows; r++) {
 					if(separateFileIncludeX_.at(s)) {
-						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
+						ts << ds->axisValue(0,r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 					}
-					ts << ds->value(r).toString() << option_->columnDelimiter() << option_->newlineDelimiter();
+					ts << ds->value(r).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
 				}
 			}
 				break;
@@ -577,7 +578,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 						ts << ds->axisValue(0,r).toString() << option_->columnDelimiter();
 					// need a loop over the second axis columns
 					for(int cc=0; cc<ds->size(1); cc++) {
-						ts << ds->value(AMnDIndex(r,cc)).toString() << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 					}
 					ts << option_->newlineDelimiter();
 				}
@@ -631,7 +632,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 					int maxTableColumns = ds->size(0);
 
 					for(int column = 0; column < maxTableColumns; column++)
-						ts << ds->axisValue(0,column).toString() << option_->columnDelimiter();
+						ts << ds->axisValue(0,column).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 
@@ -652,7 +653,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 				if(option_->columnHeaderIncluded())
 					ts << parseKeywordString(option_->columnHeader()) << option_->columnDelimiter();
 
-				ts << ds->value(AMnDIndex()).toString() << option_->columnDelimiter() << option_->newlineDelimiter();
+				ts << ds->value(AMnDIndex()).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter() << option_->newlineDelimiter();
 
 				break;
 			}
@@ -665,7 +666,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 				int maxTableColumns = ds->size(0);
 
 				for(int column = 0; column < maxTableColumns; column++)
-					ts << ds->value(column).toString() << option_->columnDelimiter();
+					ts << ds->value(column).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 
 				ts << option_->newlineDelimiter();
 
@@ -682,7 +683,7 @@ bool AMExporterGeneralAscii::writeSeparateFiles(const QString& destinationFolder
 					int maxTableColumns = ds->size(0);
 
 					for (int column = 0; column < maxTableColumns; column++)
-						ts << ds->value(AMnDIndex(column, cc)).toString() << option_->columnDelimiter();
+						ts << ds->value(AMnDIndex(column, cc)).toString(option_->exportPrecision(ds->name())) << option_->columnDelimiter();
 
 					ts << option_->newlineDelimiter();
 				}

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -71,6 +71,15 @@ bool AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, con
 		return false;
 }
 
+bool AMExporterOptionGeneralAscii::setExportPrecision(const int &precision)
+{
+	if(precision >= 1){
+		defaultExportPrecision_ = precision;
+		return true;
+	}
+	return false;
+}
+
 const QMetaObject* AMExporterOptionGeneralAscii::getMetaObject(){
 	return metaObject();
 }

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -108,12 +108,12 @@ void AMExporterOptionGeneralAscii::readPrecisionMap(const QString &stringMap)
 	}
 }
 
-const QString AMExporterOptionGeneralAscii::mapToString()
+QString AMExporterOptionGeneralAscii::mapToString() const
 {
-	QMap<QString, int>::iterator i;
+	QMap<QString, int>::ConstIterator i;
 	QString map = "";
 
-	for(i = sourceExportPrecision_.begin(); i != sourceExportPrecision_.end(); ++i)
+	for(i = sourceExportPrecision_.constBegin(); i != sourceExportPrecision_.constEnd(); ++i)
 		map = i.key() + " " + QString("%1").arg(i.value()) + "\n";
 
 	return map;

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -68,6 +68,7 @@ void AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, int
 {
 	if(!source.isEmpty() && precision >= 1) {
 		sourceExportPrecision_.insert(source, precision);
+		setModified(true);
 	}
 }
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -30,7 +30,7 @@ AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(QObject *parent) :
 {
 	columnDelimiter_ = "\t";
 	newlineDelimiter_ = "\r\n";
-
+	defaultExportPrecision_ = 19;
 	setModified(false);
 }
 
@@ -47,6 +47,30 @@ AMExporterOption *AMExporterOptionGeneralAscii::createCopy() const
 	option->dissociateFromDb(true);
 	return option;
 }
+
+int AMExporterOptionGeneralAscii::exportPrecision() const
+{
+	return defaultExportPrecision_;
+}
+
+int AMExporterOptionGeneralAscii::exportPrecision(const QString &source) const
+{
+	if(sourceExportPrecision_.contains(source))
+		return sourceExportPrecision_.value(source);
+	else
+		return defaultExportPrecision_;
+}
+
+bool AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, const int &precision)
+{
+	if(!source.isEmpty() && precision >= 1) {
+		sourceExportPrecision_.insert(source, precision);
+		return true;
+	}
+	else
+		return false;
+}
+
 const QMetaObject* AMExporterOptionGeneralAscii::getMetaObject(){
 	return metaObject();
 }

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -22,7 +22,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "AMExporterOptionGeneralAscii.h"
 #include <QPushButton>
 #include "ui/dataman/AMExporterOptionGeneralAsciiView.h"
-
+#include <QDebug>
 AMExporterOptionGeneralAscii::~AMExporterOptionGeneralAscii(){}
 
 AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(QObject *parent) :
@@ -30,7 +30,7 @@ AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(QObject *parent) :
 {
 	columnDelimiter_ = "\t";
 	newlineDelimiter_ = "\r\n";
-	defaultExportPrecision_ = 19;
+	exportPrecision_ = 0;
 	setModified(false);
 }
 
@@ -39,6 +39,8 @@ AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(const AMExporterOptio
 {
 	columnDelimiter_ = original.columnDelimiter();
 	newlineDelimiter_ = original.newlineDelimiter();
+	sourceExportPrecision_ = original.precisionMap();
+	exportPrecision_ = original.exportPrecision();
 }
 
 AMExporterOption *AMExporterOptionGeneralAscii::createCopy() const
@@ -50,18 +52,20 @@ AMExporterOption *AMExporterOptionGeneralAscii::createCopy() const
 
 int AMExporterOptionGeneralAscii::exportPrecision() const
 {
-	return defaultExportPrecision_;
+	return exportPrecision_;
 }
 
 int AMExporterOptionGeneralAscii::exportPrecision(const QString &source) const
 {
-	if(sourceExportPrecision_.contains(source))
+	if(sourceExportPrecision_.contains(source)){
 		return sourceExportPrecision_.value(source);
+	}
 	else
-		return defaultExportPrecision_;
+		qWarning("!!!Precision REQUESTED AND IS :: " + QString("%1").arg(exportPrecision_).toLocal8Bit());
+		return exportPrecision_;
 }
 
-bool AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, const int &precision)
+bool AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, int precision)
 {
 	if(!source.isEmpty() && precision >= 1) {
 		sourceExportPrecision_.insert(source, precision);
@@ -71,10 +75,13 @@ bool AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, con
 		return false;
 }
 
-bool AMExporterOptionGeneralAscii::setExportPrecision(const int &precision)
+bool AMExporterOptionGeneralAscii::setExportPrecision(int precision)
 {
 	if(precision >= 1){
-		defaultExportPrecision_ = precision;
+		qWarning("!!!Precision IS :: " + QString("%1").arg(exportPrecision_).toLocal8Bit());
+		exportPrecision_ = precision;
+		qWarning("!!!Precision has been set to :: " + QString("%1").arg(exportPrecision_).toLocal8Bit());
+		setModified(true);
 		return true;
 	}
 	return false;

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -31,6 +31,7 @@ AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(QObject *parent) :
 	columnDelimiter_ = "\t";
 	newlineDelimiter_ = "\r\n";
 	exportPrecision_ = 0;
+//	testPrecisionMapDbFunctions();
 	setModified(false);
 }
 
@@ -86,7 +87,7 @@ QString AMExporterOptionGeneralAscii::loadPrecisionMap()
 	QMap<QString, int>::iterator i;
 
 	for (i = sourceExportPrecision_.begin(); i != sourceExportPrecision_.end(); ++i)
-		pm << i.key() << ":" << QString("%1").arg(i.value());
+		pm << i.key() << QString("%1").arg(i.value());
 
 	return pm.join(":");
 
@@ -105,6 +106,36 @@ void AMExporterOptionGeneralAscii::readPrecisionMap(const QString &stringMap)
 	for(int i = 0; i < precisionMap.size(); i = i + 2){
 		sourceExportPrecision_.insert(precisionMap.at(i), precisionMap.at(i+1).toInt());
 	}
+}
+
+#include <QDebug>
+void AMExporterOptionGeneralAscii::testPrecisionMapDbFunctions(){
+	setExportPrecision("Name_1", 1);
+	setExportPrecision("Name_2", 2);
+	setExportPrecision("Name_3", 3);
+	setExportPrecision("Name_4", 4);
+	setExportPrecision("Name_5", 5);
+	setExportPrecision("Name_1_2", 2);
+	setExportPrecision("Name_2_2", 3);
+
+	mapToString();
+
+	QString test =  loadPrecisionMap();
+	qDebug() << test;
+
+	sourceExportPrecision_.clear();
+
+	readPrecisionMap(test);
+
+	qDebug() << test;
+}
+
+void AMExporterOptionGeneralAscii::mapToString()
+{
+	QMap<QString, int>::iterator i;
+
+	for(i = sourceExportPrecision_.begin(); i != sourceExportPrecision_.end(); ++i)
+		qDebug() << i.key() << " " << QString("%1").arg(i.value()) << "\n";
 }
 
 const QMetaObject* AMExporterOptionGeneralAscii::getMetaObject(){

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -82,14 +82,14 @@ void AMExporterOptionGeneralAscii::setExportPrecision(int precision)
 
 QString AMExporterOptionGeneralAscii::loadPrecisionMap()
 {
-	QStringList pm;
+	QStringList precisionMapConversion;
 
 	QMap<QString, int>::iterator i;
 
 	for (i = sourceExportPrecision_.begin(); i != sourceExportPrecision_.end(); ++i)
-		pm << i.key() << QString("%1").arg(i.value());
+		precisionMapConversion << i.key() << QString("%1").arg(i.value());
 
-	return pm.join(":");
+	return precisionMapConversion.join(":");
 
 }
 
@@ -108,7 +108,7 @@ void AMExporterOptionGeneralAscii::readPrecisionMap(const QString &stringMap)
 	}
 }
 
-QString AMExporterOptionGeneralAscii::mapToString()
+const QString AMExporterOptionGeneralAscii::mapToString()
 {
 	QMap<QString, int>::iterator i;
 	QString map = "";

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -31,7 +31,6 @@ AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(QObject *parent) :
 	columnDelimiter_ = "\t";
 	newlineDelimiter_ = "\r\n";
 	exportPrecision_ = 0;
-//	testPrecisionMapDbFunctions();
 	setModified(false);
 }
 
@@ -108,34 +107,15 @@ void AMExporterOptionGeneralAscii::readPrecisionMap(const QString &stringMap)
 	}
 }
 
-#include <QDebug>
-void AMExporterOptionGeneralAscii::testPrecisionMapDbFunctions(){
-	setExportPrecision("Name_1", 1);
-	setExportPrecision("Name_2", 2);
-	setExportPrecision("Name_3", 3);
-	setExportPrecision("Name_4", 4);
-	setExportPrecision("Name_5", 5);
-	setExportPrecision("Name_1_2", 2);
-	setExportPrecision("Name_2_2", 3);
-
-	mapToString();
-
-	QString test =  loadPrecisionMap();
-	qDebug() << test;
-
-	sourceExportPrecision_.clear();
-
-	readPrecisionMap(test);
-
-	qDebug() << test;
-}
-
-void AMExporterOptionGeneralAscii::mapToString()
+QString AMExporterOptionGeneralAscii::mapToString()
 {
 	QMap<QString, int>::iterator i;
+	QString map = "";
 
 	for(i = sourceExportPrecision_.begin(); i != sourceExportPrecision_.end(); ++i)
-		qDebug() << i.key() << " " << QString("%1").arg(i.value()) << "\n";
+		map = i.key() + " " + QString("%1").arg(i.value()) + "\n";
+
+	return map;
 }
 
 const QMetaObject* AMExporterOptionGeneralAscii::getMetaObject(){

--- a/source/dataman/export/AMExporterOptionGeneralAscii.cpp
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.cpp
@@ -22,7 +22,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "AMExporterOptionGeneralAscii.h"
 #include <QPushButton>
 #include "ui/dataman/AMExporterOptionGeneralAsciiView.h"
-#include <QDebug>
+
 AMExporterOptionGeneralAscii::~AMExporterOptionGeneralAscii(){}
 
 AMExporterOptionGeneralAscii::AMExporterOptionGeneralAscii(QObject *parent) :
@@ -61,30 +61,50 @@ int AMExporterOptionGeneralAscii::exportPrecision(const QString &source) const
 		return sourceExportPrecision_.value(source);
 	}
 	else
-		qWarning("!!!Precision REQUESTED AND IS :: " + QString("%1").arg(exportPrecision_).toLocal8Bit());
 		return exportPrecision_;
 }
 
-bool AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, int precision)
+void AMExporterOptionGeneralAscii::setExportPrecision(const QString &source, int precision)
 {
 	if(!source.isEmpty() && precision >= 1) {
 		sourceExportPrecision_.insert(source, precision);
-		return true;
 	}
-	else
-		return false;
 }
 
-bool AMExporterOptionGeneralAscii::setExportPrecision(int precision)
+void AMExporterOptionGeneralAscii::setExportPrecision(int precision)
 {
 	if(precision >= 1){
-		qWarning("!!!Precision IS :: " + QString("%1").arg(exportPrecision_).toLocal8Bit());
 		exportPrecision_ = precision;
-		qWarning("!!!Precision has been set to :: " + QString("%1").arg(exportPrecision_).toLocal8Bit());
 		setModified(true);
-		return true;
 	}
-	return false;
+}
+
+QString AMExporterOptionGeneralAscii::loadPrecisionMap()
+{
+	QStringList pm;
+
+	QMap<QString, int>::iterator i;
+
+	for (i = sourceExportPrecision_.begin(); i != sourceExportPrecision_.end(); ++i)
+		pm << i.key() << ":" << QString("%1").arg(i.value());
+
+	return pm.join(":");
+
+}
+
+void AMExporterOptionGeneralAscii::readPrecisionMap(const QString &stringMap)
+{
+	QStringList precisionMap = stringMap.split(":", QString::SkipEmptyParts);
+
+	if(precisionMap.size() % 2 != 0){
+		return;
+	}
+
+	sourceExportPrecision_.clear();
+
+	for(int i = 0; i < precisionMap.size(); i = i + 2){
+		sourceExportPrecision_.insert(precisionMap.at(i), precisionMap.at(i+1).toInt());
+	}
 }
 
 const QMetaObject* AMExporterOptionGeneralAscii::getMetaObject(){

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -48,7 +48,12 @@ public:
 	/// The delimiter to use between lines (newline character)
 	QString newlineDelimiter() const { return newlineDelimiter_; }
 
-
+	/// Returns the default precision if no source is specified.
+	int exportPrecision() const;
+	/// Returns the associated precision with the source name.
+	int exportPrecision(const QString& source) const;
+	/// Sets a precision for a source name. Duplicate naming is not allowed.
+	bool setExportPrecision(const QString& source, const int& precision);
 
 	virtual QWidget* createEditorWidget();
 
@@ -66,6 +71,10 @@ protected:
 	QString columnDelimiter_;
 	/// The delimiter to use between lines (newline character)
 	QString newlineDelimiter_;
+	/// A mapping of datasource names to the precision their data should be exported at.
+	QMap<QString, int> sourceExportPrecision_;
+	/// A default precision if a source is not given one specifically.
+	int defaultExportPrecision_ ;
 
 };
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -54,6 +54,8 @@ public:
 	int exportPrecision(const QString& source) const;
 	/// Sets a precision for a source name. Duplicate naming is not allowed.
 	bool setExportPrecision(const QString& source, const int& precision);
+	/// Sets the default precision with no AMDataSource name specified.
+	bool setExportPrecision(const int& precision);
 
 	virtual QWidget* createEditorWidget();
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -31,8 +31,9 @@ class AMExporterOptionGeneralAscii : public AMExporterOptionGeneral
 	Q_PROPERTY(QString columnDelimiter READ columnDelimiter WRITE setColumnDelimiter)
 	Q_PROPERTY(QString newlineDelimiter READ newlineDelimiter WRITE setNewlineDelimiter)
 	Q_PROPERTY(int exportPrecision READ exportPrecision WRITE setExportPrecision)
+	Q_PROPERTY(QString precisionMap READ loadPrecisionMap WRITE readPrecisionMap)
 
-	Q_CLASSINFO("exportPrecision", "upgradeDefault=8")
+	Q_CLASSINFO("exportPrecision", "upgradeDefault=6")
 
 public:
 	/// Constructor.
@@ -58,9 +59,13 @@ public:
 	/// Returns the associated precision with the source name.
 	int exportPrecision(const QString& source) const;
 	/// Sets a precision for a source name. Duplicate naming is not allowed.
-	bool setExportPrecision(const QString& source, const int precision);
+	void setExportPrecision(const QString& source, const int precision);
 	/// Sets the default precision with no AMDataSource name specified.
-	bool setExportPrecision(const int precision);
+	void setExportPrecision(const int precision);
+
+	QString loadPrecisionMap();
+
+	void readPrecisionMap(const QString& stringMap);
 
 	virtual QWidget* createEditorWidget();
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -60,16 +60,12 @@ public:
 	/// Sets a precision for a source name. Duplicate naming is not allowed.
 	void setExportPrecision(const QString& source, const int precision);
 	/// Sets the default precision with no AMDataSource name specified.
-	void setExportPrecision(const int precision);
-	/// Loads the precision map into the database in the form of a string.
-	QString loadPrecisionMap();
-	/// Parses a precision map string from the database and recreates the map.
-	void readPrecisionMap(const QString& stringMap);
+	void setExportPrecision(int precision);
 
 	virtual QWidget* createEditorWidget();
 
 	/// Output the current map in exportPrecision_ into a string to allow mapping visualization.
-	QString mapToString();
+	const QString mapToString();
 
 signals:
 
@@ -80,6 +76,12 @@ public slots:
 	void setNewlineDelimiter(const QString& t) { newlineDelimiter_ = t; setModified(true); }
 
 protected:
+
+	/// Loads the precision map into the database in the form of a string.
+	QString loadPrecisionMap();
+	/// Parses a precision map string from the database and recreates the map.
+	void readPrecisionMap(const QString& stringMap);
+
 	/// The delimiter to use between columns
 	QString columnDelimiter_;
 	/// The delimiter to use between lines (newline character)

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -51,9 +51,8 @@ public:
 	QString columnDelimiter() const { return columnDelimiter_; }
 	/// The delimiter to use between lines (newline character)
 	QString newlineDelimiter() const { return newlineDelimiter_; }
-
+	/// Returns the precision map used to assign AMDataSources an export precission.
 	QMap<QString, int> precisionMap() const { return sourceExportPrecision_; }
-
 	/// Returns the default precision if no source is specified.
 	int exportPrecision() const;
 	/// Returns the associated precision with the source name.
@@ -62,13 +61,16 @@ public:
 	void setExportPrecision(const QString& source, const int precision);
 	/// Sets the default precision with no AMDataSource name specified.
 	void setExportPrecision(const int precision);
-
+	/// Loads the precision map into the database in the form of a string.
 	QString loadPrecisionMap();
-
+	/// Parses a precision map string from the database and recreates the map.
 	void readPrecisionMap(const QString& stringMap);
 
 	virtual QWidget* createEditorWidget();
 
+	void testPrecisionMapDbFunctions();
+
+	void mapToString();
 
 signals:
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -68,9 +68,8 @@ public:
 
 	virtual QWidget* createEditorWidget();
 
-	void testPrecisionMapDbFunctions();
-
-	void mapToString();
+	/// Output the current map in exportPrecision_ into a string to allow mapping visualization.
+	QString mapToString();
 
 signals:
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -30,6 +30,9 @@ class AMExporterOptionGeneralAscii : public AMExporterOptionGeneral
 
 	Q_PROPERTY(QString columnDelimiter READ columnDelimiter WRITE setColumnDelimiter)
 	Q_PROPERTY(QString newlineDelimiter READ newlineDelimiter WRITE setNewlineDelimiter)
+	Q_PROPERTY(int exportPrecision READ exportPrecision WRITE setExportPrecision)
+
+	Q_CLASSINFO("exportPrecision", "upgradeDefault=8")
 
 public:
 	/// Constructor.
@@ -48,14 +51,16 @@ public:
 	/// The delimiter to use between lines (newline character)
 	QString newlineDelimiter() const { return newlineDelimiter_; }
 
+	QMap<QString, int> precisionMap() const { return sourceExportPrecision_; }
+
 	/// Returns the default precision if no source is specified.
 	int exportPrecision() const;
 	/// Returns the associated precision with the source name.
 	int exportPrecision(const QString& source) const;
 	/// Sets a precision for a source name. Duplicate naming is not allowed.
-	bool setExportPrecision(const QString& source, const int& precision);
+	bool setExportPrecision(const QString& source, const int precision);
 	/// Sets the default precision with no AMDataSource name specified.
-	bool setExportPrecision(const int& precision);
+	bool setExportPrecision(const int precision);
 
 	virtual QWidget* createEditorWidget();
 
@@ -76,7 +81,7 @@ protected:
 	/// A mapping of datasource names to the precision their data should be exported at.
 	QMap<QString, int> sourceExportPrecision_;
 	/// A default precision if a source is not given one specifically.
-	int defaultExportPrecision_ ;
+	int exportPrecision_ ;
 
 };
 

--- a/source/dataman/export/AMExporterOptionGeneralAscii.h
+++ b/source/dataman/export/AMExporterOptionGeneralAscii.h
@@ -65,7 +65,7 @@ public:
 	virtual QWidget* createEditorWidget();
 
 	/// Output the current map in exportPrecision_ into a string to allow mapping visualization.
-	const QString mapToString();
+	QString mapToString() const;
 
 signals:
 

--- a/source/dataman/export/AMExporterXDIFormat.cpp
+++ b/source/dataman/export/AMExporterXDIFormat.cpp
@@ -109,6 +109,7 @@ void AMExporterXDIFormat::writeMainTable()
 		for(int c=0; c<mainTableDataSources_.count(); c++) {
 			setCurrentDataSource(mainTableDataSources_.at(c));
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			if(ds->size(0) > maxTableRows)
 				maxTableRows = ds->size(0); // convenient... lets figure this out while we're looping through anyway
@@ -130,7 +131,7 @@ void AMExporterXDIFormat::writeMainTable()
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					setCurrentColumnIndex(cc);
-					ts << columnText << "[" << ds->axisValue(1, cc).toString() << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
+					ts << columnText << "[" << ds->axisValue(1, cc).toString(precision) << ds->axisInfoAt(1).units << "]" << option_->columnDelimiter();
 				}
 			}
 		}
@@ -145,27 +146,28 @@ void AMExporterXDIFormat::writeMainTable()
 		for(int c=0; c<mainTableDataSources_.count(); c++) {
 			setCurrentDataSource(mainTableDataSources_.at(c));
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			bool doPrint = (ds->size(0) > r);
 
 			// print x column?
 			if(mainTableIncludeX_.at(c)) {
 				if(doPrint)
-					ts << ds->axisValue(0,r).toString(option_->exportPrecision(ds->name()));
+					ts << ds->axisValue(0,r).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 
 			// 1D data sources:
 			if(ds->rank() == 1) {
 				if(doPrint)
-					ts << ds->value(r).toString(option_->exportPrecision(ds->name()));
+					ts << ds->value(r).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 			else if(ds->rank() == 2) {
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					if(doPrint)
-						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name()));
+						ts << ds->value(AMnDIndex(r,cc)).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 			}

--- a/source/dataman/export/AMExporterXDIFormat.cpp
+++ b/source/dataman/export/AMExporterXDIFormat.cpp
@@ -151,21 +151,21 @@ void AMExporterXDIFormat::writeMainTable()
 			// print x column?
 			if(mainTableIncludeX_.at(c)) {
 				if(doPrint)
-					ts << ds->axisValue(0,r).toString();
+					ts << ds->axisValue(0,r).toString(option_->exportPrecision(ds->name()));
 				ts << option_->columnDelimiter();
 			}
 
 			// 1D data sources:
 			if(ds->rank() == 1) {
 				if(doPrint)
-					ts << ds->value(r).toString();
+					ts << ds->value(r).toString(option_->exportPrecision(ds->name()));
 				ts << option_->columnDelimiter();
 			}
 			else if(ds->rank() == 2) {
 				// need a loop over the second axis columns
 				for(int cc=0; cc<ds->size(1); cc++) {
 					if(doPrint)
-						ts << ds->value(AMnDIndex(r,cc)).toString();
+						ts << ds->value(AMnDIndex(r,cc)).toString(option_->exportPrecision(ds->name()));
 					ts << option_->columnDelimiter();
 				}
 			}

--- a/source/dataman/export/AMSMAKExporter.cpp
+++ b/source/dataman/export/AMSMAKExporter.cpp
@@ -203,17 +203,18 @@ void AMSMAKExporter::writeMainTable()
 			for(int c=0; c<mainTableDataSources_.count(); c++) {
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,x).toString(option_->exportPrecision(ds->name()));
+					ts << ds->axisValue(0,x).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, y).toString(option_->exportPrecision(ds->name()));
+					ts << ds->axisValue(1, y).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
-				ts << ds->value(AMnDIndex(x, y)).toString(option_->exportPrecision(ds->name()));
+				ts << ds->value(AMnDIndex(x, y)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}
@@ -230,17 +231,18 @@ void AMSMAKExporter::writeMainTable()
 			for(int c=0; c<mainTableDataSources_.count(); c++) {
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,i).toString();
+					ts << ds->axisValue(0,i).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, yRange_-1).toString();
+					ts << ds->axisValue(1, yRange_-1).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
-				ts << ds->value(AMnDIndex(i, yRange_-1)).toString();
+				ts << ds->value(AMnDIndex(i, yRange_-1)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}
@@ -332,6 +334,7 @@ void AMSMAKExporter::writeSMAKFile()
 
 	const AMExporterOptionSMAK *smakOption = qobject_cast<const AMExporterOptionSMAK *>(option_);
 	QList<AMDataSource *> sources;
+	int sourcePrecision = smakOption->exportPrecision(sources.at(0)->name());
 
 	for (int i = 0; i < currentScan_->dataSourceCount(); i++)
 		if (currentScan_->dataSourceAt(i)->name().contains(QRegExp(smakOption->regExpString())))
@@ -354,13 +357,13 @@ void AMSMAKExporter::writeSMAKFile()
 
 	temp = "*";
 	for (int i = 0; i < xRange; i++)
-		temp.append(QString("\t%1").arg(sources.at(0)->axisValue(0, i).toString()));
+		temp.append(QString("\t%1").arg(sources.at(0)->axisValue(0, i).toString(sourcePrecision)));
 	temp.append("\n* BLANK LINE\n* BLANK LINE\n");
 	ts << temp;
 	ts << "* Ordinate points requested :\n";
 	temp = "*";
 	for (int i = 0; i < yRange; i++)
-		temp.append(QString("\t%1").arg(sources.at(0)->axisValue(1, i).toString()));
+		temp.append(QString("\t%1").arg(sources.at(0)->axisValue(1, i).toString(sourcePrecision)));
 	temp.append("\n* BLANK LINE\n* BLANK LINE\n* Energy points requested:\n*\t30000.0\n* BLANK LINE\n* DATA\n");
 	ts << temp;
 
@@ -375,16 +378,17 @@ void AMSMAKExporter::writeSMAKFile()
 			for(int c=0; c < sources.size(); c++) {
 
 				AMDataSource* ds = sources.at(c);
+				int precision = smakOption->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(c == 0) {
-					ts << ds->axisValue(0, x).toString();
+					ts << ds->axisValue(0, x).toString(precision);
 					ts << "\t";
-					ts << ds->axisValue(1, y).toString();
+					ts << ds->axisValue(1, y).toString(precision);
 					ts << "\t";
 				}
 
-				ts << ds->value(AMnDIndex(x, y)).toString();
+				ts << ds->value(AMnDIndex(x, y)).toString(precision);
 				ts << "\t";
 			}
 
@@ -400,16 +404,17 @@ void AMSMAKExporter::writeSMAKFile()
 			for(int c=0; c < sources.size(); c++) {
 
 				AMDataSource* ds = sources.at(c);
+				int precision = smakOption->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(c == 0) {
-					ts << ds->axisValue(0, i).toString();
+					ts << ds->axisValue(0, i).toString(precision);
 					ts << "\t";
-					ts << ds->axisValue(1, yRange_-1).toString();
+					ts << ds->axisValue(1, yRange_-1).toString(precision);
 					ts << "\t";
 				}
 
-				ts << ds->value(AMnDIndex(i, yRange_-1)).toString();
+				ts << ds->value(AMnDIndex(i, yRange_-1)).toString(precision);
 				ts << "\t";
 			}
 

--- a/source/dataman/export/AMSMAKExporter.cpp
+++ b/source/dataman/export/AMSMAKExporter.cpp
@@ -207,13 +207,13 @@ void AMSMAKExporter::writeMainTable()
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,x).toString();
+					ts << ds->axisValue(0,x).toString(option_->exportPrecision(ds->name()));
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, y).toString();
+					ts << ds->axisValue(1, y).toString(option_->exportPrecision(ds->name()));
 					ts << option_->columnDelimiter();
 				}
 
-				ts << ds->value(AMnDIndex(x, y)).toString();
+				ts << ds->value(AMnDIndex(x, y)).toString(option_->exportPrecision(ds->name()));
 
 				ts << option_->columnDelimiter();
 			}

--- a/source/dataman/export/VESPERS/VESPERSExporter2DAscii.cpp
+++ b/source/dataman/export/VESPERS/VESPERSExporter2DAscii.cpp
@@ -107,20 +107,21 @@ void VESPERSExporter2DAscii::writeMainTable()
 			for(int c=0; c<mainTableDataSources_.count(); c++) {
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0, x).toString();
+					ts << ds->axisValue(0, x).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, y).toString();
+					ts << ds->axisValue(1, y).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
 				if(ds->name().contains("FileNumber"))
 					ts << QString(ccdString).arg(int(ds->value(AMnDIndex(x, y)))-1);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 				else
-					ts << ds->value(AMnDIndex(x, y)).toString();
+					ts << ds->value(AMnDIndex(x, y)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}
@@ -138,13 +139,14 @@ void VESPERSExporter2DAscii::writeMainTable()
 
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,x).toString();
+					ts << ds->axisValue(0,x).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, yRange_-1).toString();
+					ts << ds->axisValue(1, yRange_-1).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
@@ -152,7 +154,7 @@ void VESPERSExporter2DAscii::writeMainTable()
 					ts << QString(ccdString).arg(int(ds->value(AMnDIndex(x, yRange_-1)))-1);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 
 				else
-					ts << ds->value(AMnDIndex(x, yRange_-1)).toString();
+					ts << ds->value(AMnDIndex(x, yRange_-1)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}

--- a/source/dataman/export/VESPERS/VESPERSExporter3DAscii.cpp
+++ b/source/dataman/export/VESPERS/VESPERSExporter3DAscii.cpp
@@ -234,22 +234,23 @@ void VESPERSExporter3DAscii::writeMainTable()
 				for(int c=0; c<mainTableDataSources_.count(); c++) {
 					setCurrentDataSource(mainTableDataSources_.at(c));
 					AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+					int precision = option_->exportPrecision(ds->name());
 
 					// print x and y column?
 					if(mainTableIncludeX_.at(c)) {
 
-						ts << ds->axisValue(0, x).toString();
+						ts << ds->axisValue(0, x).toString(precision);
 						ts << option_->columnDelimiter();
-						ts << ds->axisValue(1, y).toString();
+						ts << ds->axisValue(1, y).toString(precision);
 						ts << option_->columnDelimiter();
-						ts << ds->axisValue(2, z).toString();
+						ts << ds->axisValue(2, z).toString(precision);
 						ts << option_->columnDelimiter();
 					}
 
 					if(c == indexOfCCDName)
 						ts << QString(ccdString).arg(int(ds->value(AMnDIndex(x, y, z)))-1);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 					else
-						ts << ds->value(AMnDIndex(x, y, z)).toString();
+						ts << ds->value(AMnDIndex(x, y, z)).toString(precision);
 
 					ts << option_->columnDelimiter();
 				}
@@ -271,22 +272,23 @@ void VESPERSExporter3DAscii::writeMainTable()
 				for(int c=0; c<mainTableDataSources_.count(); c++) {
 					setCurrentDataSource(mainTableDataSources_.at(c));
 					AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+					int precision = option_->exportPrecision(ds->name());
 
 					// print x and y column?
 					if(mainTableIncludeX_.at(c)) {
 
-						ts << ds->axisValue(0, x).toString();
+						ts << ds->axisValue(0, x).toString(precision);
 						ts << option_->columnDelimiter();
-						ts << ds->axisValue(1, yRange_-1).toString();
+						ts << ds->axisValue(1, yRange_-1).toString(precision);
 						ts << option_->columnDelimiter();
-						ts << ds->axisValue(2, z).toString();
+						ts << ds->axisValue(2, z).toString(precision);
 						ts << option_->columnDelimiter();
 					}
 
 					if(c == indexOfCCDName)
 						ts << QString(ccdString).arg(int(ds->value(AMnDIndex(x, yRange_-1, z)))-1);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 					else
-						ts << ds->value(AMnDIndex(x, yRange_-1, z)).toString();
+						ts << ds->value(AMnDIndex(x, yRange_-1, z)).toString(precision);
 
 					ts << option_->columnDelimiter();
 				}
@@ -304,22 +306,23 @@ void VESPERSExporter3DAscii::writeMainTable()
 			for(int c=0; c<mainTableDataSources_.count(); c++) {
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0, xRange_-1).toString();
+					ts << ds->axisValue(0, xRange_-1).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, yRange_-1).toString();
+					ts << ds->axisValue(1, yRange_-1).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(2, z).toString();
+					ts << ds->axisValue(2, z).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
 				if(c == indexOfCCDName)
 					ts << QString(ccdString).arg(int(ds->value(AMnDIndex(xRange_-1, yRange_-1, z)))-1);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 				else
-					ts << ds->value(AMnDIndex(xRange_-1, yRange_-1, z)).toString();
+					ts << ds->value(AMnDIndex(xRange_-1, yRange_-1, z)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}

--- a/source/dataman/export/VESPERS/VESPERSExporterLineScanAscii.cpp
+++ b/source/dataman/export/VESPERS/VESPERSExporterLineScanAscii.cpp
@@ -226,18 +226,19 @@ void VESPERSExporterLineScanAscii::writeMainTable()
 		for(int c=0; c<mainTableDataSources_.count(); c++) {
 			setCurrentDataSource(mainTableDataSources_.at(c));
 			AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+			int precision = option_->exportPrecision(ds->name());
 
 			// print x column?
 			if(mainTableIncludeX_.at(c)) {
 
-				ts << ds->axisValue(0,x).toString();
+				ts << ds->axisValue(0,x).toString(precision);
 				ts << option_->columnDelimiter();
 			}
 
 			if(c == indexOfCCDName)
 				ts << QString(ccdString).arg(int(ds->value(AMnDIndex(x))) + shiftOffset);
 			else
-				ts << ds->value(AMnDIndex(x)).toString();
+				ts << ds->value(AMnDIndex(x)).toString(precision);
 
 			ts << option_->columnDelimiter();
 		}

--- a/source/dataman/export/VESPERS/VESPERSExporterSMAK.cpp
+++ b/source/dataman/export/VESPERS/VESPERSExporterSMAK.cpp
@@ -88,13 +88,14 @@ void VESPERSExporterSMAK::writeMainTable()
 
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,x).toString();
+					ts << ds->axisValue(0,x).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, y).toString();
+					ts << ds->axisValue(1, y).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
@@ -102,7 +103,7 @@ void VESPERSExporterSMAK::writeMainTable()
 					ts << QString("%1_%2.%3").arg(ccdFileName).arg(int(ds->value(AMnDIndex(x, y)))-1).arg(suffix);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 
 				else
-					ts << ds->value(AMnDIndex(x, y)).toString();
+					ts << ds->value(AMnDIndex(x, y)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}
@@ -120,13 +121,14 @@ void VESPERSExporterSMAK::writeMainTable()
 
 				setCurrentDataSource(mainTableDataSources_.at(c));
 				AMDataSource* ds = currentScan_->dataSourceAt(currentDataSourceIndex_);
+				int precision = option_->exportPrecision(ds->name());
 
 				// print x and y column?
 				if(mainTableIncludeX_.at(c)) {
 
-					ts << ds->axisValue(0,x).toString();
+					ts << ds->axisValue(0,x).toString(precision);
 					ts << option_->columnDelimiter();
-					ts << ds->axisValue(1, yRange_-1).toString();
+					ts << ds->axisValue(1, yRange_-1).toString(precision);
 					ts << option_->columnDelimiter();
 				}
 
@@ -134,7 +136,7 @@ void VESPERSExporterSMAK::writeMainTable()
 					ts << QString("%1_%2.%3").arg(ccdFileName).arg(int(ds->value(AMnDIndex(x, yRange_-1)))-1).arg(suffix);	// The -1 is because the value stored here is the NEXT number in the scan.  Purely a nomenclature setup from the EPICS interface.
 
 				else
-					ts << ds->value(AMnDIndex(x, yRange_-1)).toString();
+					ts << ds->value(AMnDIndex(x, yRange_-1)).toString(precision);
 
 				ts << option_->columnDelimiter();
 			}


### PR DESCRIPTION
Precision previously was 19 digits for all exported data.

Added in export options so that each export configuration would have its own as well as a mapping to give each AMDataSource its own precision if required.

Configured 6 digits for all beamlines by default. Normalization data in BioXAS is set to use precisions of 19.

#2157 