### PR TITLE
Pull Request for Issue 2456: Change region start and end labels.

### DIFF
--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -15,6 +15,8 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	scanName_->setText(configuration_->name());
 
 	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_);
+	regionsView_->setStartLabel("Min");
+	regionsView_->setEndLabel("Max");
 
 	QGroupBox *regionsGroupBox = new QGroupBox("Regions");
 	regionsGroupBox->setLayout(regionsView_->layout());

--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -14,9 +14,7 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	scanName_ = new QLineEdit();
 	scanName_->setText(configuration_->name());
 
-	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_);
-	regionsView_->setStartLabel("Min");
-	regionsView_->setEndLabel("Max");
+	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_, 0, "Min", "Max");
 
 	QGroupBox *regionsGroupBox = new QGroupBox("Regions");
 	regionsGroupBox->setLayout(regionsView_->layout());

--- a/source/ui/dataman/AMStepScanAxisView.cpp
+++ b/source/ui/dataman/AMStepScanAxisView.cpp
@@ -21,6 +21,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "AMStepScanAxisView.h"
 
+#include <QLabel>
 #include <QHBoxLayout>
 #include <QMenu>
 #include <QAction>

--- a/source/ui/dataman/AMStepScanAxisView.cpp
+++ b/source/ui/dataman/AMStepScanAxisView.cpp
@@ -29,7 +29,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 // AMStepScanAxisElementView
 /////////////////////////////////////////////
 
-AMStepScanAxisElementView::AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent, QString startLabel, QString endLabel)
+AMStepScanAxisElementView::AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent, const QString &startLabel, const QString &endLabel)
 	: QWidget(parent)
 {
 	region_ = region;
@@ -139,7 +139,7 @@ void AMStepScanAxisElementView::onTimeUpdated()
 // AMStepScanAxisView
 /////////////////////////////////////////////
 
-AMStepScanAxisView::AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent, QString startLabel, QString endLabel)
+AMStepScanAxisView::AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent, const QString &startLabel, const QString &endLabel)
 	: QWidget(parent)
 {
 	configuration_ = configuration;

--- a/source/ui/dataman/AMStepScanAxisView.cpp
+++ b/source/ui/dataman/AMStepScanAxisView.cpp
@@ -28,7 +28,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 // AMStepScanAxisElementView
 /////////////////////////////////////////////
 
-AMStepScanAxisElementView::AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent)
+AMStepScanAxisElementView::AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent, QString startLabel, QString endLabel)
 	: QWidget(parent)
 {
 	region_ = region;
@@ -68,15 +68,12 @@ AMStepScanAxisElementView::AMStepScanAxisElementView(AMScanAxisRegion *region, Q
 	connect(region_, SIGNAL(regionTimeChanged(AMNumber)), this, SLOT(setTimeSpinBox(AMNumber)));
 	connect(time_, SIGNAL(editingFinished()), this, SLOT(onTimeUpdated()));
 
-	startLabel_ = new QLabel("Start");
-	endLabel_ = new QLabel("End");
-
 	QHBoxLayout *elementViewLayout = new QHBoxLayout;
-	elementViewLayout->addWidget(startLabel_);
+	elementViewLayout->addWidget(new QLabel(startLabel));
 	elementViewLayout->addWidget(start_);
 	elementViewLayout->addWidget(new QLabel(QString::fromUtf8("Δ")));
 	elementViewLayout->addWidget(delta_);
-	elementViewLayout->addWidget(endLabel_);
+	elementViewLayout->addWidget(new QLabel(endLabel));
 	elementViewLayout->addWidget(end_);
 	elementViewLayout->addWidget(new QLabel("Time"));
 	elementViewLayout->addWidget(time_);
@@ -116,20 +113,6 @@ void AMStepScanAxisElementView::setTimeSpinBox(const AMNumber &value)
 	}
 }
 
