### PR TITLE
Pull Request for Issue 2443: Adjustments to PGM XAS scan configuration view.

### DIFF
--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -71,7 +71,7 @@ void PGMAppController::onUserConfigurationLoadedFromDb()
 			connect(oceanOpticsDetector, SIGNAL(removedRegionOfInterest(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestRemoved(AMRegionOfInterest*)));
 			connect(oceanOpticsDetector, SIGNAL(regionOfInterestBoundingRangeChanged(AMRegionOfInterest*)), this, SLOT(onRegionOfInterestBoundingRangeChanged(AMRegionOfInterest*)));
 
-			foreach (AMRegionOfInterest *region, userConfiguration_->regionsOfInterest()){
+			foreach (AMRegionOfInterest *region, pgmUserConfiguration_->regionsOfInterest()){
 				oceanOpticsDetector->addRegionOfInterest(region);
 			}
 		}
@@ -105,7 +105,7 @@ bool PGMAppController::setupDataFolder()
 {
 	// Get a destination folder.
 	return AMChooseDataFolderDialog::getDataFolder("/AcquamanLocalData/pgm",  //local directory
-							   "/home/pgm",               //remote directory
+							   "/home/pgm/acquamanData",               //remote directory
 						       "users",                   //data directory
 						       QStringList());            //extra data directory
 }

--- a/source/application/PGM/PGMAppController.cpp
+++ b/source/application/PGM/PGMAppController.cpp
@@ -220,6 +220,9 @@ void PGMAppController::createScanConfigurationPanes()
 {
 	xasScanConfigurationView_ = new PGMXASScanConfigurationView(xasScanConfiguration_);
 	xasScanConfigurationViewHolder3_ = new AMScanConfigurationViewHolder3(xasScanConfigurationView_, true);
+	connect(xasScanConfiguration_, SIGNAL(totalTimeChanged(double)), xasScanConfigurationViewHolder3_, SLOT(updateOverallScanTime(double)));
+	xasScanConfigurationViewHolder3_->updateOverallScanTime(xasScanConfiguration_->totalTime());
+
 	mw_->addPane(xasScanConfigurationViewHolder3_, scanPaneCategoryName_, "XAS", scanPaneIcon_);
 }
 

--- a/source/beamline/PGM/PGMPicoAmmeter.cpp
+++ b/source/beamline/PGM/PGMPicoAmmeter.cpp
@@ -67,6 +67,8 @@ void PGMPicoAmmeter::updateUnits()
 
 void PGMPicoAmmeter::onConnectedChanged(bool connected)
 {
+	setConnected(connected);
+
 	if (connected)
 		setReadyForAcquisition();
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -13,14 +13,14 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 
 	// Scan Name
 
-	QLabel *scanNameLable = new QLabel("Scan Name: ");
+	QLabel *scanNameLabel = new QLabel("Scan Name: ");
 
 	scanName_ = new QLineEdit();
 	scanName_->setText(configuration_->name());
 	scanName_->setAlignment(Qt::AlignCenter);
 
 	QHBoxLayout *scanNameLayout = new QHBoxLayout;
-	scanNameLayout->addWidget(scanNameLable);
+	scanNameLayout->addWidget(scanNameLabel);
 	scanNameLayout->addWidget(scanName_);
 
 	// Regions view configuration

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -108,9 +108,9 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	// Setup connections
 	connect(scanName_, SIGNAL(editingFinished()), this, SLOT(onScanNameEdited()));
 	connect(configuration_, SIGNAL(nameChanged(QString)), scanName_, SLOT(setText(QString)));
-	connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
+	connect(exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
 	connect(configuration_, SIGNAL(totalTimeChanged(double)), this, SLOT(onEstimatedTimeChanged(double)));
-	onEstimatedTimeChanged(configuration->totalTime());
+	onEstimatedTimeChanged(configuration_->totalTime());
 
 }
 

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -11,20 +11,43 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 {
 	configuration_ = configuration;
 
+	// Scan Name
+
+	QLabel *scanNameLable = new QLabel("Scan Name: ");
+
 	scanName_ = new QLineEdit();
 	scanName_->setText(configuration_->name());
+	scanName_->setAlignment(Qt::AlignCenter);
+
+	QHBoxLayout *scanNameLayout = new QHBoxLayout;
+	scanNameLayout->addWidget(scanNameLable);
+	scanNameLayout->addWidget(scanName_);
+
+	// Regions view configuration
 
 	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_);
 
 	QGroupBox *regionsGroupBox = new QGroupBox("Regions");
 	regionsGroupBox->setLayout(regionsView_->layout());
 
+	// Estimated scan time to display.
+
+	QLabel *timeLabel = new QLabel("Estimated time per scan: ");
+	estimatedTime_ = new QLabel;
+
+	QHBoxLayout *timeLayout = new QHBoxLayout;
+	timeLayout->addWidget(timeLabel);
+	timeLayout->addWidget(estimatedTime_);
+
+	QGroupBox *timeBox = new QGroupBox("Time");
+	timeBox->setLayout(timeLayout);
+
 	// Setup export option.
 	exportSpectraCheckBox_ = new QCheckBox("Export Spectra");
 	exportSpectraCheckBox_->setChecked(configuration_->autoExportEnabled());
 
 	// Setup primary (scientific) detector options.
-	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(configuration_, PGMBeamline::pgm()->exposedScientificDetectors());
+	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedScientificDetectors());
 
 	QVBoxLayout *scientificDetectorsWidgetLayout = new QVBoxLayout();
 	scientificDetectorsWidgetLayout->addWidget(scientificDetectorsView_);
@@ -34,7 +57,7 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	scientificDetectorsWidget->setLayout(scientificDetectorsWidgetLayout);
 
 	// Setup options for all detectors.
-	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(configuration_, PGMBeamline::pgm()->exposedDetectors());
+	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedDetectors());
 
 	QVBoxLayout *allDetectorsWidgetLayout = new QVBoxLayout();
 	allDetectorsWidgetLayout->addWidget(allDetectorsView_);
