### PR TITLE
Pull Request for Issue 2513: Add new run doesn't work

### DIFF
--- a/source/ui/dataman/AMRunSelector.cpp
+++ b/source/ui/dataman/AMRunSelector.cpp
@@ -180,6 +180,7 @@ void AMRunSelector::showAddRunDialog() {
 		newRunDialog_ = 0;
 	}
 	newRunDialog_ = new AMNewRunDialog(database_);
+	newRunDialog_->setModal(true);
 	newRunDialog_->show();
 	connect(newRunDialog_, SIGNAL(dialogBoxClosed(int)), this, SLOT(onAddRunDialogClosed(int)));
 }


### PR DESCRIPTION
After changing the run selector to be modal to protect the main AM window, the new run selection did not inherent the modal property.

Due to the way that new run dialog is called it does not inherent the `modal(true)` flag from the parent. Manually set the new run dialog to be modal as well. This seems to resolve the issue.
#2513
