### PR TITLE
Pull Request for Issue2493: Fix for BioXAS XAS scan initialization

### DIFF
--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -74,31 +74,7 @@ void AMGenericStepScanController::onScanTimerUpdate()
 
 AMAction3 * AMGenericStepScanController::createInitializationActions()
 {
-	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Step scan initialization", "Initialize step scan axis controls"), AMListAction3::Parallel);
-
-	// add the move actions to move the axis controls to the start point
-	for (int i=0, size=configuration_->scanAxes().count(); i < size; i++) {
-		AMScanAxis *scanAxis = configuration_->scanAxisAt(i);
-		AMControl *control = AMBeamline::bl()->exposedControlByInfo(configuration_->axisControlInfoAt(i));
-		if (scanAxis && control) {
-			qDebug() << "\n\nInitializing axis control" << control->name();
-			AMAction3 *moveAxisControlAction = AMActionSupport::buildControlMoveAction(control, scanAxis->regionAt(0)->regionStart());
-			initializationAction->addSubAction(moveAxisControlAction);
-		}
-	}
-
-	// add the beamline specific initialization actions
-	AMAction3 * beamlineScanInitializationAction = AMBeamline::bl()->createScanInitializationAction(configuration_);
-	if (beamlineScanInitializationAction)
-		initializationAction->addSubAction(beamlineScanInitializationAction);
-
-	// return the initialization actions if there are
-	if (initializationAction->hasChildren())
-		return initializationAction;
-	else {
-		initializationAction->deleteLater();
-		return 0;
-	}
+	return AMBeamline::bl()->createScanInitializationAction(configuration_);
 }
 
 AMAction3 * AMGenericStepScanController::createCleanupActions()

