### PR TITLE
Pull Request for Issue 2477: Removing scan region results in crash.

### DIFF
--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -27,8 +27,11 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 
 	regionsView_ = new AMStepScanAxisView("VLS-PGM Region Configuration", configuration_, 0, "Min", "Max");
 
+	QVBoxLayout *regionsGroupLayout = new QVBoxLayout;
+	regionsGroupLayout->addWidget(regionsView_);
+
 	QGroupBox *regionsGroupBox = new QGroupBox("Regions");
-	regionsGroupBox->setLayout(regionsView_->layout());
+	regionsGroupBox->setLayout(regionsGroupLayout);
 
 	// Estimated scan time to display.
 


### PR DESCRIPTION
Crash resulted when a scan region was removed.

When adding the AMStepScanAxisView to the scan configuration setLayout was used which re-parents the layout, breaking references in the internal map.

Instead AMStepScanAxisView must be added to a view, and that layout set to the view container.