### PR TITLE
Pull Request for Issue2530: Hiding Ge detector view

### DIFF
--- a/source/application/BioXAS/BioXASAppController.cpp
+++ b/source/application/BioXAS/BioXASAppController.cpp
@@ -755,6 +755,26 @@ void BioXASAppController::setupGenericStepScanConfiguration(AMGenericStepScanCon
 	}
 }
 
+QWidget* BioXASAppController::viewForComponent(QObject *component) const
+{
+	return componentViewMapping_.value(component, 0);
+}
+
+QObject* BioXASAppController::componentForView(QWidget *componentView) const
+{
+	return componentViewMapping_.key(componentView);
+}
+
+void BioXASAppController::addComponentViewMapping(QObject *component, QWidget *view)
+{
+	componentViewMapping_.insert(component, view);
+}
+
+void BioXASAppController::removeComponentViewMapping(QObject *component)
+{
+	componentViewMapping_.remove(component);
+}
+
 void BioXASAppController::updateScanConfigurationDetectors(AMGenericStepScanConfiguration *configuration, AMDetectorSet *detectors)
 {
 	if (configuration && detectors) {

--- a/source/application/BioXAS/BioXASAppController.h
+++ b/source/application/BioXAS/BioXASAppController.h
@@ -163,13 +163,20 @@ protected:
 	/// Creates and returns a view appropriate for viewing the given scan configuration, within a configuration view holder. Returns 0 if no view was created.
 	virtual AMScanConfigurationViewHolder3* createScanConfigurationViewWithHolder(AMScanConfiguration *configuration);
 
-//	/// Adds a component view to the main window sidebar.
-//	virtual void addComponentView(QObject *component, const QString &viewName, const QString &categoryName, const QString &icon);
-
 	/// Sets up an XAS scan configuration.
 	virtual void setupXASScanConfiguration(BioXASXASScanConfiguration *configuration);
 	/// Sets up a generic step scan configuration.
 	virtual void setupGenericStepScanConfiguration(AMGenericStepScanConfiguration *configuration);
+
+	/// Returns the view instance for the given component, 0 if no view found.
+	QWidget* viewForComponent(QObject *component) const;
+	/// Returns the component associated with the given view, 0 if no component found.
+	QObject* componentForView(QWidget *componentView) const;
+
+	/// Adds a component-view mapping, overwriting any previous mappings if they exist.
+	void addComponentViewMapping(QObject *component, QWidget *view);
+	/// Removes a component-view mapping.
+	void removeComponentViewMapping(QObject *component);
 
 	/// implementation for slot that connects generic scan editors that use the 2D scan view to the app controller so that it can enable quick configuration of scans.
 	virtual void onScanEditorCreatedImplementation(AMGenericScanEditor *editor);

--- a/source/application/BioXAS/BioXASSideAppController.cpp
+++ b/source/application/BioXAS/BioXASSideAppController.cpp
@@ -37,14 +37,13 @@ BioXASSideAppController::~BioXASSideAppController()
 void BioXASSideAppController::updateGeDetectorView()
 {
     BioXAS32ElementGeDetector *detector = BioXASSideBeamline::bioXAS()->ge32ElementDetector();
-    QWidget *detectorView = componentViewMapping_.value(detector, 0);
-    QWidget *detectorPane = viewPaneMapping_.value(detectorView, 0);
+	QWidget *detectorView = viewForComponent(detector);
 
-    if (detector && detectorView && detectorPane) {
-		if (detector->isConnected())
-			mw_->showPane(detectorPane);
+	if (detectorView) {
+		if (detector && detector->isConnected())
+			mw_->showPane(detectorView);
 		else
-			mw_->hidePane(detectorPane);
+			mw_->hidePane(detectorView);
 	}
 }
 
@@ -75,7 +74,11 @@ void BioXASSideAppController::createDetectorPanes()
 {
 	BioXASAppController::createDetectorPanes();
 
-	addMainWindowPane( createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector()), "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
+	QWidget *detectorView = createComponentView(BioXASSideBeamline::bioXAS()->ge32ElementDetector());
+	addComponentViewMapping(BioXASSideBeamline::bioXAS()->ge32ElementDetector(), detectorView);
+	viewPaneMapping_.insert(detectorView, detectorView);
+
+	addMainWindowPane( detectorView, "Ge 32-el", detectorPaneCategoryName_, detectorPaneIcon_ );
 }
 
 void BioXASSideAppController::createComponentsPane()

--- a/source/application/CLS/CLSAppController.cpp
+++ b/source/application/CLS/CLSAppController.cpp
@@ -146,17 +146,37 @@ void CLSAppController::setupUserInterfaceImplementation()
 	AMErrorMon::debug(this, CLS_APPCONTROLLER_INFO_UNIMPLEMENTED_METHOD, "Looks like there is no special implementation for setupUserInterface(). ");
 }
 
-void CLSAppController::addMainWindowPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon)
+QWidget* CLSAppController::paneForView(QWidget *view) const
 {
-	if (view)
-		mw_->addPane(view, paneCategoryName, viewName, paneIcon);
+	return viewPaneMapping_.value(view, 0);
+}
+
+QWidget* CLSAppController::viewForPane(QWidget *pane) const
+{
+	return viewPaneMapping_.key(pane, 0);
+}
+
+void CLSAppController::addViewPaneMapping(QWidget *view, QWidget *pane)
+{
+	viewPaneMapping_.insert(view, pane);
+}
+
+void CLSAppController::removeViewPaneMapping(QWidget *view)
+{
+	viewPaneMapping_.remove(view);
+}
+
+void CLSAppController::addMainWindowPane(QWidget *pane, const QString &paneName, const QString &paneCategoryName, const QString &paneIcon)
+{
+	if (pane)
+		mw_->addPane(pane, paneCategoryName, paneName, paneIcon);
 }
 
 void CLSAppController::addMainWindowView(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon)
 {
 	if (view) {
 		QWidget *pane = AMMainWindow::buildMainWindowPane(viewName, paneIcon, view);
-		viewPaneMapping_.insert(view, pane);
+		addViewPaneMapping(view, pane);
 		addMainWindowPane(pane, viewName, paneCategoryName, paneIcon);
 	}
 }

--- a/source/application/CLS/CLSAppController.h
+++ b/source/application/CLS/CLSAppController.h
@@ -65,6 +65,16 @@ protected:
 	/// create pane for the scan configuration views
 	virtual void createScanConfigurationPanes() = 0;
 
+	/// Returns the pane instance for the given view, 0 if no pane found.
+	QWidget *paneForView(QWidget *view) const;
+	/// Returns the view instance for the given pane, 0 if no view found.
+	QWidget *viewForPane(QWidget *pane) const;
+
+	/// Adds a view-pane mapping, overwriting any previous mappings if they exist.
+	void addViewPaneMapping(QWidget *view, QWidget *pane);
+	/// Removes a view-pane mapping.
+	void removeViewPaneMapping(QWidget *view);
+
 	/// helper function to add a given view directly to the given main window pane, with the given name.
 	void addMainWindowPane(QWidget *view, const QString &viewName, const QString &paneCategoryName, const QString &paneIcon);
 	/// helper function to add a given view (and create a squeeze layout) to the given main window pane, with the given name.


### PR DESCRIPTION
Added some methods to BioXASAppController to use for interacting with the componentView map, added similar methods to CLSAppController for the view-pane map. The Side Ge detector main window representation only uses a view (no pane), so adjusted the BioXASSideAppController code to look only for a view when updating the detector's visibility.

It would be nice to eventually have some way setting a 'configuration show/hide' bool where the Ge detector view can be forced to be shown or hidden, regardless of connected state. This could be useful for testing purposes. But for now, this pull request only deals with the requirement that the view be hidden when detector not connected.
