### PR TITLE
Pull Request for Issue2522: Setting editor precision.

### DIFF
--- a/source/ui/CLS/CLSValueEditor.cpp
+++ b/source/ui/CLS/CLSValueEditor.cpp
@@ -278,6 +278,7 @@ AMNumber CLSValueEditor::getDoubleValue()
 	inputDialog.setValue(value_);
 	inputDialog.setMinimum(minimumValue_);
 	inputDialog.setMaximum(maximumValue_);
+	inputDialog.setPrecision(precision_);
 	inputDialog.setWindowTitle(dialogTitle);
 	inputDialog.move(mapToGlobal(QPoint(width()/2, height()/2)));
 

--- a/source/ui/CLS/CLSValueSetpointEditor.cpp
+++ b/source/ui/CLS/CLSValueSetpointEditor.cpp
@@ -18,6 +18,8 @@ CLSValueSetpointEditor::CLSValueSetpointEditor(InputType type, QWidget *parent) 
 	maximumSet_ = false;
 	maximum_ = 0;
 
+	precision_ = 3;
+
 	// Create UI elements.
 
 	spinBox_ = new QDoubleSpinBox();
@@ -119,6 +121,16 @@ void CLSValueSetpointEditor::setMaximum(double newMax)
 	updateInputStatus();
 }
 
+void CLSValueSetpointEditor::setPrecision(int newValue)
+{
+	if (precision_ != newValue) {
+		precision_ = newValue;
+		updateBoxes();
+
+		emit precisionChanged(precision_);
+	}
+}
+
 void CLSValueSetpointEditor::setInputStatus(InputStatus newStatus)
 {
 	if (status_ != newStatus) {
@@ -153,17 +165,13 @@ void CLSValueSetpointEditor::updateBoxes()
 {
 	// Update the spinbox.
 
-	if (type_ == TypeDouble)
-		spinBox_->show();
-	else
-		spinBox_->hide();
+	spinBox_->setVisible(type_ == TypeDouble);
+	spinBox_->setDecimals(precision_);
+	spinBox_->setSingleStep(precision_);
 
 	// Update the combobox.
 
-	if (type_ == TypeEnum)
-		comboBox_->show();
-	else
-		comboBox_->hide();
+	comboBox_->setVisible(type_ == TypeEnum);
 }
 
 void CLSValueSetpointEditor::onBoxValueChanged()

--- a/source/ui/CLS/CLSValueSetpointEditor.h
+++ b/source/ui/CLS/CLSValueSetpointEditor.h
@@ -41,6 +41,8 @@ public:
 	bool maximumSet() const { return maximumSet_; }
 	/// Returns the maximum value.
 	double maximum() const { return maximum_; }
+	/// Returns the precision.
+	int precision() const { return precision_; }
 
 	/// Returns true if the minimum value is set and the current value is less than the minimum, indicating a bad input state.
 	bool valueLessThanMinimum() const;
@@ -60,6 +62,8 @@ signals:
 	void minimumChanged(double newMin);
 	/// Notifier that the maximum value has changed.
 	void maximumChanged(double newMax);
+	/// Notifier that the precision has changed.
+	void precisionChanged(int newValue);
 
 public slots:
 	/// Sets the input type.
@@ -73,6 +77,8 @@ public slots:
 	void setMinimum(double newMin);
 	/// Sets the maximum value.
 	void setMaximum(double newMax);
+	/// Sets the precision.
+	void setPrecision(int newValue);
 
 protected slots:
 	/// Sets the input status.
@@ -112,6 +118,8 @@ protected:
 	bool maximumSet_;
 	/// The maximum value.
 	double maximum_;
+	/// The precision.
+	int precision_;
 
 	/// The input spinbox.
 	QDoubleSpinBox *spinBox_;

--- a/source/ui/CLS/CLSValueSetpointEditorDialog.cpp
+++ b/source/ui/CLS/CLSValueSetpointEditorDialog.cpp
@@ -64,6 +64,11 @@ double CLSValueSetpointEditorDialog::maximum() const
 	return setpointEditor_->maximum();
 }
 
+int CLSValueSetpointEditorDialog::precision() const
+{
+	return setpointEditor_->precision();
+}
+
 void CLSValueSetpointEditorDialog::setValue(double newValue)
 {
 	setpointEditor_->setValue(newValue);
@@ -83,6 +88,11 @@ void CLSValueSetpointEditorDialog::setMinimum(double newMin)
 void CLSValueSetpointEditorDialog::setMaximum(double newMax)
 {
 	setpointEditor_->setMaximum(newMax);
+}
+
+void CLSValueSetpointEditorDialog::setPrecision(int newValue)
+{
+	setpointEditor_->setPrecision(newValue);
 }
 
 void CLSValueSetpointEditorDialog::updateButtons()

--- a/source/ui/CLS/CLSValueSetpointEditorDialog.h
+++ b/source/ui/CLS/CLSValueSetpointEditorDialog.h
@@ -28,6 +28,8 @@ public:
 	bool maximumSet() const;
 	/// Returns the maximum value.
 	double maximum() const;
+	/// Returns the precision.
+	int precision() const;
 
 public slots:
 	/// Sets the current value.
@@ -38,6 +40,8 @@ public slots:
 	void setMinimum(double newMin);
 	/// Sets the maximum value.
 	void setMaximum(double newMax);
+	/// Sets the precision, for editing double values.
+	void setPrecision(int newValue);
 
 protected slots:
 	/// Updates the buttons.


### PR DESCRIPTION
Added a precision variable to CLSValueSetpointEditor, with getter/setter/signal. Added getter and setter to the value setpoint editor dialog that calls the editor's new methods. Added call to set the dialog's precision in CLSValueEditor::getDoubleValue(). The editor should now allow a value to be edited with the same precision that it is displayed in. The amount in the editor can be stepped up or down by the same amount too.
