### PR TITLE
Pull Request for Issue 2507: Broken connect statement

### DIFF
--- a/source/ui/PGM/PGMXASScanConfigurationView.cpp
+++ b/source/ui/PGM/PGMXASScanConfigurationView.cpp
@@ -111,7 +111,7 @@ PGMXASScanConfigurationView::PGMXASScanConfigurationView(PGMXASScanConfiguration
 	// Setup connections
 	connect(scanName_, SIGNAL(editingFinished()), this, SLOT(onScanNameEdited()));
 	connect(configuration_, SIGNAL(nameChanged(QString)), scanName_, SLOT(setText(QString)));
-	connect(exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(updateConfigurationExportSpectraPreference()) );
+	connect(exportSpectraCheckBox_, SIGNAL(clicked(bool)), this, SLOT(onExportSelectionChanged()) );
 	connect(configuration_, SIGNAL(totalTimeChanged(double)), this, SLOT(onEstimatedTimeChanged(double)));
 	onEstimatedTimeChanged(configuration_->totalTime());
 
@@ -128,7 +128,7 @@ void PGMXASScanConfigurationView::onEstimatedTimeChanged(double newTime)
 	estimatedTime_->setText("Estimated time per scan:\t" + AMDateTimeUtils::convertTimeToString(newTime));
 }
 
-void PGMXASScanConfigurationView::onExportSelectionChanged(QAbstractButton *button)
+void PGMXASScanConfigurationView::onExportSelectionChanged()
 {
-	configuration_->setAutoExportEnabled(button->isChecked());
+	configuration_->setAutoExportEnabled(exportSpectraCheckBox_->isChecked());
 }

--- a/source/ui/PGM/PGMXASScanConfigurationView.h
+++ b/source/ui/PGM/PGMXASScanConfigurationView.h
@@ -39,7 +39,7 @@ protected slots:
 	void onEstimatedTimeChanged(double newTime);
 
 	/// Handles changes of the auto export check box.
-	void onExportSelectionChanged(QAbstractButton *button);
+	void onExportSelectionChanged();
 
 protected:
 	/// The configuration.


### PR DESCRIPTION
The export function called in the connect statement was not updated to the function name for PGM.
Adjusted function parameters for `onExportSelectionChanged()` as a passed button was not necessary.

#2507 