### PR TITLE
Pull Request for Issue 2442: PGM first run adjustments.

### DIFF
--- a/source/ui/AMStartScreen.cpp
+++ b/source/ui/AMStartScreen.cpp
@@ -31,6 +31,8 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 AMStartScreen::AMStartScreen(bool mustAccept, QWidget *parent) :
 	QDialog(parent)
 {
+	parent_ = parent;
+	parent->hide();
 	mustAccept_ = mustAccept;
 	runSelector_ = new AMRunSelector(AMDatabase::database("user"),this);
 
@@ -58,6 +60,7 @@ void AMStartScreen::accept()
 {
 	if(runSelector_->currentRunId() > 0) {
 		AMUser::user()->setCurrentRunId( runSelector_->currentRunId() );
+		parent_->show();
 		QDialog::accept();
 	}
 	else {

--- a/source/ui/AMStartScreen.h
+++ b/source/ui/AMStartScreen.h
@@ -43,6 +43,7 @@ public slots:
 	void reject();
 
 protected:
+	QWidget* parent_;
 	AMRunSelector *runSelector_;
 	bool mustAccept_;
 };


### PR DESCRIPTION
While the run selection dialog is being displayed at startup the main
window is hidden. The main window is brought back up when a run is
selected and accepted.

First run never successfully creates a remote folder at /home/pgm/... due to permission issues. The location needs to be adjusted or permissions adjusted on the machine.

#2442 