### PR TITLE
Pull Request for Issue 2464: onExportClicked not defined in AMSpectrumAndPeriodicTableView

### DIFF
--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -172,8 +172,6 @@ void AMXRFDetailedDetectorView::buildEnergyRangeSpinBoxView()
 {
 	AMSpectrumAndPeriodicTableView::buildEnergyRangeSpinBoxView();
 
-	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
-
 	showEnergyRangeSpinBoxes_ = new QPushButton(QIcon(":/system-run.png"), "Settings");
 	showEnergyRangeSpinBoxes_->setCheckable(true);
 

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -63,7 +63,6 @@ AMXRFDetailedDetectorView::AMXRFDetailedDetectorView(AMXRFDetector *detector, QW
 	// this is to make sure we have more columns than rows, which will looks nicer
 	deadTimeViewFactor_ = (detector->elements() / deadTimeViewFactor_ ) > deadTimeViewFactor_ ? deadTimeViewFactor_ + 1 : deadTimeViewFactor_;
 
-
 	connect(periodicTable_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementSelected(AMElement*)));
 	connect(periodicTable_, SIGNAL(elementDeselected(AMElement*)), this, SLOT(onElementDeselected(AMElement*)));
 	connect(periodicTableView_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementClicked(AMElement*)));

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -167,6 +167,8 @@ void AMXRFDetailedDetectorView::buildEnergyRangeSpinBoxView()
 {
 	AMSpectrumAndPeriodicTableView::buildEnergyRangeSpinBoxView();
 
+	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
+
 	showEnergyRangeSpinBoxes_ = new QPushButton(QIcon(":/system-run.png"), "Settings");
 	showEnergyRangeSpinBoxes_->setCheckable(true);
 
@@ -347,7 +349,7 @@ void AMXRFDetailedDetectorView::startAcquisition()
 	scanAction->start();
 }
 
-void AMXRFDetailedDetectorView::onSaveButtonClicked()
+void AMXRFDetailedDetectorView::onExportButtonClicked()
 {
 	if(!chooseScanDialog_) {
 		chooseScanDialog_ = new AMChooseScanDialog(AMDatabase::database("user"), "Choose XRF Spectrum...", "Choose the XRF Spectrum you want to export.", this);

--- a/source/ui/beamline/AMXRFDetailedDetectorView.cpp
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.cpp
@@ -62,6 +62,12 @@ AMXRFDetailedDetectorView::AMXRFDetailedDetectorView(AMXRFDetector *detector, QW
 	deadTimeViewFactor_ = int(sqrt(double(detector->elements())));
 	// this is to make sure we have more columns than rows, which will looks nicer
 	deadTimeViewFactor_ = (detector->elements() / deadTimeViewFactor_ ) > deadTimeViewFactor_ ? deadTimeViewFactor_ + 1 : deadTimeViewFactor_;
+
+
+	connect(periodicTable_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementSelected(AMElement*)));
+	connect(periodicTable_, SIGNAL(elementDeselected(AMElement*)), this, SLOT(onElementDeselected(AMElement*)));
+	connect(periodicTableView_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementClicked(AMElement*)));
+
 }
 
 void AMXRFDetailedDetectorView::buildDetectorView()
@@ -216,6 +222,7 @@ void AMXRFDetailedDetectorView::buildShowSpectraButtons()
 	connect(spectraComboBox_, SIGNAL(currentIndexChanged(int)), this, SLOT(onSpectrumComboBoxIndexChanged(int)));
 	connect(showMultipleSpectraButton, SIGNAL(clicked()), this, SLOT(onShowMultipleSpectraButtonClicked()));
 	connect(showWaterfall_, SIGNAL(toggled(bool)), this, SLOT(onWaterfallUpdateRequired()));
+	connect(logScaleButton_, SIGNAL(toggled(bool)), this, SLOT(onLogScaleEnabled(bool)));
 	connect(logScaleButton_, SIGNAL(toggled(bool)), showWaterfall_, SLOT(setDisabled(bool)));
 
 	spectraComboBox_->setCurrentIndex(detector_->allSpectrumSources().size()-1);
