### PR TITLE
Pull Request for Issue2459: Adding undulator gap and ring current detector emulators to PGM

### DIFF
--- a/source/beamline/PGM/PGMBeamline.cpp
+++ b/source/beamline/PGM/PGMBeamline.cpp
@@ -22,6 +22,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "beamline/CLS/CLSMAXvMotor.h"
 #include "beamline/PGM/PGMBranchSelectionControl.h"
+#include "beamline/AMBasicControlDetectorEmulator.h"
 
 PGMBeamline::PGMBeamline()
 	: CLSBeamline("PGM Beamline")
@@ -254,7 +255,13 @@ void PGMBeamline::setupComponents()
 
 void PGMBeamline::setupControlsAsDetectors()
 {
+	// The undulator gap.
 
+	undulatorGapDetector_ = new AMBasicControlDetectorEmulator("PGMUndulatorGapDetector", "Undulator gap", undulatorGap_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
+
+	// The ring current.
+
+	ringCurrentDetector_ = new AMBasicControlDetectorEmulator("PGMRingCurrentDetector", "Ring current", ringCurrent_, 0, 0, 0, AMDetectorDefinitions::ImmediateRead, this);
 }
 
 void PGMBeamline::setupHVControls()
@@ -321,8 +328,14 @@ void PGMBeamline::setupExposedDetectors()
 
 	addExposedDetector(oceanOpticsDetector_);
 
+	addExposedDetector(undulatorGapDetector_);
+	addExposedDetector(ringCurrentDetector_);
+
 	// Setup scientific exposed detectors. I picked random ones for testing.
 	addExposedScientificDetector(oceanOpticsDetector_);
 	addExposedScientificDetector(teyBladeCurrentDetector_);
 	addExposedScientificDetector(flyBladeCurrentDetector_);
+
+	addExposedScientificDetector(undulatorGapDetector_);
+	addExposedScientificDetector(ringCurrentDetector_);
 }

--- a/source/beamline/PGM/PGMBeamline.h
+++ b/source/beamline/PGM/PGMBeamline.h
@@ -159,6 +159,11 @@ public:
 	AMControlSet *branchAHVControlSet() const { return branchAHVControlSet_; }
 	AMControlSet *branchBHVControlSet() const { return branchBHVControlSet_; }
 
+	/// Returns the undulator gap detector emulator.
+	AMBasicControlDetectorEmulator* undulatorGapDetector() const { return undulatorGapDetector_; }
+	/// Returns the ring current detector emulator.
+	AMBasicControlDetectorEmulator* ringCurrentDetector() const { return ringCurrentDetector_; }
+
 signals:
 
 
@@ -294,6 +299,11 @@ protected:
 
 	/// The variable aperture mask.
 	PGMVariableApertureMask* vam_;
+
+	/// The undulator gap detector emulator.
+	AMBasicControlDetectorEmulator *undulatorGapDetector_;
+	/// The ring current detector emulator.
+	AMBasicControlDetectorEmulator *ringCurrentDetector_;
 };
 
 #endif // PGMBEAMLINE_H


### PR DESCRIPTION
Changes:
- Added instances of AMBasicControlDetectorEmulator to PGMBeamline for the undulator gap and the ring current.
- Added both detectors to the exposed and scientific detectors lists.

Should test to see whether this was done successfully, running scans on the beamline.

To do:
- Have the detectors auto-added to XAS scans but not visible in the scan configuration view.