--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -74,7 +74,7 @@ void AMGenericStepScanController::onScanTimerUpdate()
 
 AMAction3 * AMGenericStepScanController::createInitializationActions()
 {
-	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Step scan initialization", "Initialize step scan axis controls"), AMListAction3::Parallel);
+	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Step scan initialization", "Initialize step scan axis controls"), AMListAction3::Sequential);
 
 	// add the move actions to move the axis controls to the start point
 	for (int i=0, size=configuration_->scanAxes().count(); i < size; i++) {

--- a/source/acquaman/AMGenericStepScanController.cpp
+++ b/source/acquaman/AMGenericStepScanController.cpp
@@ -74,13 +74,14 @@ void AMGenericStepScanController::onScanTimerUpdate()
 
 AMAction3 * AMGenericStepScanController::createInitializationActions()
 {
-	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Step scan initialization", "Initialize step scan axis controls"), AMListAction3::Sequential);
+	AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Step scan initialization", "Initialize step scan axis controls"), AMListAction3::Parallel);
 
 	// add the move actions to move the axis controls to the start point
 	for (int i=0, size=configuration_->scanAxes().count(); i < size; i++) {
 		AMScanAxis *scanAxis = configuration_->scanAxisAt(i);
 		AMControl *control = AMBeamline::bl()->exposedControlByInfo(configuration_->axisControlInfoAt(i));
 		if (scanAxis && control) {
+			qDebug() << "\n\nInitializing axis control" << control->name();
 			AMAction3 *moveAxisControlAction = AMActionSupport::buildControlMoveAction(control, scanAxis->regionAt(0)->regionStart());
 			initializationAction->addSubAction(moveAxisControlAction);
 		}

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.cpp
@@ -403,18 +403,6 @@ void BioXASXASScanActionController::buildScanControllerImplementation()
 		exportXDI->storeToDb(AMDatabase::database("user"));
 }
 
-AMAction3* BioXASXASScanActionController::createInitializationActions()
-{
-	AMAction3 *initializationAction = AMGenericStepScanController::createInitializationActions();
-
-	AMListAction3 *initializationListAction = qobject_cast<AMListAction3 *> (initializationAction);
-	if (initializationListAction) {
-		initializationListAction->addSubAction(AMActionSupport::buildControlMoveAction(BioXASBeamline::bioXAS()->mono()->energy(), bioXASConfiguration_->energy()));
-	}
-
-	return initializationAction;
-}
-
 AMAnalysisBlock *BioXASXASScanActionController::createRegionOfInterestAB(const QString &name, AMRegionOfInterest *region, AMDataSource *spectrumSource) const
 {
 	if (region && region->isValid() && spectrumSource && ((spectrumSource->rank()-scan_->scanRank()) == 1)){

--- a/source/acquaman/BioXAS/BioXASXASScanActionController.h
+++ b/source/acquaman/BioXAS/BioXASXASScanActionController.h
@@ -32,9 +32,6 @@ protected:
 	/// Sets the scan axis and adds anything extra.
 	virtual void buildScanControllerImplementation();
 
-	/// Reimplemented to provide actions that will setupd the beamine for optimzed operation of the XAS scan.
-	AMAction3* createInitializationActions();
-
 	/// Creates a region of interest analysis block from the given AMRegionOfInterest and 1D spectrum source.
 	AMAnalysisBlock *createRegionOfInterestAB(const QString &name, AMRegionOfInterest *region, AMDataSource *spectrumSource) const;
 	/// Creates a normalized analysis block from a source and normalizer source.

--- a/source/beamline/AMBeamline.cpp
+++ b/source/beamline/AMBeamline.cpp
@@ -24,9 +24,9 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "util/AMErrorMonitor.h"
 
 #include "dataman/AMSamplePlate.h"
-#include "acquaman/AMGenericStepScanConfiguration.h"
 #include "actions3/AMActionSupport.h"
 #include "actions3/AMListAction3.h"
+#include "acquaman/AMStepScanConfiguration.h"
 
 AMBeamline* AMBeamline::instance_ = 0;
 
@@ -195,18 +195,20 @@ void AMBeamline::initializeBeamlineSupport(){
 	AMBeamlineSupport::setBeamlineSynchronizedDwellTimeAPI(AMBeamline::bl());
 }
 
-AMAction3* AMBeamline::createScanInitializationAction(AMGenericStepScanConfiguration *configuration)
+AMAction3* AMBeamline::createScanInitializationAction(AMScanConfiguration *configuration)
 {
 	AMAction3* result = 0;
 
-	if (configuration) {
+	AMStepScanConfiguration *stepScanConfiguration = qobject_cast<AMStepScanConfiguration*>(configuration);
+
+	if (stepScanConfiguration) {
 
 		AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Initialize step scan axis controls", "Initialize step scan axis controls"), AMListAction3::Parallel);
 
 		// add the move actions to move the axis controls to the start point
-		for (int i=0, size=configuration->scanAxes().count(); i < size; i++) {
-			AMScanAxis *scanAxis = configuration->scanAxisAt(i);
-			AMControl *control = AMBeamline::bl()->exposedControlByInfo(configuration->axisControlInfoAt(i));
+		for (int i=0, size=stepScanConfiguration->scanAxes().count(); i < size; i++) {
+			AMScanAxis *scanAxis = stepScanConfiguration->scanAxisAt(i);
+			AMControl *control = AMBeamline::bl()->exposedControlByInfo(stepScanConfiguration->axisControlInfoAt(i));
 			if (scanAxis && control) {
 				AMAction3 *moveAxisControlAction = AMActionSupport::buildControlMoveAction(control, scanAxis->regionAt(0)->regionStart());
 				initializationAction->addSubAction(moveAxisControlAction);

--- a/source/beamline/AMBeamline.cpp
+++ b/source/beamline/AMBeamline.cpp
@@ -195,20 +195,18 @@ void AMBeamline::initializeBeamlineSupport(){
 	AMBeamlineSupport::setBeamlineSynchronizedDwellTimeAPI(AMBeamline::bl());
 }
 
-AMAction3* AMBeamline::createScanInitializationAction(AMScanConfiguration *configuration)
+AMAction3* AMBeamline::createInitializeScanAxisControlsAction(AMStepScanConfiguration *configuration)
 {
 	AMAction3* result = 0;
 
-	AMStepScanConfiguration *stepScanConfiguration = qobject_cast<AMStepScanConfiguration*>(configuration);
-
-	if (stepScanConfiguration) {
+	if (configuration) {
 
 		AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("Initialize step scan axis controls", "Initialize step scan axis controls"), AMListAction3::Parallel);
 
 		// add the move actions to move the axis controls to the start point
-		for (int i=0, size=stepScanConfiguration->scanAxes().count(); i < size; i++) {
-			AMScanAxis *scanAxis = stepScanConfiguration->scanAxisAt(i);
-			AMControl *control = AMBeamline::bl()->exposedControlByInfo(stepScanConfiguration->axisControlInfoAt(i));
+		for (int i=0, size=configuration->scanAxes().count(); i < size; i++) {
+			AMScanAxis *scanAxis = configuration->scanAxisAt(i);
+			AMControl *control = AMBeamline::bl()->exposedControlByInfo(configuration->axisControlInfoAt(i));
 			if (scanAxis && control) {
 				AMAction3 *moveAxisControlAction = AMActionSupport::buildControlMoveAction(control, scanAxis->regionAt(0)->regionStart());
 				initializationAction->addSubAction(moveAxisControlAction);
@@ -217,6 +215,18 @@ AMAction3* AMBeamline::createScanInitializationAction(AMScanConfiguration *confi
 
 		result = initializationAction;
 	}
+
+	return result;
+}
+
+AMAction3* AMBeamline::createScanInitializationAction(AMScanConfiguration *configuration)
+{
+	AMAction3* result = 0;
+
+	AMStepScanConfiguration *stepScanConfiguration = qobject_cast<AMStepScanConfiguration*>(configuration);
+
+	if (stepScanConfiguration)
+		result = createInitializeScanAxisControlsAction(stepScanConfiguration);
 
 	return result;
 }

--- a/source/beamline/AMBeamline.h
+++ b/source/beamline/AMBeamline.h
@@ -34,7 +34,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 class AMSamplePlate;
 class AMSample;
 class AMSamplePlateBrowser;
-class AMGenericStepScanConfiguration;
+class AMScanConfiguration;
 
 #define AMBEAMLINE_BEAMLINE_NOT_CREATED_YET 280301
 
@@ -159,9 +159,9 @@ public:
 	void initializeBeamlineSupport();
 
 	/// Creates and returns an action that sets up the beamline for a scan.
-	virtual AMAction3* createScanInitializationAction(AMGenericStepScanConfiguration *configuration);
+	virtual AMAction3* createScanInitializationAction(AMScanConfiguration *configuration);
 	/// Creates and returns an action that cleans up the beamline after a scan.
-	virtual AMAction3* createScanCleanupAction(AMGenericStepScanConfiguration *configuration) { Q_UNUSED(configuration) return 0; }
+	virtual AMAction3* createScanCleanupAction(AMScanConfiguration *configuration) { Q_UNUSED(configuration) return 0; }
 
 signals:
 	/// Emit this signal whenever isBeamlineScanning() changes.

--- a/source/beamline/AMBeamline.h
+++ b/source/beamline/AMBeamline.h
@@ -35,6 +35,7 @@ class AMSamplePlate;
 class AMSample;
 class AMSamplePlateBrowser;
 class AMScanConfiguration;
+class AMStepScanConfiguration;
 
 #define AMBEAMLINE_BEAMLINE_NOT_CREATED_YET 280301
 
@@ -158,6 +159,8 @@ public:
 
 	void initializeBeamlineSupport();
 
+	/// Creates and returns an action that initializes the axis controls to their start positions for the given configuration.
+	virtual AMAction3* createInitializeScanAxisControlsAction(AMStepScanConfiguration *configuration);
 	/// Creates and returns an action that sets up the beamline for a scan.
 	virtual AMAction3* createScanInitializationAction(AMScanConfiguration *configuration);
 	/// Creates and returns an action that cleans up the beamline after a scan.

--- a/source/beamline/AMBeamline.h
+++ b/source/beamline/AMBeamline.h
@@ -159,7 +159,7 @@ public:
 	void initializeBeamlineSupport();
 
 	/// Creates and returns an action that sets up the beamline for a scan.
-	virtual AMAction3* createScanInitializationAction(AMGenericStepScanConfiguration *configuration) { Q_UNUSED(configuration) return 0; }
+	virtual AMAction3* createScanInitializationAction(AMGenericStepScanConfiguration *configuration);
 	/// Creates and returns an action that cleans up the beamline after a scan.
 	virtual AMAction3* createScanCleanupAction(AMGenericStepScanConfiguration *configuration) { Q_UNUSED(configuration) return 0; }
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -1,6 +1,6 @@
 #include "BioXASBeamline.h"
 
-#include "acquaman/AMGenericStepScanConfiguration.h"
+#include "acquaman/AMStepScanConfiguration.h"
 #include "acquaman/BioXAS/BioXASXASScanConfiguration.h"
 
 #include "actions3/AMActionSupport.h"
@@ -79,7 +79,7 @@ AMAction3* BioXASBeamline::createDarkCurrentMeasurementAction(double dwellSecond
 	return result;
 }
 
-AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfiguration *configuration)
+AMAction3* BioXASBeamline::createScanInitializationAction(AMStepScanConfiguration *configuration)
 {
 	BioXASGenericStepScanConfiguration * bioXASGenericStepScanConfiguration = qobject_cast<BioXASGenericStepScanConfiguration *>(configuration);
 
@@ -128,10 +128,10 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 
 			// Determine the longest region time of all axis in the scan.
 
-			double maxRegionTime = configuration->scanAxisAt(0)->regionAt(0)->regionTime();
+			double maxRegionTime = bioXASGenericStepScanConfiguration->scanAxisAt(0)->regionAt(0)->regionTime();
 
-			for (int i = 0, count = configuration->scanAxes().count(); i < count; i++) {
-				double regionTime = configuration->scanAxisAt(i)->maximumRegionTime();
+			for (int i = 0, count = bioXASGenericStepScanConfiguration->scanAxes().count(); i < count; i++) {
+				double regionTime = bioXASGenericStepScanConfiguration->scanAxisAt(i)->maximumRegionTime();
 
 				if (maxRegionTime < regionTime)
 					maxRegionTime = regionTime;
@@ -166,11 +166,11 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 			for (int i = 0, count = geDetectors->count(); i < count; i++) {
 				BioXAS32ElementGeDetector *geDetector = qobject_cast<BioXAS32ElementGeDetector*>(geDetectors->at(i));
 
-				if (geDetector && configuration->usingDetector(geDetector->name())) {
+				if (geDetector && bioXASGenericStepScanConfiguration->usingDetector(geDetector->name())) {
 
 					AMListAction3 *geDetectorInitialization = new AMListAction3(new AMListActionInfo3("BioXAS Xpress3 initialization", "BioXAS Xpress3 initialization"));
 					geDetectorInitialization->addSubAction(geDetector->createDisarmAction());
-					geDetectorInitialization->addSubAction(geDetector->createFramesPerAcquisitionAction(int(configuration->scanAxisAt(0)->numberOfPoints()*1.1)));	// Adding 10% just because.
+					geDetectorInitialization->addSubAction(geDetector->createFramesPerAcquisitionAction(int(bioXASGenericStepScanConfiguration->scanAxisAt(0)->numberOfPoints()*1.1)));	// Adding 10% just because.
 					geDetectorInitialization->addSubAction(geDetector->createInitializationAction());
 
 					AMDetectorWaitForAcquisitionStateAction *waitAction = new AMDetectorWaitForAcquisitionStateAction(new AMDetectorWaitForAcquisitionStateActionInfo(geDetector->toInfo(), AMDetector::ReadyForAcquisition), geDetector);
@@ -208,7 +208,7 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 
 		AMAction3* standardsWheelInitialization = 0;
 		CLSStandardsWheel *standardsWheel = BioXASBeamline::bioXAS()->standardsWheel();
-		BioXASXASScanConfiguration *bioxasConfiguration = qobject_cast<BioXASXASScanConfiguration*>(configuration);
+		BioXASXASScanConfiguration *bioxasConfiguration = qobject_cast<BioXASXASScanConfiguration*>(bioXASGenericStepScanConfiguration);
 
 		if (bioxasConfiguration && bioxasConfiguration->usingStandardsWheel())
 			standardsWheelInitialization = standardsWheel->createMoveToNameAction(bioxasConfiguration->edge().split(" ").first());
@@ -235,7 +235,7 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMGenericStepScanConfi
 	return initializationAction;
 }
 
-AMAction3* BioXASBeamline::createScanCleanupAction(AMGenericStepScanConfiguration *configuration)
+AMAction3* BioXASBeamline::createScanCleanupAction(AMStepScanConfiguration *configuration)
 {
 	BioXASGenericStepScanConfiguration * bioXASGenericStepScanConfiguration = qobject_cast<BioXASGenericStepScanConfiguration *>(configuration);
 

--- a/source/beamline/BioXAS/BioXASBeamline.cpp
+++ b/source/beamline/BioXAS/BioXASBeamline.cpp
@@ -243,7 +243,7 @@ AMAction3* BioXASBeamline::createScanInitializationAction(AMScanConfiguration *c
 
 		AMListAction3 *initializationAction = new AMListAction3(new AMListActionInfo3("BioXAS scan initialization", "BioXAS scan initialization"), AMListAction3::Sequential);
 		initializationAction->addSubAction(componentInitializationAction);
-		initializationAction->addSubAction(AMBeamline::createScanInitializationAction(bioXASGenericStepScanConfiguration));
+		initializationAction->addSubAction(AMBeamline::createInitializeScanAxisControlsAction(bioXASGenericStepScanConfiguration));
 
 		result = initializationAction;
 	}

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -57,6 +57,8 @@
 #define BIOXASBEAMLINE_FASTVALVE_OPEN 1
 #define BIOXASBEAMLINE_FASTVALVE_CLOSED 4
 
+class AMStepScanConfiguration;
+
 class BioXASBeamline : public CLSBeamline
 {
     Q_OBJECT
@@ -82,9 +84,9 @@ public:
 	/// Creates and returns an action that performs a dark current measurement.
 	virtual AMAction3* createDarkCurrentMeasurementAction(double dwellSeconds);
 	/// Creates and returns an action that initializes the beamline before a scan.
-	virtual AMAction3* createScanInitializationAction(AMGenericStepScanConfiguration *configuration);
+	virtual AMAction3* createScanInitializationAction(AMStepScanConfiguration *configuration);
 	/// Creates and returna an action that cleans up the beamline after a scan.
-	virtual AMAction3* createScanCleanupAction(AMGenericStepScanConfiguration *configuration);
+	virtual AMAction3* createScanCleanupAction(AMStepScanConfiguration *configuration);
 
 	/// Returns the beam status.
 	virtual CLSBeamlineStatus* beamStatus() const { return beamlineStatus_; }

--- a/source/beamline/BioXAS/BioXASBeamline.h
+++ b/source/beamline/BioXAS/BioXASBeamline.h
@@ -84,9 +84,9 @@ public:
 	/// Creates and returns an action that performs a dark current measurement.
 	virtual AMAction3* createDarkCurrentMeasurementAction(double dwellSeconds);
 	/// Creates and returns an action that initializes the beamline before a scan.
-	virtual AMAction3* createScanInitializationAction(AMStepScanConfiguration *configuration);
+	virtual AMAction3* createScanInitializationAction(AMScanConfiguration *configuration);
 	/// Creates and returna an action that cleans up the beamline after a scan.
-	virtual AMAction3* createScanCleanupAction(AMStepScanConfiguration *configuration);
+	virtual AMAction3* createScanCleanupAction(AMScanConfiguration *configuration);
 
 	/// Returns the beam status.
 	virtual CLSBeamlineStatus* beamStatus() const { return beamlineStatus_; }

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -267,15 +267,16 @@ AMAction3 *IDEASBeamline::createBeamOffAction() const
 	return beamOffAction;
 }
 
-AMAction3* IDEASBeamline::createScanInitializationAction(AMGenericStepScanConfiguration *configuration)
+AMAction3* IDEASBeamline::createScanInitializationAction(AMStepScanConfiguration *configuration)
 {
 	AMListAction3 *initializationActions = new AMListAction3(new AMListActionInfo3("IDEAS XAS Initialization Stage 1", "IDEAS XAS Initialization Stage 1"), AMListAction3::Parallel);
 	initializationActions->addSubAction(IDEASBeamline::ideas()->scaler()->createContinuousEnableAction3(false));
 	initializationActions->addSubAction(IDEASBeamline::ideas()->scaler()->createDwellTimeAction3(configuration->scanAxisAt(0)->regionAt(0)->regionTime()));
+
 	return initializationActions;
 }
 
-AMAction3* IDEASBeamline::createScanCleanupAction(AMGenericStepScanConfiguration *configuration)
+AMAction3* IDEASBeamline::createScanCleanupAction(AMStepScanConfiguration *configuration)
 {
 	Q_UNUSED(configuration)
 	AMListAction3 *cleanupActions = new AMListAction3(new AMListActionInfo3("IDEAS XAS Cleanup Actions", "IDEAS XAS Cleanup Actions"));

--- a/source/beamline/IDEAS/IDEASBeamline.cpp
+++ b/source/beamline/IDEAS/IDEASBeamline.cpp
@@ -267,16 +267,25 @@ AMAction3 *IDEASBeamline::createBeamOffAction() const
 	return beamOffAction;
 }
 
-AMAction3* IDEASBeamline::createScanInitializationAction(AMStepScanConfiguration *configuration)
+AMAction3* IDEASBeamline::createScanInitializationAction(AMScanConfiguration *configuration)
 {
-	AMListAction3 *initializationActions = new AMListAction3(new AMListActionInfo3("IDEAS XAS Initialization Stage 1", "IDEAS XAS Initialization Stage 1"), AMListAction3::Parallel);
-	initializationActions->addSubAction(IDEASBeamline::ideas()->scaler()->createContinuousEnableAction3(false));
-	initializationActions->addSubAction(IDEASBeamline::ideas()->scaler()->createDwellTimeAction3(configuration->scanAxisAt(0)->regionAt(0)->regionTime()));
+	AMAction3 *result = 0;
 
-	return initializationActions;
+	AMStepScanConfiguration *stepScanConfiguration = qobject_cast<AMStepScanConfiguration*>(configuration);
+
+	if (stepScanConfiguration) {
+		AMListAction3 *initializationActions = new AMListAction3(new AMListActionInfo3("IDEAS XAS Initialization Stage 1", "IDEAS XAS Initialization Stage 1"), AMListAction3::Parallel);
+		initializationActions->addSubAction(AMBeamline::createInitializeScanAxisControlsAction(stepScanConfiguration));
+		initializationActions->addSubAction(IDEASBeamline::ideas()->scaler()->createContinuousEnableAction3(false));
+		initializationActions->addSubAction(IDEASBeamline::ideas()->scaler()->createDwellTimeAction3(stepScanConfiguration->scanAxisAt(0)->regionAt(0)->regionTime()));
+
+		result = initializationActions;
+	}
+
+	return result;
 }
 
-AMAction3* IDEASBeamline::createScanCleanupAction(AMStepScanConfiguration *configuration)
+AMAction3* IDEASBeamline::createScanCleanupAction(AMScanConfiguration *configuration)
 {
 	Q_UNUSED(configuration)
 	AMListAction3 *cleanupActions = new AMListAction3(new AMListActionInfo3("IDEAS XAS Cleanup Actions", "IDEAS XAS Cleanup Actions"));

--- a/source/beamline/IDEAS/IDEASBeamline.h
+++ b/source/beamline/IDEAS/IDEASBeamline.h
@@ -72,9 +72,9 @@ public:
 	AMAction3 *createBeamOffAction() const;
 
 	/// Create the scan initialization actions.
-	virtual AMAction3* createScanInitializationAction(AMStepScanConfiguration *configuration);
+	virtual AMAction3* createScanInitializationAction(AMScanConfiguration *configuration);
 	/// Create the scan cleanup actions.
-	virtual AMAction3* createScanCleanupAction(AMStepScanConfiguration *configuration);
+	virtual AMAction3* createScanCleanupAction(AMScanConfiguration *configuration);
 
 
 	/// Returns the monochromator control for the beamline.

--- a/source/beamline/IDEAS/IDEASBeamline.h
+++ b/source/beamline/IDEAS/IDEASBeamline.h
@@ -41,6 +41,7 @@ along with Acquaman.  If not, see <http://www.gnu.org/licenses/>.
 #include "beamline/IDEAS/IDEAS13ElementGeDetector.h"
 
 
+class AMStepScanConfiguration;
 
 /// This class is the master class that holds EVERY control inside the VESPERS beamline.
 class IDEASBeamline : public CLSBeamline
@@ -71,9 +72,9 @@ public:
 	AMAction3 *createBeamOffAction() const;
 
 	/// Create the scan initialization actions.
-	virtual AMAction3* createScanInitializationAction(AMGenericStepScanConfiguration *configuration);
+	virtual AMAction3* createScanInitializationAction(AMStepScanConfiguration *configuration);
 	/// Create the scan cleanup actions.
-	virtual AMAction3* createScanCleanupAction(AMGenericStepScanConfiguration *configuration);
+	virtual AMAction3* createScanCleanupAction(AMStepScanConfiguration *configuration);
 
 
 	/// Returns the monochromator control for the beamline.


### PR DESCRIPTION
Changes:
- Removed an extra action to initialize the mono, introduced in BioXASXASScanActionController.
- Moved the generic step scan controller initialization actions to `AMBeamline::createScanInitializationActions(...)`. This would allow for finer control over when the initialization actions are run, and beamlines wouldn't have to reimplement `AMGenericStepScanController::createInitializationActions()`.
- Modified `AMBeamline::createScanInitializationActions(...)` to have an AMScanConfiguration argument, instead of AMGenericStepScanConfiguration. This makes the method more general.
- Updated the BioXAS and IDEAS implementations of `AMBeamline::createScanInitializationActions(...)`.

Testing:
- [x] BioXAS
- [x] IDEAS