@@ -291,6 +298,8 @@ void AMXRFDetailedDetectorView::onElementClicked(AMElement *element)
 {
 	// This is always safe because we know the periodic table is an AMSelectablePeriodicTable.
 	elementView_->setElement(qobject_cast<AMSelectableElement *>(element));
+
+	currentElement_ = element;
 
 	highlightCurrentElementRegionOfInterest();
 

--- a/source/ui/beamline/AMXRFDetailedDetectorView.h
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.h
@@ -108,7 +108,7 @@ protected slots:
 	/// Starts the acquisition.  Treats the acquisition like a scan and saves the result to the database.
 	virtual void startAcquisition();
 	/// Handles bringing up and exporting the given XRF scans.
-	void onSaveButtonClicked();
+	void onExportButtonClicked();
 	/// Handles grabbing the scan and exporting it.
 	void exportScan();
 	/// Handles deleting the export controller.

--- a/source/ui/beamline/AMXRFDetailedDetectorView.h
+++ b/source/ui/beamline/AMXRFDetailedDetectorView.h
@@ -48,13 +48,6 @@ public:
 	/// Re-implementing but still going to use the base class buildDetectorView since this view is merely adding to it.
 	virtual void buildDetectorView();
 
-	/// Returns the energy range used for filtering.  If no range has been provided the range is null.
-	const AMRange &energyRange() const { return emissionLineValidator_->range(); }
-	/// Returns the minimum energy in the energy range filter.
-	double minimumEnergy() const { return emissionLineValidator_->minimum(); }
-	/// Returns the maximum energy in the energy range filter.
-	double maximumEnergy() const { return emissionLineValidator_->maximum(); }
-
 	/// Sets the colors for each of the emission lines.
 	void setLineColors(const QColor &kColor, const QColor &lColor, const QColor &mColor, const QColor &defaultColor);
 	/// Sets the K emission line color.

--- a/source/ui/dataman/AMScanViewUtilities.cpp
+++ b/source/ui/dataman/AMScanViewUtilities.cpp
@@ -380,10 +380,16 @@ AMScanViewSingleSpectrumView::AMScanViewSingleSpectrumView(QWidget *parent)
 
 	buildShowSpectraButtons();
 
+	connect(logScaleButton_, SIGNAL(toggled(bool)), this, SLOT(onLogScaleEnabled(bool)));
+
 	buildEnergyRangeSpinBoxView();
 
 	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
 	connect(emissionLineValidator_, SIGNAL(validatorChanged()), this, SLOT(updateEmissionLineMarkers()));
+
+	connect(periodicTable_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementSelected(AMElement*)));
+	connect(periodicTable_, SIGNAL(elementDeselected(AMElement*)), this, SLOT(onElementDeselected(AMElement*)));
+	connect(periodicTableView_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementClicked(AMElement*)));
 
 	QVBoxLayout *sourcesLayout = new QVBoxLayout;
 	sourcesLayout->addLayout(sourceButtonsLayout_);

--- a/source/ui/dataman/AMScanViewUtilities.cpp
+++ b/source/ui/dataman/AMScanViewUtilities.cpp
@@ -382,6 +382,7 @@ AMScanViewSingleSpectrumView::AMScanViewSingleSpectrumView(QWidget *parent)
 
 	buildEnergyRangeSpinBoxView();
 
+	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
 	connect(emissionLineValidator_, SIGNAL(validatorChanged()), this, SLOT(updateEmissionLineMarkers()));
 
 	QVBoxLayout *sourcesLayout = new QVBoxLayout;
@@ -695,7 +696,7 @@ void AMScanViewSingleSpectrumView::setDataSources(const QList<AMDataSource *> &s
 #include <QFileDialog>
 #include <QMessageBox>
 
-void AMScanViewSingleSpectrumView::onExportClicked()
+void AMScanViewSingleSpectrumView::onExportButtonClicked()
 {
 	QString filename = QFileDialog::getSaveFileName(this, "Choose file name for data.", QString(), "Data files (*.dat);;All files (*)");
 

--- a/source/ui/dataman/AMScanViewUtilities.cpp
+++ b/source/ui/dataman/AMScanViewUtilities.cpp
@@ -384,7 +384,6 @@ AMScanViewSingleSpectrumView::AMScanViewSingleSpectrumView(QWidget *parent)
 
 	buildEnergyRangeSpinBoxView();
 
-	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
 	connect(emissionLineValidator_, SIGNAL(validatorChanged()), this, SLOT(updateEmissionLineMarkers()));
 
 	connect(periodicTable_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementSelected(AMElement*)));

--- a/source/ui/dataman/AMScanViewUtilities.h
+++ b/source/ui/dataman/AMScanViewUtilities.h
@@ -238,7 +238,7 @@ protected slots:
 	/// Slot that helps handling adding and removing of MPlot items as check boxes are checked on and off.
 	void onSpectrumCheckBoxChanged(int id);
 	/// Slot that handles getting the file name and then exporting the data sources to a file.
-	void onExportClicked();
+	void onExportButtonClicked();
 
 protected:
 	/// The title label.

--- a/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
+++ b/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
@@ -71,7 +71,6 @@ void AMSpectrumAndPeriodicTableView::buildEnergyRangeSpinBoxView()
 	exportButton_->setEnabled(false);
 	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
 
-
 	energyRangeLayout_ = new QVBoxLayout;
 
 }