-void AMStepScanAxisElementView::setStartLabel(const QString &label)
-{
-	if(!label.isNull()) {
-		startLabel_->setText(label);
-	}
-}
-
-void AMStepScanAxisElementView::setEndLabel(const QString &label)
-{
-	if(!label.isNull()) {
-		endLabel_->setText(label);
-	}
-}
-
 void AMStepScanAxisElementView::onStartPositionUpdated()
 {
 	region_->setRegionStart(start_->value());
@@ -155,13 +138,16 @@ void AMStepScanAxisElementView::onTimeUpdated()
 // AMStepScanAxisView
 /////////////////////////////////////////////
 
-AMStepScanAxisView::AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent)
+AMStepScanAxisView::AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent, QString startLabel, QString endLabel)
 	: QWidget(parent)
 {
 	configuration_ = configuration;
 
 	deleteButtonGroup_ = new QButtonGroup;
 	scanAxisViewLayout_ = new QVBoxLayout;
+
+	startLabelString_ = startLabel;
+	endLabelString_ = endLabel;
 
 	addRegionButton_ = new QToolButton;
 	addRegionButton_->setIcon(QIcon(":22x22/list-add.png"));
@@ -339,7 +325,7 @@ void AMStepScanAxisView::removeRegion(int index)
 
 void AMStepScanAxisView::buildScanAxisRegionView(int index, AMScanAxisRegion *region)
 {
-	AMStepScanAxisElementView *elementView = new AMStepScanAxisElementView(region);
+	AMStepScanAxisElementView *elementView = new AMStepScanAxisElementView(region, 0, startLabelString_, endLabelString_);
 
 	QToolButton *deleteButton = new QToolButton;
 	deleteButton->setIcon(QIcon(":22x22/list-remove-2.png"));

--- a/source/ui/dataman/AMStepScanAxisView.cpp
+++ b/source/ui/dataman/AMStepScanAxisView.cpp
@@ -21,7 +21,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "AMStepScanAxisView.h"
 
-#include <QLabel>
 #include <QHBoxLayout>
 #include <QMenu>
 #include <QAction>
@@ -69,12 +68,15 @@ AMStepScanAxisElementView::AMStepScanAxisElementView(AMScanAxisRegion *region, Q
 	connect(region_, SIGNAL(regionTimeChanged(AMNumber)), this, SLOT(setTimeSpinBox(AMNumber)));
 	connect(time_, SIGNAL(editingFinished()), this, SLOT(onTimeUpdated()));
 
+	startLabel_ = new QLabel("Start");
+	endLabel_ = new QLabel("End");
+
 	QHBoxLayout *elementViewLayout = new QHBoxLayout;
-	elementViewLayout->addWidget(new QLabel("Start"));
+	elementViewLayout->addWidget(startLabel_);
 	elementViewLayout->addWidget(start_);
 	elementViewLayout->addWidget(new QLabel(QString::fromUtf8("Δ")));
 	elementViewLayout->addWidget(delta_);
-	elementViewLayout->addWidget(new QLabel("End"));
+	elementViewLayout->addWidget(endLabel_);
 	elementViewLayout->addWidget(end_);
 	elementViewLayout->addWidget(new QLabel("Time"));
 	elementViewLayout->addWidget(time_);
@@ -112,7 +114,20 @@ void AMStepScanAxisElementView::setTimeSpinBox(const AMNumber &value)
 		time_->setValue(double(value));
 		onTimeUpdated();
 	}
+}
 
+void AMStepScanAxisElementView::setStartLabel(const QString &label)
+{
+	if(!label.isNull()) {
+		startLabel_->setText(label);
+	}
+}
+
+void AMStepScanAxisElementView::setEndLabel(const QString &label)
+{
+	if(!label.isNull()) {
+		endLabel_->setText(label);
+	}
 }
 
 void AMStepScanAxisElementView::onStartPositionUpdated()

--- a/source/ui/dataman/AMStepScanAxisView.h
+++ b/source/ui/dataman/AMStepScanAxisView.h
@@ -31,6 +31,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QButtonGroup>
 #include <QVBoxLayout>
 #include <QToolButton>
+#include <QLabel>
 
 /// View that holds everything for a single region.
 class AMStepScanAxisElementView : public QWidget
@@ -43,6 +44,11 @@ public:
 
 	/// Returns the region this view looks at.
 	AMScanAxisRegion *region() const { return region_; }
+
+	///
+	void setStartLabel(const QString &label);
+	///
+	void setEndLabel(const QString &label);
 
 signals:
 	/// Notifier that the start has changed.  This is ALWAYS in eV.
@@ -82,6 +88,10 @@ protected:
 	QDoubleSpinBox *end_;
 	/// The spin box that holds the time position.
 	QDoubleSpinBox *time_;
+	///
+	QLabel *startLabel_;
+	///
+	QLabel *endLabel_;
 };
 
 /// View that holds the collection of scan axis regions and allows the addition and deletion of regions.  Currently, only assumes a single scan axis.

