### PR TITLE
PullRequest for issue2457 when using local data storage, we won't need to change the settting again

### DIFF
--- a/source/application/AMDatamanAppController.cpp
+++ b/source/application/AMDatamanAppController.cpp
@@ -387,21 +387,24 @@ bool AMDatamanAppController::startupOnFirstTime()
 
 		firstTimeWizard->deleteLater();
 
-		if(userLocalStorage){
-			AMUserSettings::remoteDataFolder = userDataFolder;
-			if(!AMUserSettings::remoteDataFolder.endsWith('/'))
-				AMUserSettings::remoteDataFolder.append("/");
+		// we only need to change the AMUserSettings if we are doing user based data storage
+		if (AMUserSettings::userBasedDataStorage) {
+			if(userLocalStorage){
+				AMUserSettings::remoteDataFolder = userDataFolder;
+				if(!AMUserSettings::remoteDataFolder.endsWith('/'))
+					AMUserSettings::remoteDataFolder.append("/");
 
-			QString localUserDataFolder = AMUserSettings::remoteDataFolder;
-			AMUserSettings::userDataFolder = localUserDataFolder.section('/', 2, -1).prepend("/AcquamanLocalData/");
-		}
-		else{
-			AMUserSettings::userDataFolder = userDataFolder;
-			if(!AMUserSettings::userDataFolder.endsWith('/'))
-				AMUserSettings::userDataFolder.append("/");
-		}
+				QString localUserDataFolder = AMUserSettings::remoteDataFolder;
+				AMUserSettings::userDataFolder = localUserDataFolder.section('/', 2, -1).prepend("/AcquamanLocalData/");
+			}
+			else{
+				AMUserSettings::userDataFolder = userDataFolder;
+				if(!AMUserSettings::userDataFolder.endsWith('/'))
+					AMUserSettings::userDataFolder.append("/");
+			}
 
-		AMUserSettings::save();
+			AMUserSettings::save();
+		}
 
 		// Attempt to create user's data folder, only if it doesn't exist:
 		QDir userDataDir(AMUserSettings::userDataFolder);
@@ -414,7 +417,7 @@ bool AMDatamanAppController::startupOnFirstTime()
 		}
 
 		if(userLocalStorage){
-			// Attempt to create user's data folder, only if it doesn't exist:
+			// Attempt to create user's remote data folder, only if it doesn't exist:
 			QDir remoteDataDir(AMUserSettings::remoteDataFolder);
 			if(!remoteDataDir.exists()) {
 				AMErrorMon::information(0, 0, "Creating new remote data folder: "  + AMUserSettings::remoteDataFolder);
@@ -440,11 +443,10 @@ bool AMDatamanAppController::startupOnFirstTime()
 				QFile::copy(allDatabaseFiles.at(x).absoluteFilePath(), QString("%1/%2").arg(AMUserSettings::remoteDataFolder).arg(allDatabaseFiles.at(x).fileName()));
 		}
 
+		// start the one-minute timer to monitor the disk usage of local storage
 		if(usingLocalStorage()) {
 
 			storageInfo_ = AMStorageInfo(AMUserSettings::userDataFolder);
-
-			// start timer for updates every 1 minute
 			timerIntervalID_ = startTimer(60000);
 		}
 
@@ -485,11 +487,10 @@ bool AMDatamanAppController::startupOnEveryTime()
 	if(!startupCreateDatabases())
 		return false;
 
+	// start the one-minute timer to monitor the disk usage of local storage
 	if(usingLocalStorage()) {
 
 		storageInfo_ = AMStorageInfo(AMUserSettings::userDataFolder);
-
-		// start timer for updates every 1 minute
 		timerIntervalID_ = startTimer(60000);
 	}
 

--- a/source/ui/dataman/AMFirstTimeWidget.h
+++ b/source/ui/dataman/AMFirstTimeWidget.h
@@ -73,6 +73,7 @@ public:
 			// for none user-account based storage, the user data path is already chosen by the AmChooseDataFolderDialog.
 			// for simplification, we won't allow the user to change the path again here.
 			userDataFolder_->setEnabled(false);
+			useLocalStorage_->setEnabled(false);
 			hl->addWidget(userDataFolder_);
 		}
 

--- a/source/ui/util/AMChooseDataFolderDialog.cpp
+++ b/source/ui/util/AMChooseDataFolderDialog.cpp
@@ -13,7 +13,6 @@
 
 // Static member
 //////////////////////////////////////
-
 bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, const QString &remoteRootDirectory, const QString &dataDirectory, const QStringList &extraDataDirectory, QWidget *parent)
 {
 	AMUserSettings::load();
@@ -80,7 +79,7 @@ bool AMChooseDataFolderDialog::getDataFolder(const QString &localRootDirectory, 
 			QDir testRemotePath(userDataPath);
 			testRemotePath.cdUp();
 			if(!AMUserSettings::remoteDataFolder.contains(testRemotePath.dirName())){
-					AMUserSettings::removeRemoteDataFolderEntry();
+				AMUserSettings::removeRemoteDataFolderEntry();
 			}
 			AMUserSettings::save();
 		}


### PR DESCRIPTION
when using local data storage (non user based storage), the users are NOT allowed to choose the storage path in the first time wizard. Therefore, there is no need to rewrite the data folder settings after the wizard page is dismissed. 

#2457 