--- a/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
+++ b/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
@@ -19,12 +19,8 @@ AMSpectrumAndPeriodicTableView::AMSpectrumAndPeriodicTableView(QWidget *parent)
 	periodicTable_ = new AMSelectablePeriodicTable(this);
 	periodicTable_->buildPeriodicTable();
 
-	connect(periodicTable_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementSelected(AMElement*)));
-	connect(periodicTable_, SIGNAL(elementDeselected(AMElement*)), this, SLOT(onElementDeselected(AMElement*)));
-
 	periodicTableView_ = new AMSelectablePeriodicTableView(periodicTable_);
 	periodicTableView_->buildPeriodicTableView();
-	connect(periodicTableView_, SIGNAL(elementSelected(AMElement*)), this, SLOT(onElementClicked(AMElement*)));
 
 	rowAbovePeriodicTableLayout_ = new QHBoxLayout;
 }
@@ -110,8 +106,6 @@ void AMSpectrumAndPeriodicTableView::buildShowSpectraButtons()
 {
 	logScaleButton_ = new QPushButton("Log scale");
 	logScaleButton_->setCheckable(true);
-
-	connect(logScaleButton_, SIGNAL(toggled(bool)), this, SLOT(onLogScaleEnabled(bool)));
 }
 
 void AMSpectrumAndPeriodicTableView::removeAllPlotItems(QList<MPlotItem *> &items)

--- a/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
+++ b/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
@@ -69,6 +69,8 @@ void AMSpectrumAndPeriodicTableView::buildEnergyRangeSpinBoxView()
 
 	exportButton_ = new QPushButton(QIcon(":/save.png"), "Save to file...");
 	exportButton_->setEnabled(false);
+	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportButtonClicked()));
+
 
 	energyRangeLayout_ = new QVBoxLayout;
 

--- a/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
+++ b/source/ui/dataman/AMSpectrumAndPeriodicTableView.cpp
@@ -73,7 +73,6 @@ void AMSpectrumAndPeriodicTableView::buildEnergyRangeSpinBoxView()
 
 	exportButton_ = new QPushButton(QIcon(":/save.png"), "Save to file...");
 	exportButton_->setEnabled(false);
-	connect(exportButton_, SIGNAL(clicked()), this, SLOT(onExportClicked()));
 
 	energyRangeLayout_ = new QVBoxLayout;
 

--- a/source/ui/dataman/AMSpectrumAndPeriodicTableView.h
+++ b/source/ui/dataman/AMSpectrumAndPeriodicTableView.h
@@ -120,6 +120,8 @@ protected slots:
 	void onLogScaleEnabled(bool enable);
 	/// Method that takes two AMEmissionLines and adds them to the plot as a pile up peak if it would fit.
 	void addPileUpMarker(const AMEmissionLine &firstLine, const AMEmissionLine &secondLine);
+	/// Placeholder function for handling export operations in derived classes.
+	virtual void onExportButtonClicked() = 0;
 
 protected:
 	/// Sets up the plot.
@@ -156,8 +158,7 @@ protected:
 
 	/// The export button.
 	QPushButton *exportButton_;
-	///
-	virtual void onExportButtonClicked() = 0;
+
 	/// The button for choosing the second element for combination pile up peaks.
 	QToolButton *combinationChoiceButton_;
 

--- a/source/ui/dataman/AMSpectrumAndPeriodicTableView.h
+++ b/source/ui/dataman/AMSpectrumAndPeriodicTableView.h
@@ -156,6 +156,8 @@ protected:
 
 	/// The export button.
 	QPushButton *exportButton_;
+	///
+	virtual void onExportButtonClicked() = 0;
 	/// The button for choosing the second element for combination pile up peaks.
 	QToolButton *combinationChoiceButton_;
 


### PR DESCRIPTION
Fixed a few issues with connections in AMSpectrumAndPeriodicTableView

onExportClicked() was connected in parent when it needed to be connected in the child classes.
Renamed onExportClicked and onSaveButtonClicked to onExportButtonClicked so child classes are consistent with each other.

Moved some connections that were made in the parent to the child so they would properly use the child's version of the slot function.

#2464 