--- a/source/ui/dataman/AMStepScanAxisView.h
+++ b/source/ui/dataman/AMStepScanAxisView.h
@@ -31,7 +31,6 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include <QButtonGroup>
 #include <QVBoxLayout>
 #include <QToolButton>
-#include <QLabel>
 
 /// View that holds everything for a single region.
 class AMStepScanAxisElementView : public QWidget

--- a/source/ui/dataman/AMStepScanAxisView.h
+++ b/source/ui/dataman/AMStepScanAxisView.h
@@ -39,7 +39,7 @@ class AMStepScanAxisElementView : public QWidget
 
 public:
 	/// Constructor.  Builds a view for a single region.
-	explicit AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent = 0, QString startLabel = "", QString endLabel = "");
+	explicit AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent = 0, const QString &startLabel = "Start", const QString &endLabel = "End");
 
 	/// Returns the region this view looks at.
 	AMScanAxisRegion *region() const { return region_; }
@@ -91,7 +91,7 @@ class AMStepScanAxisView : public QWidget
 
 public:
 	/// Constructor.  Builds a view for the collection of regions.
-	explicit AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent = 0, QString startLabel = "Start", QString endLabel = "End");
+	explicit AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent = 0, const QString &startLabel = "Start", const QString &endLabel = "End");
 
 signals:
 

--- a/source/ui/dataman/AMStepScanAxisView.h
+++ b/source/ui/dataman/AMStepScanAxisView.h
@@ -40,15 +40,10 @@ class AMStepScanAxisElementView : public QWidget
 
 public:
 	/// Constructor.  Builds a view for a single region.
-	explicit AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent = 0);
+	explicit AMStepScanAxisElementView(AMScanAxisRegion *region, QWidget *parent = 0, QString startLabel = "", QString endLabel = "");
 
 	/// Returns the region this view looks at.
 	AMScanAxisRegion *region() const { return region_; }
-
-	///
-	void setStartLabel(const QString &label);
-	///
-	void setEndLabel(const QString &label);
 
 signals:
 	/// Notifier that the start has changed.  This is ALWAYS in eV.
@@ -88,10 +83,6 @@ protected:
 	QDoubleSpinBox *end_;
 	/// The spin box that holds the time position.
 	QDoubleSpinBox *time_;
-	///
-	QLabel *startLabel_;
-	///
-	QLabel *endLabel_;
 };
 
 /// View that holds the collection of scan axis regions and allows the addition and deletion of regions.  Currently, only assumes a single scan axis.
@@ -101,7 +92,7 @@ class AMStepScanAxisView : public QWidget
 
 public:
 	/// Constructor.  Builds a view for the collection of regions.
-	explicit AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent = 0);
+	explicit AMStepScanAxisView(const QString &title, AMStepScanConfiguration *configuration, QWidget *parent = 0, QString startLabel = "Start", QString endLabel = "End");
 
 signals:
 
@@ -145,6 +136,10 @@ protected:
 	QToolButton *addRegionButton_;
 	/// The button that locks regions together.
 	QToolButton *lockRegionsButton_;
+	/// Holds the label for the start of a region.
+	QString startLabelString_;
+	/// Holds the label for the end of a region.
+	QString endLabelString_;
 };
 
 #endif // AMSTEPSCANAXISVIEW_H


### PR DESCRIPTION
Modified AMStepScanAxisView to allow for setting region labels at initialization. 

Used new functionality to change labels in PGM to Min and Max, instead of Start and End, respectively.