### PR TITLE
Pull Request for Issue2454: fixes to PGM mono grating

### DIFF
--- a/source/beamline/PGM/PGMMonoGratingSelectionControl.cpp
+++ b/source/beamline/PGM/PGMMonoGratingSelectionControl.cpp
@@ -77,11 +77,11 @@ AMAction3 *PGMMonoGratingSelectionControl::createMoveAction(double setpoint)
 {
 	AMAction3 *result = 0;
 
-	if (setpoint == Low)
+	if (int(setpoint) == Low)
 		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, PGMMONOGRATINGSELECTIONCONTROL_PV_LOW);
-	else if (setpoint == Medium)
+	else if (int(setpoint) == Medium)
 		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, PGMMONOGRATINGSELECTIONCONTROL_PV_MEDIUM);
-	else if (setpoint == High)
+	else if (int(setpoint) == High)
 		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, PGMMONOGRATINGSELECTIONCONTROL_PV_HIGH);
 
 	return result;

--- a/source/beamline/PGM/PGMMonoGratingSelectionControl.cpp
+++ b/source/beamline/PGM/PGMMonoGratingSelectionControl.cpp
@@ -78,11 +78,11 @@ AMAction3 *PGMMonoGratingSelectionControl::createMoveAction(double setpoint)
 	AMAction3 *result = 0;
 
 	if (setpoint == Low)
-		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, 3);
+		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, PGMMONOGRATINGSELECTIONCONTROL_PV_LOW);
 	else if (setpoint == Medium)
-		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, 2);
+		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, PGMMONOGRATINGSELECTIONCONTROL_PV_MEDIUM);
 	else if (setpoint == High)
-		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, 1);
+		result = AMActionSupport::buildControlMoveAction(gratingSelectionPVControl_, PGMMONOGRATINGSELECTIONCONTROL_PV_HIGH);
 
 	return result;
 }
@@ -91,14 +91,14 @@ int PGMMonoGratingSelectionControl::currentIndex() const
 {
 	int result = enumNames().indexOf("Unknown");
 
-	if (isConnected()) {
+	if (canMeasure()) {
 		int intValue = int(gratingSelectionPVControl_->value());
 
-		if (intValue == 3)
+		if (intValue == PGMMONOGRATINGSELECTIONCONTROL_PV_LOW)
 			result = Low;
-		else if (intValue == 2)
+		else if (intValue == PGMMONOGRATINGSELECTIONCONTROL_PV_MEDIUM)
 			result = Medium;
-		else if (intValue == 1)
+		else if (intValue == PGMMONOGRATINGSELECTIONCONTROL_PV_HIGH)
 			result = High;
 	}
 

--- a/source/beamline/PGM/PGMMonoGratingSelectionControl.h
+++ b/source/beamline/PGM/PGMMonoGratingSelectionControl.h
@@ -15,6 +15,7 @@ class PGMMonoGratingSelectionControl : public AMEnumeratedControl
 	Q_OBJECT
 
 public:
+	/// Enumeration of the possible grating options.
 	enum Grating {
 		Low = 0,
 		Medium = 1,

--- a/source/beamline/PGM/PGMMonoGratingSelectionControl.h
+++ b/source/beamline/PGM/PGMMonoGratingSelectionControl.h
@@ -3,6 +3,11 @@
 
 #include "beamline/AMEnumeratedControl.h"
 
+#define PGMMONOGRATINGSELECTIONCONTROL_PV_HIGH 1
+#define PGMMONOGRATINGSELECTIONCONTROL_PV_MEDIUM 2
+#define PGMMONOGRATINGSELECTIONCONTROL_PV_LOW 3
+#define PGMMONOGRATINGSELECTIONCONTROL_PV_UNKNOWN 4
+
 class AMPVwStatusControl;
 
 class PGMMonoGratingSelectionControl : public AMEnumeratedControl
@@ -10,13 +15,6 @@ class PGMMonoGratingSelectionControl : public AMEnumeratedControl
 	Q_OBJECT
 
 public:
-//	enum Grating {
-//		Low = 3,
-//		Medium = 2,
-//		High = 1,
-//		None = 0
-//	};
-
 	enum Grating {
 		Low = 0,
 		Medium = 1,

--- a/source/beamline/PGM/PGMMonoGratingSelectionControl.h
+++ b/source/beamline/PGM/PGMMonoGratingSelectionControl.h
@@ -10,10 +10,17 @@ class PGMMonoGratingSelectionControl : public AMEnumeratedControl
 	Q_OBJECT
 
 public:
+//	enum Grating {
+//		Low = 3,
+//		Medium = 2,
+//		High = 1,
+//		None = 0
+//	};
+
 	enum Grating {
-		Low = 3,
-		Medium = 2,
-		High = 1
+		Low = 0,
+		Medium = 1,
+		High = 2
 	};
 
 	/// Constructor.


### PR DESCRIPTION
Minor adjustments to the PGM mono grating selection control. The main issue was that the enumerations didn't start at 0, so the control values were all off by one. We made some changes to the enum values, and as a consequence the createMoveAction(...) and currentIndex(...) methods had to be adjusted. The grating selection control should now correctly report the current selection and send the PV to the correct value.