@@ -58,23 +81,36 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	QGroupBox *detectorBox = new QGroupBox("Detectors");
 	detectorBox->setLayout(sideVerticalLayout);
 
+	// Combine regions, scan name and time estimate.
+	QVBoxLayout *regionsLayout = new QVBoxLayout;
+	regionsLayout->addWidget(regionsGroupBox);
+	regionsLayout->addStretch();
+	regionsLayout->addLayout(scanNameLayout);
+	regionsLayout->addWidget(timeBox);
+
 	// Add layouts to main.
 	QHBoxLayout *topHorizontalLayout = new QHBoxLayout;
-	topHorizontalLayout->addWidget(regionsGroupBox);
+	topHorizontalLayout->addLayout(regionsLayout);
 	topHorizontalLayout->addWidget(detectorBox);
 
 	QVBoxLayout *mainLayout = new QVBoxLayout;
 	mainLayout->addStretch();
 	mainLayout->addLayout(topHorizontalLayout);
-	mainLayout->addWidget(scanName_);
 	mainLayout->addStretch();
 
-	setLayout(mainLayout);
+	QHBoxLayout *centeredLayout = new QHBoxLayout;
+	centeredLayout->addStretch();
+	centeredLayout->addLayout(mainLayout);
+	centeredLayout->addStretch();
+
+	setLayout(centeredLayout);
 
 	// Setup connections
 	connect(scanName_, SIGNAL(editingFinished()), this, SLOT(onScanNameEdited()));
 	connect(configuration_, SIGNAL(nameChanged(QString)), scanName_, SLOT(setText(QString)));
 	connect( exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
+	connect(configuration_, SIGNAL(totalTimeChanged(double)), this, SLOT(onEstimatedTimeChanged(double)));
+	onEstimatedTimeChanged(configuration->totalTime());
 
 }
 
@@ -82,6 +118,11 @@ void PGMXASScanConfigurationView::onScanNameEdited()
 {
 	configuration_->setName(scanName_->text());
 	configuration_->setUserScanName(scanName_->text());
+}
+
+void PGMXASScanConfigurationView::onEstimatedTimeChanged(double newTime)
+{
+	estimatedTime_->setText("Estimated time per scan:\t" + AMDateTimeUtils::convertTimeToString(newTime));
 }
 
 void PGMXASScanConfigurationView::onExportSelectionChanged(QAbstractButton *button)

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -24,7 +24,7 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	exportSpectraCheckBox_->setChecked(configuration_->autoExportEnabled());
 
 	// Setup primary (scientific) detector options.
-	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedScientificDetectors());
+	scientificDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(configuration_, PGMBeamline::pgm()->exposedScientificDetectors());
 
 	QVBoxLayout *scientificDetectorsWidgetLayout = new QVBoxLayout();
 	scientificDetectorsWidgetLayout->addWidget(scientificDetectorsView_);
@@ -34,7 +34,7 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	scientificDetectorsWidget->setLayout(scientificDetectorsWidgetLayout);
 
 	// Setup options for all detectors.
-	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(0, PGMBeamline::pgm()->exposedDetectors());
+	allDetectorsView_ = new AMGenericStepScanConfigurationDetectorsView(configuration_, PGMBeamline::pgm()->exposedDetectors());
 
 	QVBoxLayout *allDetectorsWidgetLayout = new QVBoxLayout();
 	allDetectorsWidgetLayout->addWidget(allDetectorsView_);

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -35,6 +35,9 @@ protected slots:
 	/// Handles setting the name of the configuration from the line edit.
 	void onScanNameEdited();
 
+	///
+	void onEstimatedTimeChanged(double newTime);
+
 	/// Handles changes of the auto export check box.
 	void onExportSelectionChanged(QAbstractButton *button);
 
@@ -47,6 +50,9 @@ protected:
 
 	/// The scan name.
 	QLineEdit *scanName_;
+
+	///
+	QLabel *estimatedTime_;
 
 	/// Set of dectors to display.
 	QCheckBox *exportSpectraCheckBox_;

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -35,7 +35,7 @@ protected slots:
 	/// Handles setting the name of the configuration from the line edit.
 	void onScanNameEdited();
 
-	///
+	/// Helper to set estimated time label.
 	void onEstimatedTimeChanged(double newTime);
 
 	/// Handles changes of the auto export check box.
@@ -51,7 +51,7 @@ protected:
 	/// The scan name.
 	QLineEdit *scanName_;
 
-	///
+	/// A label holding the current estimated time per scan.
 	QLabel *estimatedTime_;
 
 	/// Set of dectors to display.


### PR DESCRIPTION
Added more spacing to the sides of the view.

Adjusted the name filed so it was nested into the left layout.

Added a label specifying the name field was for the name.

Added an estimation per scan field underneath the name field as it is on other beamlines.

#2443 